### PR TITLE
feat(ai): trial Atomic Qwen3.8 Flash Next layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This is a production-grade GitOps Kubernetes cluster running on **Talos OS** wit
 
 **AI/LLM Backend**: Two OpenAI-compatible local backends, both NOT ollama:
 
-- **llama.cpp** (`http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`, served model `Qwen3.8-Flash-Next Q4`) is active with UD-Q4_K_XL GGUF, BF16 vision, symmetric q8_0 KV at 131K, and no MTP on one RTX 3090.
+- **llama.cpp** (`http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`, served model `Qwen3.8-Flash-Next Q4`) is active with AtomicChat AD-4.27bpw-Q4_K_M-M64 GGUF, F16 vision, symmetric q8_0 KV at 131K, and no MTP on one RTX 3090.
 - **vLLM** is the parked rollback backend at `replicas: 0`.
 
 GPU topology: the GPU workloads use **mutually exclusive whole-card** allocations (`type: Recreate`, time-slicing disabled — never oversubscribe the card). They scale-swap by committed replica counts. Current state is llama-cpp `1`, vLLM `0`, and ComfyUI/SwarmUI `0`; the chassis has one RTX 3090. App→backend wiring is tabulated in `docs/domains/ai-gpu/model-catalog.md`; the swap procedure + card truth table live in `docs/domains/ai-gpu/gpu-scale-swap.md`.

--- a/docs/superpowers/plans/2026-08-29-qwen38-flash-next-atomic-quant.md
+++ b/docs/superpowers/plans/2026-08-29-qwen38-flash-next-atomic-quant.md
@@ -1,0 +1,103 @@
+# Qwen3.8 Flash Next Atomic Quant Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox notation (`- [ ]`) for tracking.
+
+**Goal:** Replace the active Flash Next GGUF layout with AtomicChat's pinned AD-4.27 Q4 build and prove whether one RTX 3090 can sustain at least 15 generated tokens per second without the current mmap/page-reclaim stall.
+
+**Architecture:** Keep NFS as the durable artifact source and node-local NVMe as the inference source. Stage both the current Unsloth rollback model and AtomicChat's split model, then point llama.cpp at AtomicChat's first ordinary-weight shard while leaving the dedicated N-gram shard mmap-backed on the host. Preserve context, KV, and serving behavior so throughput differences are attributable to artifact layout and expert placement.
+
+**Tech Stack:** Kubernetes, Argo CD sync hooks, Kustomize, llama.cpp CUDA server, Alpine shell, Hugging Face LFS artifacts, MkDocs.
+
+**Spec:** `docs/superpowers/specs/2026-08-29-qwen38-flash-next-atomic-quant-design.md`
+
+## Global Constraints
+
+- Follow root, `my-apps/`, and `my-apps/ai/` `CLAUDE.md` rules.
+- Make cluster changes only through Git; do not patch the live Deployment.
+- Pin every remote artifact by repository revision, byte size, and LFS SHA-256.
+- Do not delete the existing Unsloth model during the trial.
+- Keep `--ctx-size 131072`, q8_0/q8_0 KV, one slot, and speculative decoding disabled.
+- Never merge the pull request; deployment requires the user to merge.
+
+---
+
+## Task 1: Pin and Download the AtomicChat Q4 Artifact Set
+
+**Files:**
+
+- Modify: `my-apps/ai/llama-cpp/download-model-job.yaml`
+
+- [ ] Query the Hugging Face tree API for revision `142262902a46f7daed19c79d0771534c8106ad59` and capture all 33 files in `Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64/` plus `mmproj-Qwen3.8-Flash-Next-F16.gguf`.
+- [ ] Verify the inventory has exactly 33 model shards, contiguous indices `00001-of-00033` through `00033-of-00033`, and one projector.
+- [ ] Extend the hook so `fetch` accepts a repository URL per artifact family, preserving the existing Unsloth pins and rollback files.
+- [ ] Add AtomicChat download calls with exact byte sizes and `.lfs.oid` SHA-256 values into `/models/qwen3.8-flash-next-gguf/atomic-ad-4.27-q4-k-m-m64/` and `/models/qwen3.8-flash-next-gguf/mmproj-F16.gguf`.
+- [ ] Run `kustomize build my-apps/ai/llama-cpp --enable-helm` and inspect the rendered download command for all 34 Atomic artifacts.
+- [ ] Commit: `feat(ai): pin Atomic Flash Next Q4 artifacts`.
+
+## Task 2: Stage AtomicChat and Rollback Models on Node-Local NVMe
+
+**Files:**
+
+- Modify: `my-apps/ai/llama-cpp/cache-sync-job.yaml`
+
+- [ ] Add the Atomic destination directory without removing `unsloth-ud-q4-k-xl`.
+- [ ] Sync all 33 Atomic shards and the F16 projector by name and source size.
+- [ ] Preserve the four Unsloth shards and BF16 projector for one-rollout rollback.
+- [ ] Ensure partial copies remain atomic via `.part` followed by `mv`, and raise the job deadline enough for the additional approximately 93 GB copy.
+- [ ] Render the Kustomization and verify both model families appear in the hook script.
+- [ ] Commit: `feat(ai): stage Atomic Flash Next on NVMe`.
+
+## Task 3: Serve the Conservative Atomic Q4 Placement
+
+**Files:**
+
+- Modify: `my-apps/ai/llama-cpp/deployment.yaml`
+- Modify: `my-apps/ai/llama-cpp/README.md`
+
+- [ ] Change `--model` to Atomic shard `00001-of-00033` and `--mmproj` to `mmproj-F16.gguf`.
+- [ ] Remove only the `per_layer_token_embd.weight=CPU` override; initially preserve the current CPU expert-layer pattern to isolate the layout change.
+- [ ] Keep `--load-mode mmap`, `--tensor-read-lazy auto`, `--fit off`, the 131K context, q8 KV, and all existing API behavior.
+- [ ] Update the README with the pinned Atomic profile, the retained Unsloth rollback path, and the explicit warm `tg128 >= 15 tok/s` acceptance gate. Do not claim an unmeasured result.
+- [ ] Render the Kustomization and verify the Deployment consumes the Atomic path only after the two wave-0 hooks.
+- [ ] Commit: `feat(ai): trial Atomic Flash Next Q4 layout`.
+
+## Task 4: Run Static Repository Validation
+
+**Files:**
+
+- Verify: `my-apps/ai/llama-cpp/*.yaml`
+- Verify: `docs/superpowers/specs/2026-08-29-qwen38-flash-next-atomic-quant-design.md`
+- Verify: `docs/superpowers/plans/2026-08-29-qwen38-flash-next-atomic-quant.md`
+
+- [ ] Run `kustomize build my-apps/ai/llama-cpp --enable-helm > /tmp/llama-cpp-rendered.yaml`.
+- [ ] Run the repository's YAML/Kubernetes schema validation commands used by CI against the rendered output.
+- [ ] Run repository policy validation, including the VPA validator if available locally.
+- [ ] Run `mkdocs build --strict`; if the tool is unavailable, record that exact limitation and leave the CI check pending rather than installing an unpinned local dependency.
+- [ ] Review `git diff --check`, `git diff --stat`, and the full scoped diff for accidental deletions or stale model paths.
+
+## Task 5: Publish the GitOps Trial Without Merging
+
+**Files:**
+
+- Review: all branch changes
+
+- [ ] Push `codex/qwen38-atomic-quant-trial` to origin.
+- [ ] Open a pull request that includes the verified failure evidence, artifact/layout change, expected storage impact, acceptance gate, and exact rollback path.
+- [ ] Leave the pull request unmerged for the user.
+
+## Task 6: Post-Merge Live Benchmark and Placement Sweep
+
+**Files:**
+
+- Modify after measurement: `my-apps/ai/llama-cpp/deployment.yaml`
+- Modify after measurement: `my-apps/ai/llama-cpp/README.md`
+- Modify after acceptance: `docs/domains/ai-gpu/3090-llm-optimization.md`
+- Modify after acceptance: `docs/domains/ai-gpu/model-catalog.md`
+
+- [ ] Confirm both sync hooks complete, all 34 Atomic files are present on NVMe, and the Deployment reaches Ready with zero restarts/OOM events.
+- [ ] Record model load time, CUDA memory, cgroup memory, process read bytes, major faults, CPU utilization, and GPU utilization.
+- [ ] Run cold and warm `pp512` and `tg128` tests with the server still configured for 131K context, ensuring the sole slot is otherwise idle.
+- [ ] Run one OpenAI-compatible streaming smoke request, one tool-call prompt, and one vision prompt for correctness.
+- [ ] If warm `tg128` is below 15 tok/s, move one expert-placement boundary toward GPU residency, repeat the same measurements, and stop before CUDA OOM or unsafe device headroom.
+- [ ] If the best safe Atomic Q4 placement remains below 15 tok/s, prepare the separately pinned AD-3.84 IQ4_XS trial described in the design spec; do not combine it with context, KV, or scheduler changes.
+- [ ] Once a profile passes, record measured results in the README and AI GPU docs and capture the durable result in Mink.

