### PR TITLE
deal-scout: v0.12.0

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.11.1@sha256:ea23894a820593fb08ed0034c090391710add321fd4d332d2bb307b8ff4b68c3
+          image: ghcr.io/mitchross/deal-scout:v0.12.0@sha256:45aefe1da82a0d22f6bb57301715b361c7854a0074cf11db9023b6d89052ef79
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.11.1@sha256:3c2efa48f84939a357f050695cc99c0e0b30a36f691c42f72de95405bb605cea
+          image: ghcr.io/mitchross/deal-scout-worker:v0.12.0@sha256:27de1c61f67db1a9a5c383fadf209abde22b737fde3b0c2a91beca1c1b627c38
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.12.0.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.12.0`.