### PR TITLE
ai(llama-cpp): serve the model from node-local NVMe, not NFS

### DIFF
--- a/my-apps/ai/llama-cpp/README.md
+++ b/my-apps/ai/llama-cpp/README.md
@@ -27,8 +27,33 @@ official tag and its linux/amd64 manifest digest; do not use pre-merge `b10236`.
 
 The wave-0 Sync hook downloads and verifies all four Q4 shards and the public
 BF16 projector on the existing RWX model share. It resumes `.part` files,
-checks byte size and SHA-256, and atomically renames verified artifacts. The
-wave-1 Deployment mounts the share read-only and starts after the hook succeeds.
+checks byte size and SHA-256, and atomically renames verified artifacts.
+
+## Model storage
+
+Two tiers. NFS is the canonical archive; a node-local NVMe cache is what
+inference actually reads.
+
+| Tier | Backing | PVC | Role |
+|---|---|---|---|
+| Source | TrueNAS NFS, `192.168.10.133:/mnt/ai-pool/llama-cpp` | `llama-cpp-models-pvc` (RWX) | canonical archive, hydrated from Hugging Face |
+| Cache | GPU node's 450 GB NVMe, Talos UserVolume `ai-model-cache` → `/var/mnt/ai-model-cache` | `ai-model-cache` (RWO, `Retain`) | what the Deployment mounts at `/models` |
+
+The Deployment mounts **only** the cache. NFS must stay out of the inference
+path: llama.cpp demand-pages tensors under `--load-mode mmap`, so a page-cache
+miss against NFS becomes a network round trip, and under memory pressure that
+collapses throughput to well under 1 tok/s.
+
+`cache-sync-job.yaml` (wave-0 Sync hook) copies the four shards plus the
+projector from NFS to the cache, comparing **name and size only** — a SHA-256
+pass would stream ~104 GiB through page cache on every sync, which is the exact
+thrash the cache exists to avoid. It is idempotent; a warm cache exits in
+seconds.
+
+The cache PV is node-local by design (`nodeAffinity: gpu-worker=true`,
+`persistentVolumeReclaimPolicy: Retain`) and is **not** on Longhorn and not
+replicated — GGUF files are reproducible from NFS. The 450 GB disk holds the
+104.5 GiB checkpoint with ~336 GiB free for additional quants.
 
 ## Runtime profile
 

--- a/my-apps/ai/llama-cpp/cache-sync-job.yaml
+++ b/my-apps/ai/llama-cpp/cache-sync-job.yaml
@@ -1,0 +1,77 @@
+# Hydrates the node-local NVMe cache from the NFS source PVC. Name+size only —
+# a sha256 pass would stream ~104 GiB through page cache on every sync.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: llama-cpp-cache-sync
+  namespace: llama-cpp
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 4
+  activeDeadlineSeconds: 10800
+  template:
+    spec:
+      restartPolicy: OnFailure
+      nodeSelector:
+        gpu-worker: "true"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: sync
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              SRC=/src/qwen3.8-flash-next-gguf
+              DST=/dst/qwen3.8-flash-next-gguf
+              mkdir -p "$DST/unsloth-ud-q4-k-xl"
+
+              sync_one() {
+                rel="$1"; s="$SRC/$rel"; d="$DST/$rel"
+                want=$(stat -c %s "$s")
+                if [ -f "$d" ] && [ "$(stat -c %s "$d")" = "$want" ]; then
+                  echo "present: $rel ($want bytes)"; return
+                fi
+                echo "copying: $rel ($want bytes)"
+                cp "$s" "$d.part"
+                got=$(stat -c %s "$d.part")
+                [ "$got" = "$want" ] || { echo "SIZE MISMATCH $rel: $got != $want"; rm -f "$d.part"; exit 1; }
+                mv "$d.part" "$d"
+              }
+
+              for i in 1 2 3 4; do
+                sync_one "unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-0000$i-of-00004.gguf"
+              done
+              sync_one "mmproj-BF16.gguf"
+
+              echo "=== RESULT ==="
+              du -sb "$DST" | awk '{printf "cache: %s bytes (%.2f GiB)\n", $1, $1/1073741824}'
+              df -h /dst
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "4"
+              memory: 2Gi
+          volumeMounts:
+            - name: src
+              mountPath: /src
+              readOnly: true
+            - name: dst
+              mountPath: /dst
+      volumes:
+        - name: src
+          persistentVolumeClaim:
+            claimName: llama-cpp-models-pvc
+            readOnly: true
+        - name: dst
+          persistentVolumeClaim:
+            claimName: ai-model-cache