--- a/docs/superpowers/plans/2026-08-29-qwen38-flash-next-atomic-quant.md
+++ b/docs/superpowers/plans/2026-08-29-qwen38-flash-next-atomic-quant.md
@@ -53,6 +53,8 @@
 
 - Modify: `my-apps/ai/llama-cpp/deployment.yaml`
 - Modify: `my-apps/ai/llama-cpp/README.md`
+- Modify: `CLAUDE.md`
+- Modify: `my-apps/ai/CLAUDE.md`
 
 - [ ] Change `--model` to Atomic shard `00001-of-00033` and `--mmproj` to `mmproj-F16.gguf`.
 - [ ] Remove only the `per_layer_token_embd.weight=CPU` override; initially preserve the current CPU expert-layer pattern to isolate the layout change.

--- a/docs/superpowers/specs/2026-08-29-qwen38-flash-next-atomic-quant-design.md
+++ b/docs/superpowers/specs/2026-08-29-qwen38-flash-next-atomic-quant-design.md
@@ -1,0 +1,192 @@
+# Qwen3.8 Flash Next Atomic Quant Trial Design
+
+**Status:** Approved for implementation
+
+## Purpose
+
+Make Qwen3.8 Flash Next usable as the cluster's primary local model on one RTX
+3090 and a 100 GiB Threadripper 2950X worker. The first performance target is
+at least 15 generated tokens per second without the page-cache stalls observed
+with the current Unsloth UD-Q4_K_XL deployment.
+
+This is a controlled model-layout trial, not a claim that a 24 GiB card can
+match the 36 tok/s unified-memory or four-GPU results published elsewhere.
+
+## Current State and Verified Failure
+
+The live server runs llama.cpp b10666 with the 111 GB Unsloth UD-Q4_K_XL
+family, a BF16 projector, 131,072-token q8_0/q8_0 KV, lazy PLE reads, and expert
+tensors from blocks 9-46 on CPU. Only about ten layers' expert tensors remain
+on the GPU.
+
+The 2026-08-29 live evidence showed:
+
+- 310 prompt tokens at 3.49 tok/s and 86 generated tokens at 0.17 tok/s;
+- a subsequent request stalled at 374 of 376 prompt tokens while the GPU was
+  idle;
+- zero container restarts and zero cgroup OOM events;
+- approximately 131 GB of process reads, 10.8 million file-cache refaults, and
+  sustained full memory pressure around 44-50%;
+- ordinary workloads sharing the untainted GPU worker and competing for CPU
+  and memory bandwidth.
+
+The model is therefore not failing because its context window or KV cache is
+intrinsically too large. Its ordinary weights and PLE table leave too little
+headroom under the current shard layout, and the CPU-offloaded expert path is
+competing with host page reclaim and unrelated pods.
+
+## Decision
+
+Trial AtomicChat's `AD-4.27bpw-Q4_K_M-M64` GGUF first. AtomicChat publishes it
+as 92.9 GB total, with 54.5 GB of ordinary weights in fast memory and a 38.4 GB
+N-gram-only shard left on SSD. Its published quality measurements are 0.0842 KL
+divergence and 89.49% top-1 agreement against BF16. This is the highest-quality
+Atomic build whose stated resident set comfortably fits the worker's combined
+RAM and VRAM with 131K context headroom.
+
+The model remains on the existing node-local NVMe cache. llama.cpp keeps mmap
+enabled so the N-gram-only shard is pageable. The explicit
+`per_layer_token_embd` override is removed because the table is model-level,
+host-side by default, and physically isolated from ordinary weights in this
+build.
+
+Expert placement is discovered empirically rather than frozen to the current
+block pattern. Start conservatively, then move expert layers onto the GPU until
+the loaded process leaves safe CUDA headroom for the 131K symmetric KV cache
+and compute buffers. Change only one placement boundary per benchmark round.
+
+If the Q4 build cannot reach 15 tok/s after placement is maximized, trial
+AtomicChat's `AD-3.84bpw-IQ4_XS-M64`. It reduces the stated resident weights to
+45.8 GB and should permit more GPU-resident expert layers, at the accepted cost
+of lower published fidelity: 0.2277 KL divergence and 82.68% top-1 agreement.
+
+## Runtime Profile
+
+The first trial retains the product behavior users already depend on:
+
+- one OpenAI-compatible server slot;
+- 131,072-token context allocation;
+- symmetric q8_0 K/V cache and Flash Attention;
+- vision through AtomicChat's shared F16 projector;
+- Jinja chat templating and the existing reasoning defaults;
+- node-local NVMe as the inference source and NFS as the retained source copy.
+
+`--load-mode none` is not part of the initial Atomic trial. AtomicChat's layout
+and guide explicitly use mmap to page the separate N-gram shard. A later
+llama.cpp build may adopt the open loader and batched-readahead work after it is
+merged or after a separately reviewed custom-image decision; the first trial
+does not combine an unmerged runtime patch with a new quant.
+
+MTP and N-gram speculative decoding remain disabled during the baseline. They
+change generation mechanics and would make it impossible to attribute a speed
+change to model residency and placement.
+
+## Controlled Rollout
+
+### Phase 1: stage without serving
+
+Pin the AtomicChat repository revision and every shard digest in the download
+hook. Retain the existing Unsloth files on NFS and node-local NVMe so rollback
+does not require another 100 GB transfer. Update the cache-sync hook to stage
+the Atomic Q4 shards and F16 projector without deleting either model family.
+
+Expected result: every pinned file exists on NFS and local NVMe with the exact
+declared byte size and SHA-256 digest. Stop if AtomicChat changes the published
+file set, a digest differs, or local NVMe cannot hold both model families.
+
+### Phase 2: serve a conservative placement
+
+Change only the Deployment's model path, projector path, PLE override, and
+initial expert placement. Preserve the current context, KV, batch, sampling,
+and API settings. Argo CD performs the normal `Recreate` rollout.
+
+Expected result: the pod reaches Ready with one 131,072-token slot, zero
+restarts, no OOM event, and several GiB of host and device headroom. Stop before
+benchmarking if the loader wires the N-gram shard into CUDA memory, ordinary
+weights continually refault from disk, or available host memory falls below
+the amount needed by system workloads.
+
+### Phase 3: tune one placement boundary at a time
+
+Run the same cold and warm benchmark at each expert-placement boundary. Move
+the boundary only after recording model load time, prompt throughput,
+generation throughput, GPU memory, host memory, major faults, process read
+bytes, CPU utilization, and GPU utilization.
+
+The primary acceptance test is a warm single-stream `tg128` result of at least
+15 tok/s with the server configured for 131K context. Also run `pp512` and an
+OpenAI-compatible streaming request to verify TTFT and real server behavior.
+Depth runs at 8K, 32K, and 100K record the expected long-context degradation;
+they do not replace the primary short-depth target.
+
+### Phase 4: choose quality or speed tier
+
+Keep `AD-4.27bpw-Q4_K_M-M64` if it meets the target. If its best safe placement
+is below 15 tok/s, repeat phases 1-3 with `AD-3.84bpw-IQ4_XS-M64`. Do not change
+context size, KV type, speculative decoding, or CPU scheduling in the same
+comparison.
+
+### Phase 5: isolate host resources if still required
+
+If the selected Atomic build meets the target only when unrelated pods are
+quiet, make GPU-worker isolation a separate GitOps change. Taint the worker
+through its owning Talos/Omni configuration and verify required DaemonSets
+tolerate the taint before eviction. Ordinary workloads such as Loki and
+PostHog must move elsewhere; hardware, networking, storage, and observability
+DaemonSets remain.
+
+This phase is separate because changing the quant and scheduler population at
+once would hide which intervention fixed the stall.
+
+## Files and Sources of Truth
+
+The implementation owns:
+
+- `my-apps/ai/llama-cpp/download-model-job.yaml` for pinned source artifacts;
+- `my-apps/ai/llama-cpp/cache-sync-job.yaml` for node-local staging;
+- `my-apps/ai/llama-cpp/deployment.yaml` for model and runtime placement;
+- `my-apps/ai/llama-cpp/README.md` for measured results and rollback;
+- `docs/domains/ai-gpu/3090-llm-optimization.md` and
+  `docs/domains/ai-gpu/model-catalog.md` for the accepted production profile.
+
+External evidence:
+
+- AtomicChat guide and published residency/quality figures:
+  <https://atomic.chat/blog/guides/how-to-run-qwen-3-8-flash-next-locally>
+- AtomicChat model repository:
+  <https://huggingface.co/AtomicChat/Qwen3.8-Flash-Next-GGUF>
+- llama.cpp lazy tensor loader PR:
+  <https://github.com/ggml-org/llama.cpp/pull/27794>
+- pending loader interaction fix:
+  <https://github.com/ggml-org/llama.cpp/pull/27837>
+- pending batched PLE readahead measurements:
+  <https://github.com/unslothai/llama.cpp/pull/137>
+
+## Validation
+
+Static validation must render the Kustomization, validate YAML, run repository
+policy checks, and build documentation strictly. Artifact validation must
+compare every downloaded file to its pinned byte size and digest before the
+Deployment can consume it.
+
+Live validation must record both cold and warm timings. A result is not valid
+if another request occupied the sole slot, the pod restarted, the prompt cache
+changed between comparison arms, or the GPU worker's competing workload
+changed materially during the run.
+
+Output correctness remains a gate: deterministic smoke prompts, one tool call,
+and one vision prompt must remain coherent before throughput is accepted.
+
+## Rollback
+
+Rollback changes the Deployment path and placement flags back to the retained
+Unsloth UD-Q4_K_XL files. No model is deleted during the trial, so rollback is
+one normal Argo CD `Recreate` rollout and requires no download.
+
+If the Atomic download or local-cache sync fails, stop before changing the
+Deployment. If the Atomic pod loads but stalls, OOMs, or emits incoherent
+output, revert the serving commit; do not add simultaneous speculative,
+context, or KV changes in an attempt to rescue that run.
+
+Model cleanup is a later, explicit storage decision after the selected profile
+has remained stable. It is not part of this trial.

