### PR TITLE
deal-scout: v0.12.1

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.12.0@sha256:45aefe1da82a0d22f6bb57301715b361c7854a0074cf11db9023b6d89052ef79
+          image: ghcr.io/mitchross/deal-scout:v0.12.1@sha256:1ee8855a4273c33b070141606f8362c7ca2e9b57a9c0daae9979f051dc4a837c
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.12.0@sha256:27de1c61f67db1a9a5c383fadf209abde22b737fde3b0c2a91beca1c1b627c38
+          image: ghcr.io/mitchross/deal-scout-worker:v0.12.1@sha256:2e5d0b2e1b96db146e6413b12c5d3a51e2703fdeddf0086b87687977f263684c
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.12.1.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.12.1`.