### PR TITLE
fix(ai): name Flash Next model accurately

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This is a production-grade GitOps Kubernetes cluster running on **Talos OS** wit
 
 **AI/LLM Backend**: Two OpenAI-compatible local backends, both NOT ollama:
 
-- **llama.cpp** (`http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`, served model `qwen3.8-27b`) is active. It follows club-3090's single-card Qwen3.8-27B route: UD-IQ4_XS GGUF, F16 vision projector, symmetric q8_0 KV at 131K, and MTP-2 on one RTX 3090.
+- **llama.cpp** (`http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`, served model `Qwen3.8-Flash-Next Q4`) is active with UD-Q4_K_XL GGUF, BF16 vision, symmetric q8_0 KV at 131K, and no MTP on one RTX 3090.
 - **vLLM** is the parked rollback backend at `replicas: 0`.
 
 GPU topology: the GPU workloads use **mutually exclusive whole-card** allocations (`type: Recreate`, time-slicing disabled — never oversubscribe the card). They scale-swap by committed replica counts. Current state is llama-cpp `1`, vLLM `0`, and ComfyUI/SwarmUI `0`; the chassis has one RTX 3090. App→backend wiring is tabulated in `docs/domains/ai-gpu/model-catalog.md`; the swap procedure + card truth table live in `docs/domains/ai-gpu/gpu-scale-swap.md`.
@@ -120,7 +120,7 @@ Do **not** write changelog/jira-style comments: no per-version release-note summ
 - Use NFS CSI driver (`csi: driver: nfs.csi.k8s.io`) for static NFS PVs — **legacy `nfs:` silently ignores mountOptions**
 - Add new infrastructure component paths to `infrastructure/controllers/argocd/apps/appsets/infrastructure-appset.yaml` explicitly (not glob-discovered)
 - List ALL YAML files in each directory's `kustomization.yaml` under `resources:` — **unlisted files are never deployed**
-- Use **llama.cpp** (`qwen3.8-27b`, the default for app inference) or the parked vLLM rollback backend — **never ollama**
+- Use **llama.cpp** (`Qwen3.8-Flash-Next Q4`, the default for app inference) or the parked vLLM rollback backend — **never ollama**
 - Use sync waves when adding infrastructure components
 - Add ArgoCD hook annotations to all Kubernetes Jobs — `argocd.argoproj.io/hook: Sync` + `argocd.argoproj.io/hook-delete-policy: BeforeHookCreation`. K8s Jobs are immutable after creation; without these, image tag bumps from Renovate cause "field is immutable" sync failures. For standalone Jobs, add annotations directly. For Helm-rendered Jobs, use Kustomize patches targeting `kind: Job`
 - Check `helm show values <chart> | grep -A20 certManager` when adding any Helm chart with webhooks — if a `certManager.enabled` option exists, **set it to `true`**. Helm hook Jobs for webhook certs break under ArgoCD (SA deleted before Job runs = stuck forever = API server death)

--- a/my-apps/ai/CLAUDE.md
+++ b/my-apps/ai/CLAUDE.md
@@ -6,17 +6,16 @@ One active OpenAI-compatible local backend, **NOT ollama**:
 
 ### llama.cpp — active, single card
 - Endpoint: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`
-- Served API model: **`qwen3.8-27b`** — temporary compatibility alias for
-  Qwen3.8-Flash-Next UD-Q4_K_XL with BF16 vision and symmetric q8_0 KV at 131K
+- Served API model: **`Qwen3.8-Flash-Next Q4`** — Qwen3.8-Flash-Next
+  UD-Q4_K_XL with BF16 vision and symmetric q8_0 KV at 131K
   on **one** RTX 3090.
-- **Use llama.cpp / `qwen3.8-27b` when wiring an in-cluster app to chat inference.**
+- **Use llama.cpp / `Qwen3.8-Flash-Next Q4` when wiring an in-cluster app to chat inference.**
 
 ### vLLM — parked rollback
 - `replicas: 0`; do not point consumers at `vllm-service` while parked.
 
-All in-cluster consumers request `qwen3.8-27b`, including Karakeep text and
-image inference. ComfyUI's dedicated llama.cpp-client workflow also uses this
-active Service.
+The old `qwen3.8-27b` name is reserved for the separate 27B checkpoint; do not
+use it as a Flash-Next compatibility alias.
 
 **App→backend wiring + capacity rules:
 [`model-catalog.md`](../../docs/domains/ai-gpu/model-catalog.md) ·

--- a/my-apps/ai/README.md
+++ b/my-apps/ai/README.md
@@ -13,20 +13,20 @@ ComfyUI, and SwarmUI are parked. Exactly one GPU workload may be active.
 
 ```
 Apps / OpenWebUI ──► llama.cpp (replicas: 1, one 3090)
