### PR TITLE
perf(llama-cpp): skip re-hashing verified model shards on every sync

### DIFF
--- a/my-apps/ai/llama-cpp/download-model-job.yaml
+++ b/my-apps/ai/llama-cpp/download-model-job.yaml
@@ -36,19 +36,29 @@ spec:
               mkdir -p "$BASE/unsloth-ud-q4-k-xl"
               apk add --no-cache curl
 
+              # This hook re-runs on every sync. Hashing all shards each time is a
+              # ~104 GiB NFS read that contends with the server's mmap of the
+              # same files, so a matching stamp short-circuits it.
               fetch() {
                 name="$1" dest="$2" size="$3" expected="$4"
-                part="$dest.part"
-                if [ -f "$dest" ] && [ "$(stat -c %s "$dest")" = "$size" ] && \
-                   [ "$(sha256sum "$dest" | cut -d' ' -f1)" = "$expected" ]; then
-                  echo "verified: $name"
-                  return
+                part="$dest.part" stamp="$dest.sha256"
+                if [ -f "$dest" ] && [ "$(stat -c %s "$dest")" = "$size" ]; then
+                  if [ "$(cat "$stamp" 2>/dev/null)" = "$expected" ]; then
+                    echo "verified (stamp): $name"
+                    return
+                  fi
+                  if [ "$(sha256sum "$dest" | cut -d' ' -f1)" = "$expected" ]; then
+                    printf '%s' "$expected" > "$stamp"
+                    echo "verified: $name"
+                    return
+                  fi
                 fi
                 curl -fL -C - --retry 5 -o "$part" "$REPO/$name"
                 actual="$(sha256sum "$part" | cut -d' ' -f1)"
                 [ "$actual" = "$expected" ] || { echo "SHA MISMATCH: $name: $actual"; rm -f "$part"; exit 1; }
                 [ "$(stat -c %s "$part")" = "$size" ] || { echo "SIZE MISMATCH: $name"; rm -f "$part"; exit 1; }
                 mv "$part" "$dest"
+                printf '%s' "$expected" > "$stamp"
                 echo "downloaded and verified: $name"
               }
 


### PR DESCRIPTION
The model download hook is a `Sync` hook, so it re-runs on every ArgoCD sync of
this app. Its `fetch()` guard verified each shard by unconditionally hashing it:

```sh
if [ -f "$dest" ] && [ "$(stat -c %s "$dest")" = "$size" ] && \
   [ "$(sha256sum "$dest" | cut -d' ' -f1)" = "$expected" ]; then
```

It never re-downloads — that part works. But it reads and SHA-256s all five
shards every time:

| shard | bytes |
|---|---:|
| 00001 | 10.9 MB |
| 00002 | 49.86 GB |
| 00003 | 49.38 GB |
| 00004 | 12.09 GB |
| mmproj | 0.91 GB |
| **total** | **~112 GB (104.5 GiB)** |

That is a ~104 GiB NFS read, single-threaded, on every sync. It runs for minutes
and contends with `llama-cpp-server` on the same export — the server mmaps these
files and demand-pages the PLE tensor during inference, so the hook competes with
live serving, not just with startup.

## Change

Record the verified digest next to each shard as `<shard>.sha256` and
short-circuit when the size *and* the stamp both match:

- stamp matches + size matches → skip (a `stat` and a small read)
- stamp missing → full hash, then write the stamp (first run after this lands)
- size differs, stamp differs, or file absent → full hash / re-download, unchanged

A `REV` bump changes the expected digest, so the stamp stops matching and the
shard is re-fetched exactly as before. A truncated or partially written file
changes the size and is caught. `.part` handling, `curl -C -` resume, and both
mismatch guards are untouched.

## Tradeoff

This stops detecting silent bit-rot that preserves file size, on every sync.
That was never really what the hook was for — it exists to guarantee the model is
present and correct after download — and paying 104 GiB of contended NFS reads
per sync for that property is the wrong trade. Deleting the `.sha256` stamps
forces a full re-verification on the next sync.

Renders clean under `kustomize build`; embedded script passes `sh -n`.