### PR TITLE
fix(ai): let model cache hook schedule with server

### DIFF
--- a/my-apps/ai/llama-cpp/cache-sync-job.yaml
+++ b/my-apps/ai/llama-cpp/cache-sync-job.yaml
@@ -68,7 +68,10 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 512Mi
+              # The serving pod reserves 80 GiB on this node. The copy process
+              # needs little anonymous memory; its file cache is reclaimable
+              # and bounded by the 2 GiB limit below.
+              memory: 64Mi
             limits:
               cpu: "4"
               memory: 2Gi


### PR DESCRIPTION
## Root cause

The Atomic rollout is blocked at the NVMe cache hook. The GPU node has 102411680 KiB allocatable and 104739209224 bytes already requested, leaving about 124 MiB of scheduler headroom. The hook requests 512 MiB, so Kubernetes correctly reports Insufficient memory even though actual node use is only 32 percent.

## Fix

Reduce only the cache-copy pod memory request from 512 MiB to 64 MiB. Keep its 2 GiB limit unchanged. The Alpine copy process needs little anonymous memory, while file cache is reclaimable and bounded by the existing limit.

## Test

RED: rendered request was 512Mi and failed the 64Mi scheduling contract.

GREEN: rendered request is 64Mi. Kustomize render, rendered hook shell syntax, Argo application topology, and git diff checks pass.

## Rollout

After merge, terminate the currently stale cache hook operation and resync my-apps-llama-cpp. The new hook will fit the measured request headroom and stage the 88.88 GiB Atomic model before wave 1 replaces the server.