-                         └── qwen3.8-27b (chat, tools, vision; 131,072 tokens)
+                         └── Qwen3.8-Flash-Next Q4 (chat, tools, vision; 131,072 tokens)
 
 vLLM (replicas: 0) ──► parked rollback backend
 ```
 
 ## Active LLM model
 
-llama.cpp exposes one OpenAI-compatible compatibility alias over the
-Flash-Next Q4 GGUF and BF16 projector. `qwen3.8-27b` is temporarily retained as
-the API id even though the physical model is Qwen3.8-Flash-Next.
+llama.cpp exposes the Flash-Next Q4 GGUF and BF16 projector under an API model
+name that matches the physical checkpoint. `qwen3.8-27b` is reserved for the
+separate 27B model and is not a Flash-Next alias.
 
 | API model | Model | Think | Context | Primary Use |
 |---|---|---|---:|---|
-| `qwen3.8-27b` | Qwen3.8-Flash-Next UD-Q4_K_XL + mmproj-BF16 | Low effort | 131K | Chat, tools, vision, and tasks |
+| `Qwen3.8-Flash-Next Q4` | Qwen3.8-Flash-Next UD-Q4_K_XL + mmproj-BF16 | Low effort | 131K | Chat, tools, vision, and tasks |
 
 Source of truth: `my-apps/ai/llama-cpp/deployment.yaml`.
 
@@ -50,7 +50,7 @@ llama-server natively supports the Anthropic Messages API at `/v1/messages`. No 
 export ANTHROPIC_BASE_URL="http://llama.vanillax.me"
 export ANTHROPIC_AUTH_TOKEN="no-key-required"
 export ANTHROPIC_API_KEY=""
-claude --model "qwen3.8-27b"
+claude --model "Qwen3.8-Flash-Next Q4"
 ```
 
 ### Using with OpenClaw / Other Tools
