### PR TITLE
fix(open-webui): stop the global HAR filter killing every image request

### DIFF
--- a/my-apps/ai/open-webui/har-analyzer-function.py
+++ b/my-apps/ai/open-webui/har-analyzer-function.py
@@ -71,7 +71,17 @@ class Filter:
             return body
 
         files = last_message.get("files", [])
-        content = last_message.get("content", "")
+        raw_content = last_message.get("content", "")
+        # Multimodal content is a list of parts, not a str — this filter is global,
+        # so an unguarded .strip() below fails EVERY image request in Open WebUI.
+        if isinstance(raw_content, list):
+            content = "".join(
+                p.get("text", "")
+                for p in raw_content
+                if isinstance(p, dict) and p.get("type") == "text"
+            )
+        else:
+            content = raw_content
 
         har_data = None
         har_filename = ""
@@ -123,7 +133,15 @@ class Filter:
             f"{report}"
         )
 
-        last_message["content"] = new_content
+        if isinstance(raw_content, list):
+            # Swap the text part for the report; keep image parts so HAR+image still sees the image.
+            last_message["content"] = [{"type": "text", "text": new_content}] + [
+                p
+                for p in raw_content
+                if not (isinstance(p, dict) and p.get("type") == "text")
+            ]
+        else:
+            last_message["content"] = new_content
         # Remove HAR from file list (already processed)
         last_message["files"] = [
             f for f in files


### PR DESCRIPTION
Attaching an image to any Open WebUI chat returns **`'list' object has no attribute 'strip'`** and the request never reaches the model.

## Not the vLLM swap

`har-analyzer-function.py` is untouched by #2102. It has been installed with **`is_global: True` since 2026-02-05**, so its `inlet()` runs on every chat request for every model — images through Open WebUI have been broken that whole time. The swap only surfaced it by putting a vision-capable model back in front of it.

The backend is fine. vLLM answers a real multimodal request correctly when called directly (8×8 red PNG → `red`).

## Cause

```python
content = last_message.get("content", "")
...
if not har_data and content.strip().startswith('{"log"'):   # ← here
```

Text-only messages give a `str`, so this worked. Attach an image and Open WebUI sends the OpenAI multimodal shape — a **list** of `{"type": "text"}` / `{"type": "image_url"}` parts — and `.strip()` on a list raises `AttributeError`. `open_webui.main:process_chat` catches it and renders it as the assistant's reply.

## Fix

Normalise the parts list to its concatenated text before sniffing for a HAR. When a HAR really is present, rebuild content as a list so image parts survive rather than being flattened into the report string.

## Verification

Run **inside the live `open-webui` pod** against real pydantic, not a local stub:

```
1 multimodal (the crash)  PASS   content passes through untouched
2 image-only              PASS
3 plain string            PASS
4 HAR pasted as string    PASS   report still replaces content
5 HAR + image             PASS   report injected, image part retained
```

The pre-patch file from `origin/main` was run through the same case 1 in the same pod and reproduces the bug:

```
CURRENT main REPRODUCES BUG -> 'list' object has no attribute 'strip'
```

`tokens-per-second-function.py` never touches message content and needs no change.

## After merge

The function-loader Job re-installs the filter on sync. If the old version is cached, restart `deploy/open-webui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)