### PR TITLE
feat(ai): run Flash Next IQ4_XS with expert-only offload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This is a production-grade GitOps Kubernetes cluster running on **Talos OS** wit
 
 **AI/LLM Backend**: Two OpenAI-compatible local backends, both NOT ollama:
 
-- **llama.cpp** (`http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`, served model `Qwen3.8-Flash-Next Q4`) is active with AtomicChat AD-4.27bpw-Q4_K_M-M64 GGUF, F16 vision, symmetric q8_0 KV at 131K, and no MTP on one RTX 3090.
+- **llama.cpp** (`http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`, served model `Qwen3.8-Flash-Next Q4`) is active with Unsloth UD-IQ4_XS GGUF, BF16 vision, expert-only CPU offload, symmetric q8_0 KV at 131K, and no MTP on one RTX 3090.
 - **vLLM** is the parked rollback backend at `replicas: 0`.
 
 GPU topology: the GPU workloads use **mutually exclusive whole-card** allocations (`type: Recreate`, time-slicing disabled — never oversubscribe the card). They scale-swap by committed replica counts. Current state is llama-cpp `1`, vLLM `0`, and ComfyUI/SwarmUI `0`; the chassis has one RTX 3090. App→backend wiring is tabulated in `docs/domains/ai-gpu/model-catalog.md`; the swap procedure + card truth table live in `docs/domains/ai-gpu/gpu-scale-swap.md`.