@@ -111,7 +111,7 @@ For deeper image analysis (visual Q&A, reasoning), use **Qwen 3.8** via Open Web
 ComfyUI can also call llama-server's vision API directly via the `comfyui-llamacpp-client`
 node (URL: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080`). The
 checked-in ComfyUI workflow is parked with ComfyUI and already requests the
-canonical `qwen3.8-27b` id.
+legacy `qwen3.8-27b` id; migrate that parked consumer separately before use.
 
 ## Video Generation (ComfyUI)
 
@@ -237,7 +237,7 @@ The job downloads (skips existing):
 ### Task Model
 
 Background tasks (title generation, chat tagging, follow-up suggestions) use
-`qwen3.8-27b` currently maps to Flash-Next with reasoning enabled at low effort.
+`Qwen3.8-Flash-Next Q4` uses reasoning enabled at low effort.
 
 ### RAG Tuning
 

--- a/my-apps/ai/llama-cpp/README.md
+++ b/my-apps/ai/llama-cpp/README.md
@@ -5,11 +5,11 @@ This is the active OpenAI-compatible chat, tool, and vision backend:
 - in cluster: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`
 - on the LAN: `https://llama.vanillax.me/v1` and the compatibility hostname
   `https://vllm.vanillax.me/v1`
-- API model: `qwen3.8-27b`
+- API model: `Qwen3.8-Flash-Next Q4`
 
-`qwen3.8-27b` is temporarily a compatibility alias. The physical model is
-Qwen3.8-Flash-Next UD-Q4_K_XL, so existing Pi, Perplexica, Deal Scout,
-Karakeep, and other consumers do not need a coordinated rename for this trial.
+The API model name identifies the physical Qwen3.8-Flash-Next UD-Q4_K_XL
+checkpoint. Do not use `qwen3.8-27b` for this model; that name belongs to the
+separate 27B checkpoint.
 
 ## Pinned inputs
 

--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - /models/qwen3.8-flash-next-gguf/mmproj-BF16.gguf
             - --no-mmproj-offload
             - --alias
-            - qwen3.8-27b
+            - Qwen3.8-Flash-Next Q4
             - --ctx-size
             - "131072"
             - --batch-size

--- a/my-apps/ai/open-webui/README.md
+++ b/my-apps/ai/open-webui/README.md
@@ -41,10 +41,10 @@ Currently wired up (see `open-webui-configmap.env`):
 | Role                  | Model / Value                                                  |
 |-----------------------|----------------------------------------------------------------|
 | Chat backend          | `OPENAI_API_BASE_URL=http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1` |
-| `DEFAULT_MODELS`      | `qwen3.8-27b` — llama.cpp `--alias` |
-| `VISION_MODELS`       | `qwen3.8-27b` |
-| `TASK_MODEL`          | `qwen3.8-27b` |
-| `TASK_MODEL_EXTERNAL` | `qwen3.8-27b` |
+| `DEFAULT_MODELS`      | `Qwen3.8-Flash-Next Q4` — llama.cpp `--alias` |
+| `VISION_MODELS`       | `Qwen3.8-Flash-Next Q4` |
+| `TASK_MODEL`          | `Qwen3.8-Flash-Next Q4` |
+| `TASK_MODEL_EXTERNAL` | `Qwen3.8-Flash-Next Q4` |
 | `CONTEXT_WINDOW`      | `131072` (131K) — keep aligned with llama.cpp `--ctx-size`. If smaller, Open WebUI silently trims history / RAG before sending. |
 | Sampling              | `TEMPERATURE=0.7`, `TOP_P=0.80`, `MIN_P=0.0` |
 | Image generation      | ComfyUI — Z-Image-Turbo (text→img, 9 steps), Qwen-Image-Edit-2511 (edit) |
@@ -52,8 +52,8 @@ Currently wired up (see `open-webui-configmap.env`):
 | STT / TTS             | Whisper `medium` on CPU (in-pod), OpenAI TTS voice `alloy` |
 
 llama.cpp is served from `my-apps/ai/llama-cpp/deployment.yaml`; the Open WebUI
-model ID must match its `--alias`. It advertises only `qwen3.8-27b` so the model
-selector stays clean.
+model ID must match its `--alias`. It advertises only `Qwen3.8-Flash-Next Q4`
+so the model selector stays clean.
 
 ## Performance tuning (env ConfigMap)
 

--- a/my-apps/ai/open-webui/open-webui-configmap.env
+++ b/my-apps/ai/open-webui/open-webui-configmap.env
@@ -1,12 +1,12 @@
 ENABLE_OPENAI_API=True
-# All in-cluster consumers use the single-card llama.cpp Qwen3.8 backend.
+# Open WebUI uses the single-card llama.cpp Flash-Next backend.
 OPENAI_API_BASE_URL=http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1
 OPENAI_API_BASE_URLS=http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1
 OPENAI_API_KEY=sk-required
 OPENAI_API_KEYS=sk-required
 ENABLE_OLLAMA_API=false
-DEFAULT_MODELS=qwen3.8-27b
-VISION_MODELS=qwen3.8-27b
+DEFAULT_MODELS=Qwen3.8-Flash-Next Q4
+VISION_MODELS=Qwen3.8-Flash-Next Q4
 CONTEXT_WINDOW=131072
 # Qwen 3.8 publishes different sampling per mode. The server defaults to
 # non-thinking output,
@@ -52,9 +52,9 @@ RAG_FILE_MAX_COUNT=10
 RAG_SYSTEM_CONTEXT=True
 ENABLE_TOOLS=True
 OPENAPI_API_ENDPOINTS=mcpo-time:http://mcpo.open-webui.svc.cluster.local:8000:mcp-demo-key;mcpo-multi:http://mcpo-multi.open-webui.svc.cluster.local:8001:mcp-multi-key;mcpo-kiwix:http://mcpo-kiwix.open-webui.svc.cluster.local:8002:mcp-kiwix-key
-# The server exposes one non-thinking alias, so title/tag generation uses it too.
-TASK_MODEL=qwen3.8-27b
-TASK_MODEL_EXTERNAL=qwen3.8-27b
+# Title/tag generation uses the same advertised Flash-Next model.
+TASK_MODEL=Qwen3.8-Flash-Next Q4
+TASK_MODEL_EXTERNAL=Qwen3.8-Flash-Next Q4
 DEFAULT_SYSTEM_PROMPT="You have access to an offline encyclopedia (Kiwix) via the 'fetch' tool.\nThe Kiwix server is located at: http://kiwix.kiwix.svc.cluster.local:8080\n\nTo search for information:\n1. Use the 'fetch' tool to search: \"http://kiwix.kiwix.svc.cluster.local:8080/search?pattern=YOUR_SEARCH_QUERY\"\n2. The result will be an HTML page containing search results. Read the links from this page.\n3. To read an article, use 'fetch' again on the article URL found in the search results (e.g., \"http://kiwix.kiwix.svc.cluster.local:8080/content/wikipedia_en_all_maxi_2025-08/Article_Name\").\n\nWhen asked about general knowledge or historical facts, ALWAYS check the offline encyclopedia first using these steps.\nCITE your sources by referencing the article title.\n"
 ENABLE_IMAGE_GENERATION=True
 IMAGE_GENERATION_ENGINE=comfyui


### PR DESCRIPTION
## Summary

- advertise the active llama.cpp model as `Qwen3.8-Flash-Next Q4`
- stop reusing `qwen3.8-27b` as the Flash-Next compatibility alias
- configure Open WebUI default, vision, and task model selectors to use the exact new alias
- update the llama.cpp, Open WebUI, and AI source-of-truth docs to distinguish Flash-Next from the separate 27B checkpoint

## Validation

- `kustomize build my-apps/ai/llama-cpp`
- `kustomize build my-apps/ai/open-webui`
- `kubectl apply --dry-run=client -f <rendered llama.cpp manifest>`
- `kubectl apply --dry-run=client -f <rendered Open WebUI manifest>`
- rendered llama.cpp Deployment contains `--alias "Qwen3.8-Flash-Next Q4"`
- rendered Open WebUI ConfigMap contains `Qwen3.8-Flash-Next Q4` for `DEFAULT_MODELS`, `VISION_MODELS`, `TASK_MODEL`, and `TASK_MODEL_EXTERNAL`

## Scope

This PR changes the llama.cpp advertised model name and updates Open WebUI to select it. Other consumers are unchanged.