--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -142,9 +142,11 @@ spec:
             - name: dshm
               mountPath: /dev/shm
       volumes:
+        # Node-local NVMe cache, not the NFS PVC: mmap page-cache misses during
+        # inference must not become NFS round trips. See cache-sync-job.yaml.
         - name: models
           persistentVolumeClaim:
-            claimName: llama-cpp-models-pvc
+            claimName: ai-model-cache
         - name: dshm
           emptyDir:
             medium: Memory

--- a/my-apps/ai/llama-cpp/kustomization.yaml
+++ b/my-apps/ai/llama-cpp/kustomization.yaml
@@ -6,7 +6,9 @@ namespace: llama-cpp
 resources:
   - namespace.yaml
   - pvc.yaml
+  - pvc-model-cache.yaml
   - download-model-job.yaml
+  - cache-sync-job.yaml
   - deployment.yaml
   - service.yaml
   - httproute.yaml

--- a/my-apps/ai/llama-cpp/pvc-model-cache.yaml
+++ b/my-apps/ai/llama-cpp/pvc-model-cache.yaml
@@ -1,0 +1,42 @@
+# Node-local model cache on the GPU worker's 450GB NVMe (`ai-model-cache` Talos
+# UserVolume, /dev/sdb1). Inference mmaps from here; the NFS PVC is the source copy.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ai-model-cache-local
+spec:
+  capacity:
+    storage: 450Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ai-model-cache-local
+  volumeMode: Filesystem
+  local:
+    path: /var/mnt/ai-model-cache
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: gpu-worker
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ai-model-cache
+  namespace: llama-cpp
+  labels:
+    backup-exempt: "true"
+  annotations:
+    storage.vanillax.dev/backup-exempt-reason: "Node-local GGUF cache; reproducible from the NFS source PVC"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 450Gi
+  storageClassName: ai-model-cache-local
+  volumeName: ai-model-cache-local

--- a/omni/cluster-template/cluster-template-prod-v2.yaml
+++ b/omni/cluster-template/cluster-template-prod-v2.yaml
@@ -349,7 +349,7 @@ patches:
         node.longhorn.io/create-default-disk: "config"
       nodeAnnotations:
         node.longhorn.io/default-disks-config: >-
-          [{"name":"talos-ephemeral","path":"/var/lib/longhorn","allowScheduling":true,"diskType":"filesystem","storageReserved":0,"tags":[]},{"name":"nvme1","path":"/var/mnt/longhorn-nvme1","allowScheduling":true,"diskType":"filesystem","storageReserved":0,"tags":[]},{"name":"ssd-flash","path":"/var/mnt/longhorn-ssd-flash","allowScheduling":true,"diskType":"filesystem","storageReserved":0,"tags":["flash"]}]
+          [{"name":"talos-ephemeral","path":"/var/lib/longhorn","allowScheduling":true,"diskType":"filesystem","storageReserved":0,"tags":[]},{"name":"ssd-flash","path":"/var/mnt/longhorn-ssd-flash","allowScheduling":true,"diskType":"filesystem","storageReserved":0,"tags":["flash"]}]
 - file: patches/threadripper-gpu-workers.yaml
 - name: kubelet-performance
   inline:
@@ -370,16 +370,16 @@ patches:
           - bind
           - rshared
           - rw
-- name: longhorn-nvme1-volume
+# The 450GB NVMe disk is the AI model cache, not Longhorn: llama.cpp mmaps GGUF weights
+# from here, so page-cache misses are local NVMe reads instead of NFS round trips.
+- name: ai-model-cache-volume
   inline:
     apiVersion: v1alpha1
     kind: UserVolumeConfig
