### PR TITLE
fix(llama-cpp): let auto-fit place Flash Next

### DIFF
--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -54,12 +54,12 @@ spec:
             - "4096"
             - --ubatch-size
             - "512"
-            - --n-gpu-layers
-            - "99"
             - --fit
-            - "off"
-            - --n-cpu-moe
-            - "38"
+            - "on"
+            - --fit-ctx
+            - "131072"
+            - --fit-target
+            - "512"
             - --load-mode
             - mmap
             - --tensor-read-lazy


### PR DESCRIPTION
## Summary
- replace the fixed `--n-gpu-layers 99 --fit off --n-cpu-moe 38` placement with llama.cpp auto-fit
- preserve the requested 131072-token context through `--fit-ctx 131072`
- use Unsloth Desktop's tighter 512 MiB auto-fit margin via `--fit-target 512`
- keep AtomicChat's split n-gram shard mmap-backed and lazy

## Why
The fixed CPU-MoE profile left CUDA idle during decode and produced roughly 0.3 tok/s. Unsloth Desktop treats `--n-cpu-moe` as a manual-only placement control. Its smarter tensor-spill planner deliberately abstains for split GGUFs, then delegates placement to llama.cpp `--fit on`. This model is a 33-shard GGUF, so this PR mirrors that fallback path.

## Verification
- `kustomize build my-apps/ai/llama-cpp`
- rendered-argument assertion: fit on, fit context 131072, fit target 512, no fixed GPU/MoE flags
- `kustomize build my-apps/ai/llama-cpp | kubectl apply --dry-run=server -f -`
- live b10666 `llama-server --help` confirms `--fit`, `--fit-ctx`, and `--fit-target` support

## Runtime acceptance
After merge and Argo sync, verify CUDA utilization during decode and measure warm short-context generation. Target: at least 15 tok/s.