--- a/docs/domains/ai-gpu/3090-llm-optimization.md
+++ b/docs/domains/ai-gpu/3090-llm-optimization.md
@@ -5,12 +5,13 @@
 > [`noonghunna/club-3090`](https://github.com/noonghunna/club-3090) recipe repo,
 > recipe used for the active single-card configuration.
 >
-> Last updated: 2026-08-21 (current-state banner; historical analysis retained).
+> Last updated: 2026-08-29 (current-state banner; historical analysis retained).
 >
-> ⚠️ **Current topology:** llama.cpp serves `qwen3.8-27b` on the sole RTX 3090
-> using UD-IQ4_XS, F16 vision, q8_0 KV at 131K, and embedded MTP-2. vLLM and
-> image generation are parked. Any dual-card, Qwen3.6, or old preset statement
-> below is historical unless repeated in the model catalog.
+> ⚠️ **Current topology:** llama.cpp serves `Qwen3.8-Flash-Next Q4` on the sole
+> RTX 3090 using UD-IQ4_XS, BF16 vision, q8_0 KV at 131K, expert-only CPU
+> offload, and no MTP. vLLM and image generation are parked. Any dual-card,
+> Qwen3.6, or old preset statement below is historical unless repeated in the
+> model catalog.
 
 ## TL;DR
 

--- a/docs/domains/ai-gpu/model-catalog.md
+++ b/docs/domains/ai-gpu/model-catalog.md
@@ -8,7 +8,7 @@ inference. The GPU swap procedure lives in
 
 | Backend | Replicas | Cards | Served model | Status |
 |---|---:|---:|---|---|
-| llama.cpp | `1` | **1** | `qwen3.8-27b` | Active backend for every app |
+| llama.cpp | `1` | **1** | `Qwen3.8-Flash-Next Q4` | Active backend for every app |
 | vLLM | `0` | 1 | `qwen3.8-27b` | Parked rollback |
 | NInfer | `0` | 1 | `qwen3.8-ninfer` | Parked evaluation |
 | ComfyUI / SwarmUI | `0` | 1 | Image generation | Parked |
@@ -18,30 +18,32 @@ The chassis has one RTX 3090. Exactly one GPU Deployment may have
 
 ## Active Qwen3.8 backend
 
-llama.cpp follows `club-3090/docs/SINGLE_CARD.md` at commit `4e6c3363` and
-serves one canonical id, `qwen3.8-27b`:
+llama.cpp serves one canonical id, `Qwen3.8-Flash-Next Q4`:
 
 | Property | Value |
 |---|---|
-| Engine | mainline llama.cpp `server-cuda-b10236` |
-| Weights | Unsloth `Qwen3.8-27B-UD-IQ4_XS.gguf` |
-| Vision | `mmproj-F16.gguf` |
+| Engine | mainline llama.cpp `server-cuda-b10666` (`4e97ac86e`) |
+| Weights | Unsloth `Qwen3.8-Flash-Next-UD-IQ4_XS`, three shards |
+| Vision | `mmproj-BF16.gguf`, CUDA-resident |
 | KV | symmetric q8_0 K/V |
 | Context allocation | 131,072 tokens |
 | Concurrency | one parallel slot |
-| Speculation | embedded MTP head, depth 2 |
-| Default mode | reasoning off; temp 0.7, top-p 0.8, top-k 20 |
+| Placement | all layers on CUDA; first 45 layers' MoE experts in host RAM |
+| N-grams | lazy mmap from node-local NVMe |
+| Speculation | disabled |
+| Default mode | reasoning low; temp 0.7, top-p 0.8, top-k 20 |
 
-The club-3090 slug defaults to q4_0 KV at 262K as a maximum-context exhibit.
-This cluster uses the guide's serving-grade q8_0 / 131K override. The 200 W
+The initial acceptance gate is warm single-stream `tg128 >= 15 tok/s`; no
+throughput result is claimed until it is measured after rollout. The 200 W
 power cap remains mandatory.
 
 ## Storage and staging
 
-The wave-0 Sync hook downloads the GGUF and F16 projector from the pinned
-Hugging Face revision, verifies their SHA-256 digests, and writes them to
-`192.168.10.133:/mnt/ai-pool/llama-cpp`. The wave-1 server mounts that share
-read-only.
+The wave -1 Sync hook downloads the GGUF and BF16 projector from pinned
+Hugging Face revisions, verifies their SHA-256 digests, and writes them to
+`192.168.10.133:/mnt/ai-pool/llama-cpp`. The wave 0 hook hydrates a node-local
+NVMe cache; the wave 1 server mounts only that cache read-only so mmap misses
+never become NFS round trips.
 
 The vLLM model share and compile cache remain intact for rollback. The retired
 syv-ai `qwen38-3090` application was removed; ArgoCD prunes its namespace and
@@ -49,16 +51,15 @@ Longhorn compile-cache PVC, while the shared NFS model store remains retained.
 
 ## App wiring
 
-All deployed consumers use:
+The canonical direct-client configuration is:
 
 - endpoint: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`
-- model: `qwen3.8-27b`
+- model: `Qwen3.8-Flash-Next Q4`
 
-This includes Open WebUI, Perplexica, LiteLLM, Hindsight, Presenton, HolmesGPT,
-Keep, Karakeep, World Monitor, Project NOMAD, News Reader, Deal Scout, and the
-n8n Qwen workflows. The compatibility hostname `https://vllm.vanillax.me/v1`
-now routes to the same llama.cpp Service so external clients do not need an
-immediate endpoint migration.
+Open WebUI uses the canonical alias. Several legacy direct consumers still
+send `qwen3.8-27b`; migrating those request strings is intentionally separate
+from this runtime placement trial. The compatibility hostname
+`https://vllm.vanillax.me/v1` routes to the same llama.cpp Service.
 
 ## Changing the served model
 

--- a/docs/superpowers/plans/2026-08-29-qwen38-flash-next-iq4-xs.md
+++ b/docs/superpowers/plans/2026-08-29-qwen38-flash-next-iq4-xs.md
@@ -1,0 +1,182 @@
+# Qwen3.8 Flash Next IQ4_XS Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the active AtomicChat auto-fit profile with Unsloth UD-IQ4_XS and explicit expert-only CPU placement, using the existing prebuilt llama.cpp image, then publish the GitOps change as an unmerged pull request.
+
+**Architecture:** Keep the existing NFS-to-node-local-NVMe artifact flow and immutable official llama.cpp image. Add the pinned three-shard IQ4_XS model, hydrate it before Deployment wave 1, and run all non-expert layer work on CUDA while keeping the first 45 MoE expert blocks in host RAM. Preserve the API alias, 131K context, q8/q8 KV, and rollback assets so throughput is the only intended behavioral change.
+
+**Tech Stack:** Kubernetes, Argo CD sync hooks, Kustomize, llama.cpp CUDA server, Alpine shell, Hugging Face LFS, GitHub pull requests.
+
+**Spec:** `docs/superpowers/specs/2026-08-29-qwen38-flash-next-iq4-xs-design.md`
+
+## Global Constraints
+
+- Follow root, `my-apps/`, and `my-apps/ai/` `CLAUDE.md` rules.
+- Make cluster changes only through Git; do not patch the live Deployment.
+- Retain official image build `10666` at digest `sha256:a2d04d1d1c2b2abe287fef9a22a3700a7fa20aec4c4ab56135e0099f38119848`.
+- Pin Unsloth revision `c8b5954a88c2775c546b92593eda40ea041d3176`, byte sizes, and SHA-256 values exactly as specified.
+- Keep `--ctx-size 131072`, q8_0/q8_0 KV, one slot, and speculative decoding disabled.
+- Retain AtomicChat and UD-Q4_K_XL files for rollback.
+- Never merge the pull request; deployment requires the user to merge.
+
+---
+
+### Task 1: Add the Pinned IQ4_XS Artifact Set
+
+**Files:**
+- Modify: `my-apps/ai/llama-cpp/download-model-job.yaml`
+
+**Interfaces:**
+- Consumes: existing `fetch REPO NAME DEST SIZE SHA256` shell function and pinned Unsloth repository URL.
+- Produces: verified NFS files under `qwen3.8-flash-next-gguf/unsloth-ud-iq4-xs/` for the cache hydration hook.
+
+- [ ] **Step 1: Write a failing artifact-inventory assertion**
+
+  Run a shell assertion requiring the three IQ4_XS shard names and their expected sizes/checksums in `download-model-job.yaml`; expect failure because the directory and calls do not exist yet.
+
+- [ ] **Step 2: Add IQ4_XS downloads**
+
+  Extend the existing `mkdir -p` list with `"$BASE/unsloth-ud-iq4-xs"`. Add three `fetch` calls for `UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf` through `00003-of-00003.gguf`, targeting the new directory with the exact values from the spec. Reuse the already-pinned BF16 projector.
+
+- [ ] **Step 3: Run the artifact assertion and render test**
+
+  Run the inventory assertion again and `kustomize build my-apps/ai/llama-cpp --enable-helm`; expect all three shards exactly once and a successful render.
+
+- [ ] **Step 4: Commit the model acquisition change**
+
+  Stage only `download-model-job.yaml` and commit `feat(ai): pin Flash Next IQ4_XS artifacts`.
+
+### Task 2: Hydrate IQ4_XS to Node-Local NVMe
+
+**Files:**
+- Modify: `my-apps/ai/llama-cpp/cache-sync-job.yaml`
+
+**Interfaces:**
+- Consumes: the three verified NFS files produced by Task 1.
+- Produces: size-checked, atomically copied NVMe files under `unsloth-ud-iq4-xs/` before Deployment wave 1.
+
+- [ ] **Step 1: Write a failing cache inventory assertion**
+
+  Require the new directory and a loop that resolves all three `0000N-of-00003` shard paths; expect failure before editing.
+
+- [ ] **Step 2: Add the cache directory and sync loop**
+
+  Add `"$DST/unsloth-ud-iq4-xs"` to `mkdir -p`, then call `sync_one` for shards 1 through 3. Preserve AtomicChat, UD-Q4_K_XL, and both projectors.
+
+- [ ] **Step 3: Run the cache assertion and render test**
+
+  Confirm the three-shard loop is present, the `.part` plus atomic `mv` behavior is unchanged, and Kustomize renders successfully.
+
+- [ ] **Step 4: Commit the NVMe hydration change**
+
+  Stage only `cache-sync-job.yaml` and commit `feat(ai): stage Flash Next IQ4_XS on NVMe`.
+
+### Task 3: Switch to Expert-Only CPU Placement
+
+**Files:**
+- Modify: `my-apps/ai/llama-cpp/deployment.yaml`
+
+**Interfaces:**
+- Consumes: the IQ4_XS entry shard and existing BF16 projector from node-local NVMe.
+- Produces: the unchanged OpenAI-compatible endpoint and alias with explicit CUDA/non-expert and CPU/expert placement.
+
+- [ ] **Step 1: Write failing runtime-profile assertions**
+
+  Assert the Deployment contains the IQ4_XS entry shard, `--n-gpu-layers 99`, `--fit off`, `--n-cpu-moe 45`, `--ubatch-size 2048`, mmap, lazy reads `on`, BF16 projector, and no `--no-mmproj-offload`; expect failure against auto-fit.
+
+- [ ] **Step 2: Apply the minimal runtime profile**
+
+  Switch the model path to `unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf` and projector to `mmproj-BF16.gguf`. Remove `--no-mmproj-offload`, `--fit-ctx`, and `--fit-target`; set `--fit off`, `--n-gpu-layers 99`, `--n-cpu-moe 45`, `--ubatch-size 2048`, and `--tensor-read-lazy on`. Preserve context, q8/q8 KV, alias, reasoning, sampling, probes, and resources.
+
+- [ ] **Step 3: Run runtime assertions and render test**
+
+  Confirm each required flag appears exactly once, removed auto-fit flags are absent, and Kustomize renders successfully.
+
+- [ ] **Step 4: Commit the runtime change**
+
+  Stage only `deployment.yaml` and commit `feat(ai): use IQ4_XS expert-only offload`.
+
+### Task 4: Update Current-State Documentation
+
+**Files:**
+- Modify: `my-apps/ai/llama-cpp/README.md`
+- Modify: `CLAUDE.md`
+- Modify: `my-apps/ai/CLAUDE.md`
+- Modify: `docs/domains/ai-gpu/model-catalog.md`
+
+**Interfaces:**
+- Consumes: the exact runtime and artifact pins from Tasks 1-3.
+- Produces: current-state operational guidance, performance gate, and rollback instructions for maintainers.
+
+- [ ] **Step 1: Replace obsolete active-profile claims**
+
+  Document Unsloth UD-IQ4_XS, BF16 vision on CUDA, explicit 45-block expert CPU placement, mmap/lazy n-grams, q8/q8 KV, and the retained official prebuilt image. Remove claims that AtomicChat auto-fit is the active profile.
+
+- [ ] **Step 2: Preserve measured results as historical evidence**
+
+  Keep the prior Atomic/auto-fit throughput numbers clearly labeled as historical. State `warm tg128 >= 15 tok/s` as pending acceptance rather than claiming success.
+
+- [ ] **Step 3: Document exact rollback**
+
+  Record the prior AtomicChat model path, F16 projector, auto-fit arguments, and unchanged image digest as the one-commit rollback profile.
+
+- [ ] **Step 4: Validate documentation consistency**
+
+  Search the changed current-state sections for stale `AtomicChat AD-4.27` active claims and confirm the API alias remains `Qwen3.8-Flash-Next Q4` everywhere it is documented.
+
+- [ ] **Step 5: Commit documentation**
+
+  Stage only the four documentation files and commit `docs(ai): document IQ4_XS placement trial`.
+
+### Task 5: Run Static Verification
+
+**Files:**
+- Verify: `my-apps/ai/llama-cpp/*.yaml`
+- Verify: `docs/superpowers/specs/2026-08-29-qwen38-flash-next-iq4-xs-design.md`
+- Verify: `docs/superpowers/plans/2026-08-29-qwen38-flash-next-iq4-xs.md`
+
+**Interfaces:**
+- Consumes: the complete branch diff.
+- Produces: reproducible evidence that the GitOps application renders and repository policies pass before publication.
+
+- [ ] **Step 1: Render the application**
+
+  Run `kustomize build my-apps/ai/llama-cpp --enable-helm > /tmp/llama-cpp-iq4-xs.yaml`; expect exit 0 and a non-empty multi-document manifest.
+
+- [ ] **Step 2: Validate placement and wave invariants in the render**
+
+  Assert download wave `-1`, cache wave `0`, Deployment wave `1`, IQ4_XS model path, expert-only flags, 131072 context, q8/q8 KV, and the immutable image digest.
+
+- [ ] **Step 3: Run repository policy checks**
+
+  Generate the all-app manifest stream using the same loop as `.github/workflows/cluster-ci.yml`, then run `python3 scripts/validate-kopiur-coverage.py` and `python3 scripts/validate-vpa-policies.py` against it.
+
+- [ ] **Step 4: Run documentation and diff checks**
+
+  Run `mkdocs build --strict` if installed, `git diff --check`, inspect `git diff --stat`, and review the full branch diff against `origin/main`.
+
+### Task 6: Publish an Unmerged Draft Pull Request
+
+**Files:**
+- Review: all branch commits and changes.
+
+**Interfaces:**
+- Consumes: the verified feature branch.
+- Produces: a pushed branch and draft GitHub pull request targeting `main`; the user remains the only merge actor.
+
+- [ ] **Step 1: Confirm the planning commits are present**
+
+  Confirm the design spec and implementation plan commits precede the implementation commits in the branch history.
+
+- [ ] **Step 2: Push the feature branch**
+
+  Push `feat/llama-beellama-iq4-xs` to `origin` without force.
+
+- [ ] **Step 3: Open the draft pull request**
+
+  Create one draft PR from `feat/llama-beellama-iq4-xs` to `main`. Include the measured 0.44-0.58 tok/s auto-fit failure, prebuilt-image decision, exact IQ4_XS placement, 15 tok/s acceptance gate, storage impact, validation commands, and rollback profile.
+
+- [ ] **Step 4: Leave the PR unmerged**
+
+  Report the PR URL and pending post-merge ArgoCD/live benchmark steps. Do not merge even if CI passes.

--- a/docs/superpowers/plans/2026-08-29-qwen38-flash-next-iq4-xs.md
+++ b/docs/superpowers/plans/2026-08-29-qwen38-flash-next-iq4-xs.md
@@ -103,7 +103,9 @@
 - Modify: `my-apps/ai/llama-cpp/README.md`
 - Modify: `CLAUDE.md`
 - Modify: `my-apps/ai/CLAUDE.md`
+- Modify: `my-apps/ai/README.md`
 - Modify: `docs/domains/ai-gpu/model-catalog.md`
+- Modify: `docs/domains/ai-gpu/3090-llm-optimization.md`
 
 **Interfaces:**
 - Consumes: the exact runtime and artifact pins from Tasks 1-3.
@@ -127,7 +129,7 @@
 
 - [ ] **Step 5: Commit documentation**
 
-  Stage only the four documentation files and commit `docs(ai): document IQ4_XS placement trial`.
+  Stage only the six current-state documentation files and commit `docs(ai): document IQ4_XS placement trial`.
 
 ### Task 5: Run Static Verification
 

--- a/docs/superpowers/specs/2026-08-29-qwen38-flash-next-iq4-xs-design.md
+++ b/docs/superpowers/specs/2026-08-29-qwen38-flash-next-iq4-xs-design.md
@@ -1,0 +1,147 @@
+# Qwen3.8 Flash Next IQ4_XS Deployment Design
+
+## Goal
+
+Run Unsloth Qwen3.8-Flash-Next UD-IQ4_XS on the cluster's single RTX 3090
+at the existing 131,072-token service context, with sustained warm decode of
+at least 15 tokens per second. Preserve the OpenAI-compatible service name and
+model alias used by existing clients.
+
+## Why the Current Deployment Misses the Target
+
+The current upstream llama.cpp `--fit on` deployment chooses whole-layer
+placement for the AtomicChat quant. Live measurements reached only 0.44-0.58
+decode tokens per second because significant non-expert work runs on the CPU.
+The successful single-3090 recipe uses a different placement boundary: every
+layer remains GPU-resident while only MoE expert tensors are kept in host RAM.
+Current mainline llama.cpp exposes that boundary through `--n-cpu-moe`.
+
+## Chosen Architecture
+
+Reuse the official prebuilt x86_64 CUDA llama.cpp image already running on the
+GPU node: build `10666`, commit `4e97ac86e`, pinned as
+`ghcr.io/ggml-org/llama.cpp:server-cuda-b10666@sha256:a2d04d1d1c2b2abe287fef9a22a3700a7fa20aec4c4ab56135e0099f38119848`.
+Live inspection confirms this binary supports Qwen3.8, `--n-cpu-moe`, mmap,
+lazy tensor reads, and manual fit control. This avoids compiling CUDA on the
+Apple Silicon workstation or waiting for a custom GitHub Actions build.
+
+Serve Unsloth `UD-IQ4_XS` from Hugging Face revision
+`c8b5954a88c2775c546b92593eda40ea041d3176`. The durable NFS model source and
+node-local NVMe hydration pattern remain unchanged. The three model shards and
+BF16 projector are downloaded with exact sizes and SHA-256 checksums. Existing
+AtomicChat and UD-Q4_K_XL files remain available for rollback; pruning them is
+outside this change.
+
+The initial runtime profile is:
+
+- 131,072-token context and one parallel slot
+- all model layers eligible for CUDA with `--n-gpu-layers 99`
+- automatic fit disabled with `--fit off`
+- 45 MoE expert blocks in host RAM with `--n-cpu-moe 45`
+- disk-backed n-gram table with `--load-mode mmap`
+- lazy tensor reads enabled with `--tensor-read-lazy on`
+- flash attention enabled
+- symmetric `q8_0` K and V caches
+- batch size 4,096 and micro-batch size 2,048
+- the BF16 vision projector on CUDA
+- MTP and weight prefetch disabled for the baseline measurement
+
+The external model alias remains `Qwen3.8-Flash-Next Q4`. Existing clients do
+not need configuration changes.
+
+## Components and Responsibilities
+
+### Inference Image
+
+The Deployment retains the existing official image digest. There is no custom
+Dockerfile, emulated build, or new container publication workflow. The image is
+already cached on the target node, so this rollout has no image-build or
+large-image-pull dependency.
+
+### Model Acquisition
+
+`download-model-job.yaml` adds an `unsloth-ud-iq4-xs` directory and downloads:
+
+| Artifact | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf` | 10,946,624 | `5ce89370720f8bf90890f439361282104c1aa1482d4013bb9a50923e758e71a4` |
+| `Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf` | 49,835,229,856 | `577a38a2392b40ca2193cea502e1d92f60b8cd370675d308e0ec21885d9daaa7` |
+| `Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf` | 43,836,407,744 | `d4634e6d84f0ebb0940be15c90d3790bf6464e3dea3a1cddc567dc0e83ad8833` |
+| `mmproj-BF16.gguf` | 907,542,944 | `2e788f8c511d8093c7b43cb87b2fd7e14228340318057f8fb20c86df2efe2355` |
+
+The existing resumable download and checksum-stamp behavior stays intact.
+`cache-sync-job.yaml` copies the same files from NFS to the GPU worker's local
+NVMe before the serving Deployment advances.
+
+### Runtime Deployment
+
+`deployment.yaml` switches the model entrypoint, projector, and placement/cache
+flags together while retaining the image digest. The ArgoCD hook waves remain
+download `-1`, NVMe hydration `0`, and server `1`, so the pod cannot start
+against incomplete model files.
+
+### Documentation
+
+The app README and AI model catalog record the pinned image, quant, tensor
+placement, context, expected resource usage, performance acceptance test, and
+rollback path. Root and directory guidance are updated only where they state
+the old live engine or quant as current truth.
+
+## Build and Rollout Sequence
+
+1. Add the exact IQ4_XS artifacts to both download and cache hydration hooks.
+2. Switch the Deployment from auto-fit to explicit expert-only CPU placement.
+3. Render and validate the Kustomize application locally.
+4. Open a pull request; the user performs the merge.
+5. Observe ArgoCD download, hydration, pod startup, and model-load logs.
+6. Run controlled prompt-processing and token-generation benchmarks.
+
+## Failure Handling and Rollback
+
+- A model size or checksum mismatch fails the wave `-1` hook and prevents the
+  Deployment from advancing.
+- A truncated local copy fails the wave `0` hook before the server starts.
+- Startup/readiness probes keep an unloaded or crashed server out of service.
+- Rollback restores the prior upstream llama.cpp image digest, AtomicChat model
+  path, F16 projector, q8 KV cache, and auto-fit arguments. The retained model
+  files make this a manifest rollback rather than another large download.
+
+## Verification and Acceptance
+
+Before rollout:
+
+- The pinned image reports build `10666`, commit `4e97ac86e`, and Linux x86_64.
+- The image's help exposes `--n-cpu-moe`, mmap, lazy reads, and manual fit.
+- `kubectl kustomize my-apps/ai/llama-cpp` renders successfully.
+- Repository policy checks and YAML validation pass.
+
+After ArgoCD sync:
+
+- Application is `Synced` and `Healthy`; pod is ready with zero restarts.
+- Logs show the full 131,072-token slot, CUDA placement, q8 KV cache, mmap, and
+  45 CPU-resident MoE expert blocks.
+- The process does not exhaust the 94 GiB container memory limit or 24 GiB GPU.
+- A warm controlled decode test produces at least 15 tokens per second.
+- Prompt processing is recorded separately; the reference target is roughly
+  160 tokens per second, but it is diagnostic rather than a rollout gate.
+- Text, tool-call formatting, and one vision request return valid output.
+
+If decode remains below 15 tokens per second, do not enable MTP or change
+multiple variables. Capture CPU, GPU, PCIe, memory, and mmap/page-fault data,
+then tune only expert placement (`--n-cpu-moe`) in a follow-up trial.
+
+## Non-Goals
+
+- Raising context from 131,072 to 262,144 in the initial rollout
+- Enabling MTP, n-gram speculative decoding, or weight prefetch
+- Building or maintaining a custom Beellama container
+- Adopting KVarN cache before a Qwen3.8-capable prebuilt Beellama image exists
+- Removing rollback model files
+- Raising the RTX 3090's 200 W power cap
+- Changing client endpoints, aliases, or Open WebUI configuration
+
+## Source References
+
+- Exact runtime preset: <https://github.com/crusaderky/pixi-llm-recipes/blob/26ed50ace2a40772aa2b45d1358aaf0993fd5596/models.ini#L3-L94>
+- Pinned llama.cpp source: <https://github.com/ggml-org/llama.cpp/tree/4e97ac86e>
+- Pinned Unsloth artifacts: <https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF/tree/c8b5954a88c2775c546b92593eda40ea041d3176/UD-IQ4_XS>

--- a/my-apps/ai/CLAUDE.md
+++ b/my-apps/ai/CLAUDE.md
@@ -7,7 +7,7 @@ One active OpenAI-compatible local backend, **NOT ollama**:
 ### llama.cpp — active, single card
 - Endpoint: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`
 - Served API model: **`Qwen3.8-Flash-Next Q4`** — Qwen3.8-Flash-Next
-  AtomicChat AD-4.27bpw-Q4_K_M-M64 with F16 vision and symmetric q8_0 KV at 131K
+  Unsloth UD-IQ4_XS with BF16 vision, expert-only CPU offload, and symmetric q8_0 KV at 131K
   on **one** RTX 3090.
 - **Use llama.cpp / `Qwen3.8-Flash-Next Q4` when wiring an in-cluster app to chat inference.**
 
@@ -31,13 +31,13 @@ use it as a Flash-Next compatibility alias.
   [`single-vs-dual-3090.md`](../../docs/domains/ai-gpu/single-vs-dual-3090.md).
 - **Local = unlimited token *volume* (free), not an infinite *window* per request.**
 - **Engine choice:** Qwen3.8-Flash-Next runs on a pinned post-merge llama.cpp
-  qwen4exp build via AtomicChat's split Q4 GGUF and F16 projector. The stock-vLLM
+  qwen4exp build via Unsloth's split IQ4_XS GGUF and BF16 projector. The stock-vLLM
   W4A16 deployment is a parked rollback.
 - **MTP stays off for Flash-Next.** The merged qwen4exp implementation did not
   include the final Flash-Next MTP path.
 - **The dedicated N-gram shard stays lazy and mmap-backed.** Do not add mlock,
   disable `--tensor-read-lazy`, or explicitly offload `per_layer_token_embd`;
-  the split AtomicChat layout keeps that table out of ordinary weight shards.
+  the split IQ4_XS layout keeps that table separate from ordinary weights.
 - **TurboQuant `turbo3` KV** (≈5x smaller) is coming to mainline llama.cpp
   (PR #21089) — adopt it then for cheap big context.
 

--- a/my-apps/ai/README.md
+++ b/my-apps/ai/README.md
@@ -6,7 +6,7 @@ via the GPU Operator.
 
 The GPU workloads (vLLM, llama-cpp, ComfyUI) use whole-card allocation
 (`type: Recreate`, no time-slicing) and scale-swap by committed replica counts.
-llama.cpp is active with multimodal Qwen3.8-Flash-Next UD-Q4_K_XL; vLLM,
+llama.cpp is active with multimodal Qwen3.8-Flash-Next UD-IQ4_XS; vLLM,
 ComfyUI, and SwarmUI are parked. Exactly one GPU workload may be active.
 
 ## Architecture
@@ -26,7 +26,7 @@ separate 27B model and is not a Flash-Next alias.
 
 | API model | Model | Think | Context | Primary Use |
 |---|---|---|---:|---|
-| `Qwen3.8-Flash-Next Q4` | Qwen3.8-Flash-Next UD-Q4_K_XL + mmproj-BF16 | Low effort | 131K | Chat, tools, vision, and tasks |
+| `Qwen3.8-Flash-Next Q4` | Qwen3.8-Flash-Next UD-IQ4_XS + mmproj-BF16 | Low effort | 131K | Chat, tools, vision, and tasks |
 
 Source of truth: `my-apps/ai/llama-cpp/deployment.yaml`.
 

--- a/my-apps/ai/llama-cpp/README.md
+++ b/my-apps/ai/llama-cpp/README.md
@@ -7,9 +7,9 @@ This is the active OpenAI-compatible chat, tool, and vision backend:
   `https://vllm.vanillax.me/v1`
 - API model: `Qwen3.8-Flash-Next Q4`
 
-The API model name identifies the physical AtomicChat
-AD-4.27bpw-Q4_K_M-M64 checkpoint. Do not use `qwen3.8-27b` for this model;
-that name belongs to the separate 27B checkpoint.
+The API model name identifies the physical Unsloth UD-IQ4_XS checkpoint. Do
+not use `qwen3.8-27b` for this model; that name belongs to the separate 27B
+checkpoint.
 
 ## Pinned inputs
 
@@ -17,19 +17,19 @@ that name belongs to the separate 27B checkpoint.
 |---|---|
 | Engine source | upstream llama.cpp `4e97ac86ebe2c4cb8212d98d2641ad6768810896` (`b10666`) |
 | Engine image | `ghcr.io/ggml-org/llama.cpp:server-cuda-b10666@sha256:a2d04d1d1c2b2abe287fef9a22a3700a7fa20aec4c4ab56135e0099f38119848` (amd64) |
-| Model repository | `AtomicChat/Qwen3.8-Flash-Next-GGUF` revision `142262902a46f7daed19c79d0771534c8106ad59` |
-| Weights | `Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00001-of-00033.gguf` through `00033-of-00033.gguf` |
-| Vision projector | `mmproj-Qwen3.8-Flash-Next-F16.gguf`, SHA-256 `0e61454a76dd154a10aaa8fb1ada32615f55a13e4171014dacd06913e4aa6889` |
+| Model repository | `unsloth/Qwen3.8-Flash-Next-GGUF` revision `c8b5954a88c2775c546b92593eda40ea041d3176` |
+| Weights | `Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf` through `00003-of-00003.gguf` |
+| Vision projector | `mmproj-BF16.gguf`, SHA-256 `2e788f8c511d8093c7b43cb87b2fd7e14228340318057f8fb20c86df2efe2355` |
 
 Official build `b10666` is produced from a commit after the qwen4exp merge
 commit `6c84c7d5d8833c6e0df69628f75a0f599797934e`. The Deployment pins the
 official tag and its linux/amd64 manifest digest; do not use pre-merge `b10236`.
 
-The wave -1 Sync hook downloads and verifies all 33 Atomic Q4 shards and the
-public F16 projector on the existing RWX model share. It also retains and
-verifies the prior four-shard Unsloth model and BF16 projector for rollback.
-Downloads resume `.part` files, check byte size and SHA-256, and atomically
-rename verified artifacts.
+The wave -1 Sync hook downloads and verifies all three IQ4_XS shards and the
+public BF16 projector on the existing RWX model share. It retains the prior
+AtomicChat and four-shard UD-Q4_K_XL artifacts for rollback. Downloads resume
+`.part` files, check byte size and SHA-256, and atomically rename verified
+artifacts.
 
 ## Model storage
 
@@ -46,31 +46,31 @@ path: llama.cpp demand-pages tensors under `--load-mode mmap`, so a page-cache
 miss against NFS becomes a network round trip, and under memory pressure that
 collapses throughput to well under 1 tok/s.
 
-`cache-sync-job.yaml` (wave 0 Sync hook) copies the Atomic model, its projector,
-and the retained Unsloth rollback files from NFS to the cache. It compares
+`cache-sync-job.yaml` (wave 0 Sync hook) copies the IQ4_XS model, its projector,
+and the retained rollback files from NFS to the cache. It compares
 **name and size only** because the wave -1 source hook already pins SHA-256; a
 second hash pass would stream both families through page cache on every sync.
 It is idempotent, and a warm cache exits in seconds.
 
 The cache PV is node-local by design (`nodeAffinity: gpu-worker=true`,
 `persistentVolumeReclaimPolicy: Retain`) and is **not** on Longhorn and not
-replicated — GGUF files are reproducible from NFS. The Atomic model and F16
-projector use 88.88 GiB; the retained Unsloth model and projector use 104.53
-GiB. Together they leave approximately 256 GiB on the 450 GiB cache.
+replicated — GGUF files are reproducible from NFS. IQ4_XS adds approximately
+87.25 GiB to the retained AtomicChat and UD-Q4_K_XL families. All three model
+families use approximately 281 GiB and leave roughly 169 GiB on the 450 GiB
+cache.
 
 ## Runtime profile
 
 - one whole RTX 3090 and one parallel slot
 - 131,072-token context with symmetric q8_0 K/V cache
 - Flash Attention and native Jinja; reasoning enabled at low effort
-- F16 vision enabled with the projector on CPU to preserve the 131K GPU KV budget
+- BF16 vision enabled with the projector on CUDA
 - MTP disabled because the merged Flash-Next path does not include final MTP support
-- automatic fit disabled; the native `--n-cpu-moe 38` path keeps the first 38
-  layers' expert weights on CPU and leaves ten expert layers on the GPU
-- `--load-mode mmap --tensor-read-lazy auto`; no mlock, so tensors larger than
-  4 GiB are demand-paged instead of being forced resident. Atomic shard 00002
-  contains only the 38.4 GB decimal N-gram table, so it is not interleaved with
-  CUDA-pinned ordinary weights and needs no explicit PLE tensor override.
+- automatic fit disabled; `--n-gpu-layers 99 --n-cpu-moe 45` keeps non-expert
+  work on CUDA while the first 45 layers' expert weights use host RAM
+- `--load-mode mmap --tensor-read-lazy on`; no mlock, so the dedicated IQ4_XS
+  N-gram shard stays disk-backed and only touched rows enter page cache
+- batch size 4096 and micro-batch size 2048
 - 20 CPU / 80 GiB requests, no CPU limit, and a 94 GiB memory limit; the 100
   GiB Talos VM keeps roughly 6 GiB outside the pod for Talos and node services
   while allowing useful mmap page cache. The sole GPU remains limit=request=1.
@@ -78,20 +78,27 @@ GiB. Together they leave approximately 256 GiB on the 450 GiB cache.
 No existing model is deleted during this trial. The PVC's 150 GiB capacity is
 a static Kubernetes declaration, not an export quota.
 
-## Atomic layout acceptance gate — pending deployment
+## IQ4_XS placement acceptance gate — pending deployment
 
-This commit changes the GGUF layout and projector while deliberately preserving
-context, KV, batching, sampling, and the initial expert placement. It does not
-claim a throughput win before the branch is merged and measured on the GPU
-worker.
+This change replaces whole-layer auto-fit with expert-only CPU placement while
+preserving context, KV, sampling, and the external API. It does not claim a
+throughput win before the branch is merged and measured on the GPU worker.
 
 Acceptance requires a warm, single-stream `tg128` result of at least 15 tok/s
 while the server remains configured for a 131,072-token slot. Record `pp512`,
 streaming TTFT, device and cgroup memory, major faults, process read bytes, CPU
 and GPU utilization, plus text, tool-call, and vision correctness. If the
-conservative 38-CPU-layer placement misses the target, reduce `--n-cpu-moe`
-one boundary per measurement round; do not simultaneously change context, KV
-type, or speculative decoding.
+45-CPU-expert-layer placement misses the target, tune only `--n-cpu-moe` one
+boundary per measurement round; do not simultaneously change context, KV type,
+or speculative decoding.
+
+## Historical Atomic auto-fit trial — 2026-08-29
+
+The official b10666 image loaded the AtomicChat model with `--fit on` and the
+full 131K slot, but whole-layer placement reached only 0.44-0.58 generated
+tokens per second. The pod used approximately 23.4 GiB VRAM and drove CPU while
+GPU activity stayed low and bursty. That result is the reason this trial uses
+explicit expert-only placement instead of auto-fit.
 
 ## Historical Unsloth baseline — 2026-08-28
 
@@ -119,12 +126,12 @@ uses `--no-mmproj-offload`.
 
 ## Rollback
 
-For an in-place llama.cpp rollback, restore the model path to
-`unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf`, restore
-`mmproj-BF16.gguf`, and restore
-`^per_layer_token_embd\.weight$=CPU,blk\.((9|[123][0123456789]|40|41|42|43|44|45|46))\.ffn_.*=CPU`.
-Both model families remain on NFS and NVMe, so this is one normal `Recreate`
-rollout with no download.
+For an in-place llama.cpp rollback, restore the Atomic model path
+`atomic-ad-4.27-q4-k-m-m64/Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00001-of-00033.gguf`,
+restore `mmproj-F16.gguf` and `--no-mmproj-offload`, set micro-batch back to
+512, set lazy reads to `auto`, remove `--n-gpu-layers` and `--n-cpu-moe`, then
+restore `--fit on --fit-ctx 131072 --fit-target 512`. All artifacts remain on
+NFS and NVMe, so this is one normal `Recreate` rollout with no download.
 
 For a backend rollback, set llama.cpp to `replicas: 0`, set
 `my-apps/ai/vllm/deployment.yaml` to `replicas: 1`, restore the vLLM HTTPRoute,

--- a/my-apps/ai/llama-cpp/cache-sync-job.yaml
+++ b/my-apps/ai/llama-cpp/cache-sync-job.yaml
@@ -33,6 +33,7 @@ spec:
               SRC=/src/qwen3.8-flash-next-gguf
               DST=/dst/qwen3.8-flash-next-gguf
               mkdir -p \
+                "$DST/unsloth-ud-iq4-xs" \
                 "$DST/unsloth-ud-q4-k-xl" \
                 "$DST/atomic-ad-4.27-q4-k-m-m64"
 
@@ -48,6 +49,10 @@ spec:
                 [ "$got" = "$want" ] || { echo "SIZE MISMATCH $rel: $got != $want"; rm -f "$d.part"; exit 1; }
                 mv "$d.part" "$d"
               }
+
+              for i in 1 2 3; do
+                sync_one "unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-0000$i-of-00003.gguf"
+              done
 
               for i in 1 2 3 4; do
                 sync_one "unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-0000$i-of-00004.gguf"

--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -42,10 +42,9 @@ spec:
           command: ["/app/llama-server"]
           args:
             - --model
-            - /models/qwen3.8-flash-next-gguf/atomic-ad-4.27-q4-k-m-m64/Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00001-of-00033.gguf
+            - /models/qwen3.8-flash-next-gguf/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf
             - --mmproj
-            - /models/qwen3.8-flash-next-gguf/mmproj-F16.gguf
-            - --no-mmproj-offload
+            - /models/qwen3.8-flash-next-gguf/mmproj-BF16.gguf
             - --alias
             - Qwen3.8-Flash-Next Q4
             - --ctx-size
@@ -53,17 +52,17 @@ spec:
             - --batch-size
             - "4096"
             - --ubatch-size
-            - "512"
+            - "2048"
+            - --n-gpu-layers
+            - "99"
+            - --n-cpu-moe
+            - "45"
             - --fit
-            - "on"
-            - --fit-ctx
-            - "131072"
-            - --fit-target
-            - "512"
+            - "off"
             - --load-mode
             - mmap
             - --tensor-read-lazy
-            - "auto"
+            - "on"
             - --flash-attn
             - on
             - --cache-type-k

--- a/my-apps/ai/llama-cpp/download-model-job.yaml
+++ b/my-apps/ai/llama-cpp/download-model-job.yaml
@@ -38,6 +38,7 @@ spec:
               ATOMIC_REPO=https://huggingface.co/AtomicChat/Qwen3.8-Flash-Next-GGUF/resolve/$ATOMIC_REV
               ATOMIC_DIR=Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64
               mkdir -p \
+                "$BASE/unsloth-ud-iq4-xs" \
                 "$BASE/unsloth-ud-q4-k-xl" \
                 "$BASE/atomic-ad-4.27-q4-k-m-m64"
               apk add --no-cache curl
@@ -67,6 +68,16 @@ spec:
                 printf '%s' "$expected" > "$stamp"
                 echo "downloaded and verified: $name"
               }