-    name: longhorn-nvme1
+    name: ai-model-cache
     provisioning:
-      # Upper bound added when longhorn-ssd-flash was introduced: without it this
-      # selector would ALSO match the 300GB enterprise-SSD disk and the two volumes
-      # would race for the same device. Sizes are the only thing that distinguishes
-      # them — both are virtio-scsi disks reporting the same model to Talos.
+      # Size is the only thing separating this from the 300GB ssd-flash disk — both are
+      # virtio-scsi disks reporting the same model to Talos. Do not drop the bound.
       diskSelector:
         match: "!system_disk && disk.size >= 400u * GB"
       minSize: 400GB


### PR DESCRIPTION
## Why

llama.cpp demand-pages tensors under `--load-mode mmap`, so every page-cache miss against the NFS-backed model PVC became a network round trip. Under memory pressure that collapsed throughput from **~11.5 PP / ~5.5 TG** to **~0.29 PP / ~0.22 TG** on an otherwise byte-identical config.

This takes NFS out of the inference hot path.

## What changed

Repurposes the GPU worker's second 450 GB NVMe (`scsi1` / `nvme1-vmstore`, `/dev/sdb`) from Longhorn into a dedicated AI model cache.

`scsi0` was never a candidate — it is the Talos **system disk** (EFI/META/STATE + the 481 GB `EPHEMERAL` partition that backs `/var` and the `talos-ephemeral` Longhorn disk).

**Talos** (`omni/cluster-template/`)
- UserVolume `longhorn-nvme1` → `ai-model-cache`, mounted at `/var/mnt/ai-model-cache`
- drop `nvme1` from the node's Longhorn `default-disks-config`
- remove the abandoned 120 GB `ai-models` volume on `ssd-ent` that this supersedes

**Kubernetes** (`my-apps/ai/llama-cpp/`)
- `pvc-model-cache.yaml` — node-local PV/PVC, `Retain`, `gpu-worker=true` nodeAffinity, deliberately **not** Longhorn and **not** replicated (GGUFs are reproducible)
- `cache-sync-job.yaml` — wave-0 idempotent NFS → NVMe copy, **name + size only**. A SHA-256 pass would stream ~104 GiB through page cache on every sync, which is precisely the thrash the cache exists to avoid
- Deployment `/models` now mounts the cache instead of the NFS PVC

## Disk eviction — what was on it

`nvme1` was drained via Longhorn eviction (`evictionRequested`) before any wipe. Every volume in this cluster is `numberOfReplicas: 1`, so this was done properly rather than by deleting the disk.

| Volume | Size | Disposition |
|---|---|---|
| 8x kopiur `*-src` snapshot clones | ~95 GiB | transient backup scaffolding, self-deleted |
| `swarmui/swarmui-dlbackend` | 40 GiB | relocated to dell-worker (app at `replicas: 0`, unused/exempt) |
| `project-zomboid/zomboid-server-files` | 60 GiB | relocated to dell-worker (app at `replicas: 0`, backup-exempt, SteamCMD-reproducible) |

Post-eviction: 0 replicas on `nvme1`, 0 faulted/degraded volumes cluster-wide.

## Result

- `/var/mnt/ai-model-cache` — 483 GB xfs on `/dev/sdb1`, no reboot required
- 104.53 GiB checkpoint resident locally, **~336 GiB free** for further quants
- NFS remains the canonical archive

## Not changed

**Zero llama.cpp runtime parameters.** `b10666`, UD-Q4_K_XL, ctx 131072, q8_0/q8_0 KV, parallel 1, batch 4096, ubatch 512, `-ngl 99`, `--fit off`, `--load-mode mmap`, `--tensor-read-lazy auto`, flash-attn on, MTP off, CPU-side vision projector, and the existing tensor override regex are all untouched — so storage is the only benchmark variable.

Benchmark numbers to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLC3tRwx7ck4mWDzph4Qqh