### PR TITLE
fix(ai): download Flash Next shards concurrently

### DIFF
--- a/docs/domains/ai-gpu/model-catalog.md
+++ b/docs/domains/ai-gpu/model-catalog.md
@@ -49,6 +49,19 @@ The vLLM model share and compile cache remain intact for rollback. The retired
 syv-ai `qwen38-3090` application was removed; ArgoCD prunes its namespace and
 Longhorn compile-cache PVC, while the shared NFS model store remains retained.
 
+### Model acquisition performance
+
+The download hook resumes `.part` files and fetches the two large IQ4_XS
+shards concurrently. Each completed artifact is checked against its pinned
+byte size and SHA-256 before it becomes the canonical NAS copy; wave 0 then
+copies it to the GPU node's local NVMe PVC.
+
+Planned follow-up: replace the public-model curl transfers with authenticated
+`huggingface_hub` plus adaptive `hf_xet`, reusing the Hugging Face token in
+1Password. Keep normal adaptive mode under the downloader's 4 GiB memory limit;
+do not enable Xet high-performance mode until its larger buffers and node
+headroom are explicitly sized.
+
 ## App wiring
 
 The canonical direct-client configuration is:

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ reconstructs protected data. [Open the full-size platform map](assets/platform-o
 - **Database**: plain Postgres Deployments backed up by kopiur — hourly snapshots, restore-before-bind (CNPG retired 2026-08-13)
 - **Secrets**: 1Password Connect + External Secrets Operator
 - **Observability**: kube-prometheus-stack, Loki, Tempo, OpenTelemetry
-- **AI**: llama.cpp serving Qwen3.8-27B (`qwen3.8-27b`, UD-IQ4_XS + F16 vision, q8 KV at 131K) on the sole RTX 3090. vLLM and image generation are parked ([model catalog](domains/ai-gpu/model-catalog.md) · [scale-swap runbook](domains/ai-gpu/gpu-scale-swap.md))
+- **AI**: llama.cpp serving `Qwen3.8-Flash-Next Q4` (UD-IQ4_XS + BF16 vision, expert-only CPU offload, q8 KV at 131K) on the sole RTX 3090. vLLM and image generation are parked ([model catalog](domains/ai-gpu/model-catalog.md) · [scale-swap runbook](domains/ai-gpu/gpu-scale-swap.md))
 
 ## Documentation
 

--- a/my-apps/ai/llama-cpp/download-model-job.yaml
+++ b/my-apps/ai/llama-cpp/download-model-job.yaml
@@ -74,10 +74,14 @@ spec:
                 10946624 5ce89370720f8bf90890f439361282104c1aa1482d4013bb9a50923e758e71a4
               fetch "$UNSLOTH_REPO" UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf \
                 "$BASE/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf" \
-                49835229856 577a38a2392b40ca2193cea502e1d92f60b8cd370675d308e0ec21885d9daaa7
+                49835229856 577a38a2392b40ca2193cea502e1d92f60b8cd370675d308e0ec21885d9daaa7 &
+              iq4_xs_pid_2=$!
               fetch "$UNSLOTH_REPO" UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf \
                 "$BASE/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf" \
-                43836407744 d4634e6d84f0ebb0940be15c90d3790bf6464e3dea3a1cddc567dc0e83ad8833
+                43836407744 d4634e6d84f0ebb0940be15c90d3790bf6464e3dea3a1cddc567dc0e83ad8833 &
+              iq4_xs_pid_3=$!
+              wait "$iq4_xs_pid_2"
+              wait "$iq4_xs_pid_3"
 
               fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf \
                 "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf" \


### PR DESCRIPTION
## Summary

- resume IQ4_XS shard 2 from its existing curl `.part` file
- start shard 3 concurrently instead of waiting for shard 2
- retain size checks, pinned SHA-256 verification, and NAS -> node-local NVMe flow
- document the active behavior and planned authenticated Xet upgrade on the GitHub Pages model catalog
- correct the public docs landing page to the active Flash Next model

## Why

The sequential curl transfer was using about 74 MB/s on a 2 Gb/s connection. Two concurrent large-shard transfers preserve current progress while allowing the downloader to use more available bandwidth. Switching download engines mid-file could discard the existing partial shard.

## Verification

- failing regression assertion confirmed the hook was sequential
- concurrency/resume assertions pass after the change
- `kustomize build my-apps/ai/llama-cpp --enable-helm` passes
- `git diff --check` passes

## Rollout

Merging restarts the Argo download hook. Shard 2 resumes from its existing `.part`; shard 3 starts in parallel. Completed artifacts remain size- and SHA-verified before wave 0 copies them from NAS to local NVMe.