### PR TITLE
chore(zomboid): pin container images to digests

### DIFF
--- a/my-apps/home/project-zomboid/deployment.yaml
+++ b/my-apps/home/project-zomboid/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       initContainers:
         - name: steamcmd-update
-          image: indifferentbroccoli/projectzomboid-server-docker:latest
+          image: indifferentbroccoli/projectzomboid-server-docker:latest@sha256:8e13816b92fdd3e1fac3044b8b9228b255e6deb4d28b268f93a911fbd58ca6e8
           imagePullPolicy: Always
           command:
             - /bin/bash
@@ -32,7 +32,7 @@ spec:
             - name: steam-cache
               mountPath: /steam-cache
         - name: copy-config
-          image: busybox:1.38
+          image: busybox:1.38@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
           command:
             - sh
             - -c
@@ -48,7 +48,7 @@ spec:
               mountPath: /config
       containers:
         - name: project-zomboid
-          image: indifferentbroccoli/projectzomboid-server-docker:latest
+          image: indifferentbroccoli/projectzomboid-server-docker:latest@sha256:8e13816b92fdd3e1fac3044b8b9228b255e6deb4d28b268f93a911fbd58ca6e8
           imagePullPolicy: Always
           env:
             - name: PUID


### PR DESCRIPTION
## What

Pins all three image refs in `my-apps/home/project-zomboid/deployment.yaml` to digests:

| Container | Ref |
|---|---|
| `steamcmd-update` (init) | `projectzomboid-server-docker:latest@sha256:8e13816b…` |
| `copy-config` (init) | `busybox:1.38@sha256:dc2d74b2…` |
| `project-zomboid` | `projectzomboid-server-docker:latest@sha256:8e13816b…` |

## Why

All three floated on mutable tags — two of them on `:latest` — with `imagePullPolicy: Always`, so any pod restart could pull different code with no review.

This came out of a Firewalla exposure review. project-zomboid is one of the few workloads deliberately reachable from the internet (router port-forwards on 16261/udp and 16262/udp → the Cilium LB IP `192.168.10.51`), which makes an unreviewed upstream image change land directly on a public listener. It also conflicts with the repo's standing rule that every image ref carries a digest.

## Notes

- Digests resolved from Docker Hub at pin time.
- The `tag@digest` form is what Renovate expects, so digest updates keep flowing as normal PRs.
- Deployment is currently `replicas: 0`, so this is a no-op until the server is next scaled up.
- `imagePullPolicy: Always` is now a redundant registry round-trip per start since digests are immutable — left alone to keep the diff minimal.

## Out of scope (tracked separately)

- The `zomboid` **27015/tcp (RCON)** port-forward is still live and internet-facing. `copy-config` rewrites `Server/vanillax.ini` from the ConfigMap on every start with `RCONPassword=` blank, and whether the entrypoint templates `RCON_PASSWORD` back in is unverified. Needs checking before the server is scaled up — or the forward dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)