+
+              fetch "$UNSLOTH_REPO" UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf \
+                "$BASE/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf" \
+                10946624 5ce89370720f8bf90890f439361282104c1aa1482d4013bb9a50923e758e71a4
+              fetch "$UNSLOTH_REPO" UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf \
+                "$BASE/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf" \
+                49835229856 577a38a2392b40ca2193cea502e1d92f60b8cd370675d308e0ec21885d9daaa7
+              fetch "$UNSLOTH_REPO" UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf \
+                "$BASE/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf" \
+                43836407744 d4634e6d84f0ebb0940be15c90d3790bf6464e3dea3a1cddc567dc0e83ad8833
 
               fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf \
                 "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf" \


### PR DESCRIPTION
## Summary

- retain the existing official prebuilt x86_64 CUDA llama.cpp b10666 image
- add pinned Unsloth UD-IQ4_XS shards to NFS and node-local NVMe hydration
- replace whole-layer auto-fit with `--n-gpu-layers 99 --n-cpu-moe 45`
- keep mmap/lazy N-grams, 131K context, q8/q8 KV, one slot, and the existing API alias
- retain AtomicChat and UD-Q4_K_XL artifacts for rollback

## Why

The merged AtomicChat auto-fit profile loads successfully but measures only 0.44-0.58 generated tok/s. The single-3090 reference configuration reaches about 16 tok/s by keeping non-expert work on CUDA and moving only MoE experts to host RAM.

## Storage impact

IQ4_XS adds approximately 87.25 GiB. All retained Flash Next model families use approximately 281 GiB of the 450 GiB node-local cache.

## Acceptance gate

After merge and ArgoCD sync, warm single-stream `tg128` must reach at least 15 tok/s at the unchanged 131,072-token context. Also verify text, tools, vision, VRAM, cgroup memory, major faults, CPU, and GPU utilization.

## Verification

- `kustomize build my-apps/ai/llama-cpp --enable-helm` passed
- focused assertions passed for sync waves, immutable image digest, IQ4_XS paths, expert placement, q8/q8 KV, and removal of auto-fit flags
- `git diff --check origin/main...HEAD` passed
- full 99-app render and repository policy checks deferred to PR CI at user request

## Rollback

Restore the AtomicChat model path and F16 CPU projector, micro-batch 512, lazy mode auto, and `--fit on --fit-ctx 131072 --fit-target 512`; remove `--n-gpu-layers` and `--n-cpu-moe`. The previous artifacts remain on both NFS and NVMe.