### PR TITLE
fix(ai): use native CPU MoE placement

### DIFF
--- a/my-apps/ai/llama-cpp/README.md
+++ b/my-apps/ai/llama-cpp/README.md
@@ -65,7 +65,8 @@ GiB. Together they leave approximately 256 GiB on the 450 GiB cache.
 - Flash Attention and native Jinja; reasoning enabled at low effort
 - F16 vision enabled with the projector on CPU to preserve the 131K GPU KV budget
 - MTP disabled because the merged Flash-Next path does not include final MTP support
-- automatic fit disabled; blocks 9-46 FFN tensors initially placed on CPU
+- automatic fit disabled; the native `--n-cpu-moe 38` path keeps the first 38
+  layers' expert weights on CPU and leaves ten expert layers on the GPU
 - `--load-mode mmap --tensor-read-lazy auto`; no mlock, so tensors larger than
   4 GiB are demand-paged instead of being forced resident. Atomic shard 00002
   contains only the 38.4 GB decimal N-gram table, so it is not interleaved with
@@ -88,9 +89,9 @@ Acceptance requires a warm, single-stream `tg128` result of at least 15 tok/s
 while the server remains configured for a 131,072-token slot. Record `pp512`,
 streaming TTFT, device and cgroup memory, major faults, process read bytes, CPU
 and GPU utilization, plus text, tool-call, and vision correctness. If the
-conservative blocks 9-46 CPU placement misses the target, move one expert
-boundary toward the GPU per measurement round; do not simultaneously change
-context, KV type, or speculative decoding.
+conservative 38-CPU-layer placement misses the target, reduce `--n-cpu-moe`
+one boundary per measurement round; do not simultaneously change context, KV
+type, or speculative decoding.
 
 ## Historical Unsloth baseline — 2026-08-28
 

--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -58,8 +58,8 @@ spec:
             - "99"
             - --fit
             - "off"
-            - --override-tensor
-            - '^blk\.((9|[123][0123456789]|40|41|42|43|44|45|46))\.ffn_.*=CPU'
+            - --n-cpu-moe
+            - "38"
             - --load-mode
             - mmap
             - --tensor-read-lazy


### PR DESCRIPTION
## Root cause evidence

The Atomic layout rollout succeeded, but a live user request generated at about 0.13 tok/s. During a 10-second decode sample the server produced one token, read effectively zero GiB from disk, incurred only 16 major faults and zero file-cache refaults, saturated about 20 CPU cores, and left the RTX 3090 at 0 percent utilization. This rules out the SSD and N-gram shard as the active bottleneck.

The server also warns that raw tensor overrides with mmap can hurt performance. The successful community configurations use the native n-cpu-moe placement path provided by this b10666 build.

## Change

Replace the raw blocks 9-46 FFN tensor regex with native --n-cpu-moe 38. This preserves the same conservative budget of 38 CPU expert layers and 10 GPU expert layers while using the supported MoE graph placement path. Context, q8 KV, mmap, lazy N-gram reads, batching, sampling, and projector placement do not change.

## Verification

RED: the rendered Deployment contained --override-tensor and lacked --n-cpu-moe.

GREEN: the rendered Deployment contains --n-cpu-moe 38 and no raw override. Kustomize render, YAML parse, both hook shell scripts, Argo application topology, and git diff checks pass.

## Rollout gate

After merge and Argo sync, require a Ready 131072-token slot with safe VRAM, then rerun the same controlled 128-token request. If warm decode remains below 15 tok/s, reduce n-cpu-moe one boundary at a time while watching CUDA headroom.