--- a/my-apps/ai/CLAUDE.md
+++ b/my-apps/ai/CLAUDE.md
@@ -7,7 +7,7 @@ One active OpenAI-compatible local backend, **NOT ollama**:
 ### llama.cpp — active, single card
 - Endpoint: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`
 - Served API model: **`Qwen3.8-Flash-Next Q4`** — Qwen3.8-Flash-Next
-  UD-Q4_K_XL with BF16 vision and symmetric q8_0 KV at 131K
+  AtomicChat AD-4.27bpw-Q4_K_M-M64 with F16 vision and symmetric q8_0 KV at 131K
   on **one** RTX 3090.
 - **Use llama.cpp / `Qwen3.8-Flash-Next Q4` when wiring an in-cluster app to chat inference.**
 
@@ -31,12 +31,13 @@ use it as a Flash-Next compatibility alias.
   [`single-vs-dual-3090.md`](../../docs/domains/ai-gpu/single-vs-dual-3090.md).
 - **Local = unlimited token *volume* (free), not an infinite *window* per request.**
 - **Engine choice:** Qwen3.8-Flash-Next runs on a pinned post-merge llama.cpp
-  qwen4exp build via UD-Q4_K_XL GGUF and the BF16 projector. The stock-vLLM
+  qwen4exp build via AtomicChat's split Q4 GGUF and F16 projector. The stock-vLLM
   W4A16 deployment is a parked rollback.
 - **MTP stays off for Flash-Next.** The merged qwen4exp implementation did not
   include the final Flash-Next MTP path.
-- **PLE stays lazy and mmap-backed.** Do not add mlock or disable
-  `--tensor-read-lazy`; the 100 GiB Talos VM cannot hold the Q4 model resident.
+- **The dedicated N-gram shard stays lazy and mmap-backed.** Do not add mlock,
+  disable `--tensor-read-lazy`, or explicitly offload `per_layer_token_embd`;
+  the split AtomicChat layout keeps that table out of ordinary weight shards.
 - **TurboQuant `turbo3` KV** (≈5x smaller) is coming to mainline llama.cpp
   (PR #21089) — adopt it then for cheap big context.
 

--- a/my-apps/ai/llama-cpp/README.md
+++ b/my-apps/ai/llama-cpp/README.md
@@ -7,9 +7,9 @@ This is the active OpenAI-compatible chat, tool, and vision backend:
   `https://vllm.vanillax.me/v1`
 - API model: `Qwen3.8-Flash-Next Q4`
 
-The API model name identifies the physical Qwen3.8-Flash-Next UD-Q4_K_XL
-checkpoint. Do not use `qwen3.8-27b` for this model; that name belongs to the
-separate 27B checkpoint.
+The API model name identifies the physical AtomicChat
+AD-4.27bpw-Q4_K_M-M64 checkpoint. Do not use `qwen3.8-27b` for this model;
+that name belongs to the separate 27B checkpoint.
 
 ## Pinned inputs
 
@@ -17,17 +17,19 @@ separate 27B checkpoint.
 |---|---|
 | Engine source | upstream llama.cpp `4e97ac86ebe2c4cb8212d98d2641ad6768810896` (`b10666`) |
 | Engine image | `ghcr.io/ggml-org/llama.cpp:server-cuda-b10666@sha256:a2d04d1d1c2b2abe287fef9a22a3700a7fa20aec4c4ab56135e0099f38119848` (amd64) |
-| Model repository | `unsloth/Qwen3.8-Flash-Next-GGUF` revision `c8b5954a88c2775c546b92593eda40ea041d3176` |
-| Weights | `Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf` through `00004-of-00004.gguf` |
-| Vision projector | `mmproj-BF16.gguf`, SHA-256 `2e788f8c511d8093c7b43cb87b2fd7e14228340318057f8fb20c86df2efe2355` |
+| Model repository | `AtomicChat/Qwen3.8-Flash-Next-GGUF` revision `142262902a46f7daed19c79d0771534c8106ad59` |
+| Weights | `Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00001-of-00033.gguf` through `00033-of-00033.gguf` |
+| Vision projector | `mmproj-Qwen3.8-Flash-Next-F16.gguf`, SHA-256 `0e61454a76dd154a10aaa8fb1ada32615f55a13e4171014dacd06913e4aa6889` |
 
 Official build `b10666` is produced from a commit after the qwen4exp merge
 commit `6c84c7d5d8833c6e0df69628f75a0f599797934e`. The Deployment pins the
 official tag and its linux/amd64 manifest digest; do not use pre-merge `b10236`.
 
-The wave-0 Sync hook downloads and verifies all four Q4 shards and the public
-BF16 projector on the existing RWX model share. It resumes `.part` files,
-checks byte size and SHA-256, and atomically renames verified artifacts.
+The wave -1 Sync hook downloads and verifies all 33 Atomic Q4 shards and the
+public F16 projector on the existing RWX model share. It also retains and
+verifies the prior four-shard Unsloth model and BF16 projector for rollback.
+Downloads resume `.part` files, check byte size and SHA-256, and atomically
+rename verified artifacts.
 
 ## Model storage
 
@@ -44,36 +46,53 @@ path: llama.cpp demand-pages tensors under `--load-mode mmap`, so a page-cache
 miss against NFS becomes a network round trip, and under memory pressure that
 collapses throughput to well under 1 tok/s.
 
-`cache-sync-job.yaml` (wave-0 Sync hook) copies the four shards plus the
-projector from NFS to the cache, comparing **name and size only** — a SHA-256
-pass would stream ~104 GiB through page cache on every sync, which is the exact
-thrash the cache exists to avoid. It is idempotent; a warm cache exits in
-seconds.
+`cache-sync-job.yaml` (wave 0 Sync hook) copies the Atomic model, its projector,
+and the retained Unsloth rollback files from NFS to the cache. It compares
+**name and size only** because the wave -1 source hook already pins SHA-256; a
+second hash pass would stream both families through page cache on every sync.
+It is idempotent, and a warm cache exits in seconds.
 
 The cache PV is node-local by design (`nodeAffinity: gpu-worker=true`,
 `persistentVolumeReclaimPolicy: Retain`) and is **not** on Longhorn and not
-replicated — GGUF files are reproducible from NFS. The 450 GB disk holds the
-104.5 GiB checkpoint with ~336 GiB free for additional quants.
+replicated — GGUF files are reproducible from NFS. The Atomic model and F16
+projector use 88.88 GiB; the retained Unsloth model and projector use 104.53
+GiB. Together they leave approximately 256 GiB on the 450 GiB cache.
 
 ## Runtime profile
 
 - one whole RTX 3090 and one parallel slot
 - 131,072-token context with symmetric q8_0 K/V cache
 - Flash Attention and native Jinja; reasoning enabled at low effort
-- BF16 vision enabled with the projector on CPU to preserve the 131K GPU KV budget
+- F16 vision enabled with the projector on CPU to preserve the 131K GPU KV budget
 - MTP disabled because the merged Flash-Next path does not include final MTP support
-- automatic fit disabled; PLE and blocks 9-46 FFN tensors explicitly placed on CPU
+- automatic fit disabled; blocks 9-46 FFN tensors initially placed on CPU
 - `--load-mode mmap --tensor-read-lazy auto`; no mlock, so tensors larger than
-  4 GiB (including PLE/ngram) are demand-paged instead of being forced resident
+  4 GiB are demand-paged instead of being forced resident. Atomic shard 00002
+  contains only the 38.4 GB decimal N-gram table, so it is not interleaved with
+  CUDA-pinned ordinary weights and needs no explicit PLE tensor override.
 - 20 CPU / 80 GiB requests, no CPU limit, and a 94 GiB memory limit; the 100
   GiB Talos VM keeps roughly 6 GiB outside the pod for Talos and node services
   while allowing useful mmap page cache. The sole GPU remains limit=request=1.
 
-The NFS export reported 728 GiB free before download, so no existing model was
-deleted. The PVC's 150 GiB capacity is a static Kubernetes declaration, not an
-export quota.
+No existing model is deleted during this trial. The PVC's 150 GiB capacity is
+a static Kubernetes declaration, not an export quota.
 
-## First successful baseline — 2026-08-28
+## Atomic layout acceptance gate — pending deployment
+
+This commit changes the GGUF layout and projector while deliberately preserving
+context, KV, batching, sampling, and the initial expert placement. It does not
+claim a throughput win before the branch is merged and measured on the GPU
+worker.
+
+Acceptance requires a warm, single-stream `tg128` result of at least 15 tok/s
+while the server remains configured for a 131,072-token slot. Record `pp512`,
+streaming TTFT, device and cgroup memory, major faults, process read bytes, CPU
+and GPU utilization, plus text, tool-call, and vision correctness. If the
+conservative blocks 9-46 CPU placement misses the target, move one expert
+boundary toward the GPU per measurement round; do not simultaneously change
+context, KV type, or speculative decoding.
+
+## Historical Unsloth baseline — 2026-08-28
 
 - llama.cpp `b10666` / `4e97ac86e`; GGUF architecture `qwen4exp`
 - model plus CPU-resident BF16 projector loaded in 3m51.26s from NFS
@@ -99,6 +118,14 @@ uses `--no-mmproj-offload`.
 
 ## Rollback
 
-Set llama.cpp to `replicas: 0`, set `my-apps/ai/vllm/deployment.yaml` to
-`replicas: 1`, restore the vLLM HTTPRoute resource, and repoint consumers in the
-same commit. The scheduler sequences the sole GPU; never scale both to one.
+For an in-place llama.cpp rollback, restore the model path to
+`unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf`, restore
+`mmproj-BF16.gguf`, and restore
+`^per_layer_token_embd\.weight$=CPU,blk\.((9|[123][0123456789]|40|41|42|43|44|45|46))\.ffn_.*=CPU`.
+Both model families remain on NFS and NVMe, so this is one normal `Recreate`
+rollout with no download.
+
+For a backend rollback, set llama.cpp to `replicas: 0`, set
+`my-apps/ai/vllm/deployment.yaml` to `replicas: 1`, restore the vLLM HTTPRoute,
+and repoint consumers in the same commit. The scheduler sequences the sole GPU;
+never scale both to one.

--- a/my-apps/ai/llama-cpp/cache-sync-job.yaml
+++ b/my-apps/ai/llama-cpp/cache-sync-job.yaml
@@ -1,5 +1,6 @@
-# Hydrates the node-local NVMe cache from the NFS source PVC. Name+size only —
-# a sha256 pass would stream ~104 GiB through page cache on every sync.
+# Hydrates the node-local NVMe cache from the verified NFS source PVC.
+# Name+size only here: the wave -1 downloader already pins SHA-256, while a
+# second hash pass would stream both retained model families through page cache.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -12,7 +13,7 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 4
-  activeDeadlineSeconds: 10800
+  activeDeadlineSeconds: 21600
   template:
     spec:
       restartPolicy: OnFailure
@@ -31,7 +32,9 @@ spec:
             - |
               SRC=/src/qwen3.8-flash-next-gguf
               DST=/dst/qwen3.8-flash-next-gguf
-              mkdir -p "$DST/unsloth-ud-q4-k-xl"
+              mkdir -p \
+                "$DST/unsloth-ud-q4-k-xl" \
+                "$DST/atomic-ad-4.27-q4-k-m-m64"
 
               sync_one() {
                 rel="$1"; s="$SRC/$rel"; d="$DST/$rel"
@@ -40,7 +43,7 @@ spec:
                   echo "present: $rel ($want bytes)"; return
                 fi
                 echo "copying: $rel ($want bytes)"
-                cp "$s" "$d.part"
+                cp "$s" "$d.part" || { rm -f "$d.part"; exit 1; }
                 got=$(stat -c %s "$d.part")
                 [ "$got" = "$want" ] || { echo "SIZE MISMATCH $rel: $got != $want"; rm -f "$d.part"; exit 1; }
                 mv "$d.part" "$d"
@@ -50,6 +53,14 @@ spec:
                 sync_one "unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-0000$i-of-00004.gguf"
               done
               sync_one "mmproj-BF16.gguf"
+
+              i=1
+              while [ "$i" -le 33 ]; do
+                shard=$(printf '%05d' "$i")
+                sync_one "atomic-ad-4.27-q4-k-m-m64/Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-${shard}-of-00033.gguf"
+                i=$((i + 1))
+              done
+              sync_one "mmproj-F16.gguf"
 
               echo "=== RESULT ==="
               du -sb "$DST" | awk '{printf "cache: %s bytes (%.2f GiB)\n", $1, $1/1073741824}'

--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -42,9 +42,9 @@ spec:
           command: ["/app/llama-server"]
           args:
             - --model
-            - /models/qwen3.8-flash-next-gguf/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf
+            - /models/qwen3.8-flash-next-gguf/atomic-ad-4.27-q4-k-m-m64/Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00001-of-00033.gguf
             - --mmproj
-            - /models/qwen3.8-flash-next-gguf/mmproj-BF16.gguf
+            - /models/qwen3.8-flash-next-gguf/mmproj-F16.gguf
             - --no-mmproj-offload
             - --alias
             - Qwen3.8-Flash-Next Q4
@@ -59,7 +59,7 @@ spec:
             - --fit
             - "off"
             - --override-tensor
-            - '^per_layer_token_embd\.weight$=CPU,blk\.((9|[123][0123456789]|40|41|42|43|44|45|46))\.ffn_.*=CPU'
+            - '^blk\.((9|[123][0123456789]|40|41|42|43|44|45|46))\.ffn_.*=CPU'
             - --load-mode
             - mmap
             - --tensor-read-lazy

--- a/my-apps/ai/llama-cpp/download-model-job.yaml
+++ b/my-apps/ai/llama-cpp/download-model-job.yaml
@@ -31,16 +31,21 @@ spec:
             - -ec
             - |
               BASE=/models/qwen3.8-flash-next-gguf
-              REV=c8b5954a88c2775c546b92593eda40ea041d3176
-              REPO=https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF/resolve/$REV
-              mkdir -p "$BASE/unsloth-ud-q4-k-xl"
+              UNSLOTH_REV=c8b5954a88c2775c546b92593eda40ea041d3176
+              ATOMIC_REV=142262902a46f7daed19c79d0771534c8106ad59
+              UNSLOTH_REPO=https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF/resolve/$UNSLOTH_REV
+              ATOMIC_REPO=https://huggingface.co/AtomicChat/Qwen3.8-Flash-Next-GGUF/resolve/$ATOMIC_REV
+              ATOMIC_DIR=Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64
+              mkdir -p \
+                "$BASE/unsloth-ud-q4-k-xl" \
+                "$BASE/atomic-ad-4.27-q4-k-m-m64"
               apk add --no-cache curl
 
               # This hook re-runs on every sync. Hashing all shards each time is a
               # ~104 GiB NFS read that contends with the server's mmap of the
               # same files, so a matching stamp short-circuits it.
               fetch() {
-                name="$1" dest="$2" size="$3" expected="$4"
+                repo="$1" name="$2" dest="$3" size="$4" expected="$5"
                 part="$dest.part" stamp="$dest.sha256"
                 if [ -f "$dest" ] && [ "$(stat -c %s "$dest")" = "$size" ]; then
                   if [ "$(cat "$stamp" 2>/dev/null)" = "$expected" ]; then
@@ -53,7 +58,7 @@ spec:
                     return
                   fi
                 fi
-                curl -fL -C - --retry 5 -o "$part" "$REPO/$name"
+                curl -fL -C - --retry 5 -o "$part" "$repo/$name"
                 actual="$(sha256sum "$part" | cut -d' ' -f1)"
                 [ "$actual" = "$expected" ] || { echo "SHA MISMATCH: $name: $actual"; rm -f "$part"; exit 1; }
                 [ "$(stat -c %s "$part")" = "$size" ] || { echo "SIZE MISMATCH: $name"; rm -f "$part"; exit 1; }
@@ -62,20 +67,66 @@ spec:
                 echo "downloaded and verified: $name"
               }
 
-              fetch UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf \
+              fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf \
                 "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf" \
                 10946624 4448186216b3af4cc558bbce2c3213f01608f8f8b2e5267a9767971dd3ec8082
-              fetch UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00002-of-00004.gguf \
+              fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00002-of-00004.gguf \
                 "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00002-of-00004.gguf" \
                 49859583136 3f342f1c1580473f1ee94ddd5b28206e8c07a70fa1a366f59d1d6c922919a6c9
-              fetch UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00003-of-00004.gguf \
+              fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00003-of-00004.gguf \
                 "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00003-of-00004.gguf" \
                 49376141504 56758f40269cad5cd9b0d3d6fbae0f40f6d5be6de49e4ab392dbe83157d9cbd3
-              fetch UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00004-of-00004.gguf \
+              fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00004-of-00004.gguf \
                 "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00004-of-00004.gguf" \
                 12087983520 753bda48b98ba4f1636134a90a967de1b2d3908a236c026e464777342e53510a
-              fetch mmproj-BF16.gguf "$BASE/mmproj-BF16.gguf" \
+              fetch "$UNSLOTH_REPO" mmproj-BF16.gguf "$BASE/mmproj-BF16.gguf" \
                 907542944 2e788f8c511d8093c7b43cb87b2fd7e14228340318057f8fb20c86df2efe2355
+
+              # AtomicChat isolates the approximately 38.4 GB N-gram table in
+              # shard 00002 so mmap can page it without pinning ordinary model
+              # tensors. Keep every LFS object immutable and independently
+              # verifiable; the first shard is the llama.cpp model entrypoint.
+              while read -r name size expected; do
+                fetch "$ATOMIC_REPO" "$ATOMIC_DIR/$name" \
+                  "$BASE/atomic-ad-4.27-q4-k-m-m64/$name" "$size" "$expected"
+              done <<'ATOMIC_Q4_ARTIFACTS'
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00001-of-00033.gguf 693380288 d74620aad612239711e0947f58d2614fa8f47335fb01f23e47b24a3315c3e730
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00002-of-00033.gguf 38400184512 77edf6523f6abbd7ba6a78aa1ef4a658dfaca544f9c5f46cf0efd0b0ff00bef0
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00003-of-00033.gguf 1999024832 50a95250ea2cfb5b9359bfbf37e8334959266c38777c134e1c7082c4a668f59d
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00004-of-00033.gguf 1787651072 0a32371569fd1564e82be13301a872847d00dce450db7c7f930f6978c0bccd6d
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00005-of-00033.gguf 1654830080 d545285f60dd11a2dfc46388a86af7ecb4c1bbdd86ac5364bb860ad3eefca8a4
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00006-of-00033.gguf 1993256608 64aacb4a86cc92a5a48f19619393f22af9b1a17d1c2dfbaded21bf936553994d
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00007-of-00033.gguf 1725815808 7cfd22c0de5dda2500643b9e13ef9c4aea338968ca29c1786226b325bc5948c6
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00008-of-00033.gguf 1830961056 408457d6a65f632b62ebec099112fb106ed1c1d3d5bc2bd9e189004bad9af550
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00009-of-00033.gguf 1915366048 c1f962654057e9a4f71af34ccada5d242af62a5c915b0694a0a152b30b24ba99
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00010-of-00033.gguf 1711956000 b85555c695efc1bd6852d005bd20931882b54c2d0f48a0912f846fe5e252b697
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00011-of-00033.gguf 1844820928 e5cb081065b8721583ddc29f5f71f5acb1d537c2d2a3bd8bc18e03d4340d2e43
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00012-of-00033.gguf 1923724224 cc9cb8624556958f65b9763c918ee077542e3d0cc1f6a81a647b2987860f1243
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00013-of-00033.gguf 1703597888 cd4abb2dc631a08f9b3885597f77bc24d1b1d9acd4662cafc17ebfb8e0b8959e
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00014-of-00033.gguf 1844820928 b14050af3b53ee789575a2a8159cb1524a2160a8b251e97fd367f2c0ffcf73d3
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00015-of-00033.gguf 1909864352 d6066a9799e1640b2609fa9c28b19d33ce1441c4737de11d3eb8e283d494c61f
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00016-of-00033.gguf 1717457728 76c95f5229b461e6c648f536a714457913fab50fb2608ffa64ec10ddbf8eabed
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00017-of-00033.gguf 1853179072 5a9428ca9bab16c1ada3b43bc98b60d3a884f7bded0aa9b468fb66dd6c36e68b
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00018-of-00033.gguf 1901506240 d4ad15dfa433fc1d0d09112bb175512321d41fe60a651b720e1c104cdd2c8f97
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00019-of-00033.gguf 1725815872 6ba1501407c639a126e74f483bfa4073da42ea24abecd251a7d560a0810855ba
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00020-of-00033.gguf 1830961088 96fc276c556886d19af5d1514876c59ad7d37005e99c329f35e4d4418515219b
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00021-of-00033.gguf 1915366080 f3c46604b832c24201c1d4d6ac22830ec729830f66e7bb91a2f8895ec41d62f9
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00022-of-00033.gguf 1711956000 5ae92fbdd717a4246620608a441571fd041dfb2a4bd20d969a8f6c8cd411b734
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00023-of-00033.gguf 1844820928 59bc05521ea68a8b6ff4b78fd275a0da975270384db05f2fbc62fbb901f28b15
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00024-of-00033.gguf 1923724224 14216d45769bc6ffec284e1be54ef9b200081fb528b97653ccaeedad896a5396
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00025-of-00033.gguf 1703597888 94bd0311975222d1c62f47fa6cde17bb56ad6f98c47c42c888a19e7d57b704af
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00026-of-00033.gguf 1844820928 b69a8f3b9896f7c0c1b75778d833ef8b0a3aa6d2df587444741a172a39f49c1f
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00027-of-00033.gguf 1909864352 35c3703530a17fcf42b8dbe8a582a3fe1be6e5d58885460fd46fd614585bec8b
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00028-of-00033.gguf 1646472000 8d01bec24d38b8876c8a011e04ccfca22584d9f86ea24c13e7e7b07a781cfbba
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00029-of-00033.gguf 1725375264 2b266e2d2a7f610d0a3de55a626e2f9029594c383074240d29c383a8f70e1064
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00030-of-00033.gguf 1738770080 36af1ca74bbf2bd4d79ac78b61a9f5d24e5ca9aac33d298bfbed7d9dbbe86c69
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00031-of-00033.gguf 1646472000 2cf675a6d3df1ff2eb018323c7e64ab14cd650eb38f954e948df27501822fdc1
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00032-of-00033.gguf 1725375264 59c5ab585958f86cecbd812a9ae34f1475d98ffff235d27734964fb53d8b4951
+              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00033-of-00033.gguf 1220605344 0a7311b24f8636f5b7c0f0dca4f6275ec6b45e326a5eb7400410ca4e32c269c2
+              ATOMIC_Q4_ARTIFACTS
+              fetch "$ATOMIC_REPO" mmproj-Qwen3.8-Flash-Next-F16.gguf \
+                "$BASE/mmproj-F16.gguf" \
+                904003840 0e61454a76dd154a10aaa8fb1ada32615f55a13e4171014dacd06913e4aa6889
           resources:
             requests:
               cpu: 250m

--- a/my-apps/ai/llama-cpp/download-model-job.yaml
+++ b/my-apps/ai/llama-cpp/download-model-job.yaml
@@ -6,7 +6,8 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-    argocd.argoproj.io/sync-wave: "0"
+    # Finish the durable NFS download before the wave-0 NVMe hydration hook.
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 4


### PR DESCRIPTION
## Why

The live Unsloth UD-Q4_K_XL server degraded to 0.17 generated tok/s and later stalled with an idle GPU. The pod had no restart or OOM, while cgroup evidence showed about 131 GB of reads, 10.8 million file-cache refaults, and sustained full memory pressure around 44-50 percent. The current interleaved PLE layout is therefore the main variable under test.

## What changes

- Pins AtomicChat AD-4.27bpw-Q4_K_M-M64 at revision 142262902a46f7daed19c79d0771534c8106ad59: 33 exact LFS objects plus the shared F16 projector.
- Keeps the dedicated 38.4 GB decimal N-gram shard mmap-backed and removes the explicit PLE override.
- Preserves 131K context, q8_0/q8_0 KV, one slot, batching, sampling, and the initial blocks 9-46 CPU expert placement.
- Orders verified NFS download at sync wave -1, NVMe hydration at wave 0, and the Recreate server rollout at wave 1.
- Retains the complete Unsloth model and BF16 projector on NFS and NVMe.

## Storage impact

Atomic plus F16 uses 88.88 GiB. The retained Unsloth rollback set uses 104.53 GiB. Together they consume 193.41 GiB of the 450 GiB node-local cache, leaving approximately 256 GiB.

## Acceptance gate

After merge, the primary gate is warm single-stream tg128 at or above 15 tok/s while the server remains configured for a 131072-token slot. The runbook also requires pp512, streaming TTFT, memory/fault/utilization evidence, and text, tool-call, and vision correctness. Expert placement moves toward the GPU one boundary per benchmark round only if the conservative placement misses the target.

## Rollback

Restore the retained Unsloth shard-1 model path, mmproj-BF16.gguf, and the prior per_layer_token_embd plus blocks 9-46 CPU override. This is one normal Recreate rollout and requires no download.

## Verification

Passed locally:

- Kustomize 5.8.1 render and YAML parse
- shell syntax for both rendered hook scripts
- exact 33-shard inventory and -1/0/1 hook order assertions
- Atomic serving path and absence of the PLE override
- ArgoCD application topology validation
- git diff checks and clean worktree

Pending GitHub CI because local tools are unavailable or misconfigured: kubeconform, PyYAML policy validators, MkDocs strict build, and Puppeteer diagram rendering.