### PR TITLE
feat(vllm): serve weights from node-local NVMe, not NFS

### DIFF
--- a/docs/domains/ai-gpu/model-catalog.md
+++ b/docs/domains/ai-gpu/model-catalog.md
@@ -44,10 +44,12 @@ is the 4-bit vLLM path on this card.
 
 ## Storage and staging
 
-vLLM mounts `192.168.10.133:/mnt/ai-pool/vllm` read-only over the NFS CSI
-driver; the checkpoint is already staged there and needs no download Job. The
-torch.compile and Triton caches persist on a Longhorn PVC — without them the
-engine recompiles every boot.
+Both backends use the same two-tier shape: the TrueNAS share is the canonical
+archive, and a wave 0 Sync hook copies the weights to the GPU node's 450 GB
+NVMe, which is all the serving pod mounts. For vLLM that is
+`192.168.10.133:/mnt/ai-pool/vllm` → `/var/mnt/ai-model-cache/vllm`. The
+torch.compile and Triton caches persist separately on a Longhorn PVC — without
+them the engine recompiles every boot.
 
 The llama.cpp GGUF share, its download/cache-sync hooks, and its node-local
 NVMe cache all remain intact so the rollback is a replica flip plus a rewire.

--- a/my-apps/ai/vllm/README.md
+++ b/my-apps/ai/vllm/README.md
@@ -13,12 +13,25 @@ The chassis has one RTX 3090. llama.cpp is the parked GGUF rollback at
 ## Model and storage
 
 The checkpoint is derived from the public
-`dbirks/Qwen3.8-27B-W4A16-AutoRound` Hugging Face repository. It is already on
-the TrueNAS `ai-pool/vllm` share as
-`Qwen3.8-27B-W4A16-AutoRound-3090-int8lmhead` and is mounted read-only through
-the NFS CSI driver. The existing 10 GbE NFS path is the repo's faster and more
-appropriate tier for large sequential model reads; no Longhorn model PVC or
-in-cluster download Job is needed.
+`dbirks/Qwen3.8-27B-W4A16-AutoRound` Hugging Face repository and lives on the
+TrueNAS `ai-pool/vllm` share as
+`Qwen3.8-27B-W4A16-AutoRound-3090-int8lmhead`.
+
+Two tiers, matching llama-cpp:
+
+| Tier | Backing | PVC | Role |
+|---|---|---|---|
+| Source | TrueNAS NFS, `192.168.10.133:/mnt/ai-pool/vllm` | `vllm-models-pvc` (ROX) | canonical archive |
+| Cache | GPU node's 450 GB NVMe, Talos UserVolume `ai-model-cache` → `/var/mnt/ai-model-cache` under `vllm/` | `ai-model-cache-vllm` (RWO, `Retain`) | what the Deployment mounts at `/models` |
+
+The Deployment mounts **only** the cache. `cache-sync-job.yaml` (wave 0 Sync
+hook) copies the checkpoint from NFS to the NVMe before the wave 1 server
+starts; it compares **name and size only** and a warm cache exits in seconds.
+
+The cache PV shares the same physical volume as llama-cpp's GGUF tree, kept
+apart by `subPath: vllm`. Its declared 60Gi is informational — a local PV
+enforces no quota, and the real ceiling is what llama-cpp's ~281 GiB leaves free
+of 450 GB.
 
 The server uses the stock digest-pinned `vllm/vllm-openai:v0.28.0` image. There
 is no custom image, runtime patch, or model-prep controller in this deployment.

--- a/my-apps/ai/vllm/cache-sync-job.yaml
+++ b/my-apps/ai/vllm/cache-sync-job.yaml
@@ -1,0 +1,84 @@
+# Hydrates the node-local NVMe cache from the NFS source PVC before the server
+# starts. Name+size only: a sha256 pass would stream the checkpoint through page
+# cache on every sync, which is the exact thrash the cache exists to avoid.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vllm-cache-sync
+  namespace: vllm
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 4
+  activeDeadlineSeconds: 21600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      nodeSelector:
+        gpu-worker: "true"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: sync
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              MODEL=Qwen3.8-27B-W4A16-AutoRound-3090-int8lmhead
+              SRC=/src/$MODEL
+              DST=/dst/$MODEL
+              mkdir -p "$DST"
+
+              [ -d "$SRC" ] || { echo "MISSING SOURCE: $SRC"; exit 1; }
+
+              sync_one() {
+                rel="$1"; s="$SRC/$rel"; d="$DST/$rel"
+                want=$(stat -c %s "$s")
+                if [ -f "$d" ] && [ "$(stat -c %s "$d")" = "$want" ]; then
+                  echo "present: $rel ($want bytes)"; return
+                fi
+                echo "copying: $rel ($want bytes)"
+                cp "$s" "$d.part" || { rm -f "$d.part"; exit 1; }
+                got=$(stat -c %s "$d.part")
+                [ "$got" = "$want" ] || { echo "SIZE MISMATCH $rel: $got != $want"; rm -f "$d.part"; exit 1; }
+                mv "$d.part" "$d"
+              }
+
+              # Whole checkpoint dir, flat — weights plus tokenizer/config/template
+              # files. vLLM refuses to load if any of them is missing.
+              for f in $(ls -1 "$SRC"); do
+                [ -f "$SRC/$f" ] && sync_one "$f"
+              done
+
+              echo "=== RESULT ==="
+              ls -1 "$DST" | wc -l | awk '{print "files: " $1}'
+              du -sb "$DST" | awk '{printf "model: %s bytes (%.2f GiB)\n", $1, $1/1073741824}'
+              df -h /dst
+          resources:
+            requests:
+              cpu: 500m
+              # The serving pod reserves 8 GiB on this node. The copy needs little
+              # anonymous memory; its file cache is reclaimable and capped below.
+              memory: 64Mi
+            limits:
+              memory: 2Gi
+          volumeMounts:
+            - name: src
+              mountPath: /src
+              readOnly: true
+            - name: dst
+              mountPath: /dst
+              subPath: vllm
+      volumes:
+        - name: src
+          persistentVolumeClaim:
+            claimName: vllm-models-pvc
+        - name: dst
+          persistentVolumeClaim:
+            claimName: ai-model-cache-vllm

--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: vllm
   labels:
     app: vllm-server
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"    # after the wave-0 cache-sync hook
 spec:
   # Active backend; owns the sole RTX 3090 (llama-cpp is parked at 0).
   replicas: 1
@@ -139,6 +141,7 @@ spec:
           volumeMounts:
             - name: models
               mountPath: /models
+              subPath: vllm          # shares the NVMe volume with llama-cpp's GGUF tree
               readOnly: true
             - name: dshm
               mountPath: /dev/shm        # kept: torch still uses it; default 64Mi is too small
@@ -150,9 +153,11 @@ spec:
               mountPath: /root/.triton/cache
               subPath: triton
       volumes:
+        # Node-local NVMe, NOT the NFS PVC. cache-sync-job.yaml hydrates it from
+        # NFS at wave 0; NFS stays the canonical archive and out of the serve path.
         - name: models
           persistentVolumeClaim:
-            claimName: vllm-models-pvc
+            claimName: ai-model-cache-vllm
         - name: dshm
           emptyDir:
             medium: Memory

--- a/my-apps/ai/vllm/kustomization.yaml
+++ b/my-apps/ai/vllm/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - vpa.yaml
   - namespace.yaml
   - pvc.yaml
+  - pvc-model-cache.yaml
+  - cache-sync-job.yaml
   - deployment.yaml
   - service.yaml
   - httproute.yaml

--- a/my-apps/ai/vllm/pvc-model-cache.yaml
+++ b/my-apps/ai/vllm/pvc-model-cache.yaml
@@ -1,0 +1,45 @@
+# Node-local model cache on the GPU worker's 450GB NVMe (`ai-model-cache` Talos
+# UserVolume, /dev/sdb1) — the same disk llama-cpp uses, kept apart by subPath.
+# Serving reads from here; the NFS PVC stays the canonical source copy.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ai-model-cache-vllm-local
+spec:
+  # Informational only for a local PV (nothing enforces it); the real ceiling is
+  # whatever llama-cpp's GGUF families leave free on the shared 450G volume.
+  capacity:
+    storage: 60Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ai-model-cache-local
+  volumeMode: Filesystem
+  local:
+    path: /var/mnt/ai-model-cache
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: gpu-worker
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ai-model-cache-vllm
+  namespace: vllm
+  labels:
+    backup-exempt: "true"
+  annotations:
+    storage.vanillax.dev/backup-exempt-reason: "Node-local safetensors cache; reproducible from the NFS source PVC"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 60Gi
+  storageClassName: ai-model-cache-local
+  volumeName: ai-model-cache-vllm-local


### PR DESCRIPTION
Applies llama-cpp's already-solved two-tier model storage to vLLM. Same shape as #2094, same file names, same name+size sync semantics.

**Before:** `vllm-server` mounted the NFS PVC directly at `/models`.
**After:** NAS is the canonical archive → wave 0 Sync hook copies to the GPU node's NVMe → the serving pod mounts only the local copy.

| Tier | Backing | PVC | Role |
|---|---|---|---|
| Source | TrueNAS NFS `192.168.10.133:/mnt/ai-pool/vllm` | `vllm-models-pvc` (ROX) | canonical archive |
| Cache | 450 GB NVMe, `/var/mnt/ai-model-cache` under `vllm/` | `ai-model-cache-vllm` (RWO, Retain) | mounted at `/models` |

## Changes

- **`pvc-model-cache.yaml`** — PV `ai-model-cache-vllm-local` + PVC `ai-model-cache-vllm`, `gpu-worker` nodeAffinity, `Retain`, deliberately not Longhorn and not replicated (reproducible from NFS).
- **`cache-sync-job.yaml`** — wave 0 Sync hook, `BeforeHookCreation`. Copies the whole checkpoint dir — weights *plus* tokenizer/config/chat-template files, which vLLM refuses to load without. Compares **name + size only**; a sha256 pass would stream the checkpoint through page cache every sync, which is the exact thrash the cache exists to avoid.
- **`deployment.yaml`** — mounts `ai-model-cache-vllm` at `/models` with `subPath: vllm`, `sync-wave: "1"` so it lands after the hook. NFS is now referenced only by the sync Job.

## Capacity

The NVMe volume is shared with llama-cpp's GGUF tree, kept apart by `subPath: vllm`. Measured on the node:

```
/dev/sdb1  449.8G  289.3G used  160.5G available  64%
280.7G  /cache/qwen3.8-flash-next-gguf
```

~160 GB free against a ~17 GB checkpoint. The PV's declared `60Gi` is informational — a local PV enforces no quota.

## Scope — read before assuming a speedup

**This will not change inference throughput, and is not expected to.** Measured on the running pod, a 72-token generation did:

```
pid 1    rchar +581   read_bytes(disk) +0
pid 151  rchar +224   read_bytes(disk) +0
open fds on /models: none    mmaps of /models: none
```

vLLM loads weights into VRAM at startup and closes the files. Unlike llama-cpp — whose `--load-mode mmap` demand-paging collapsed **5.5 → 0.22 TG** when NFS was in the inference path (#2094) — vLLM's NFS exposure is **boot-time only**.

What this does buy: faster cold start, no dependency on the NAS being up to boot, and one consistent storage pattern across both engines.

## Expected on sync

The first sync copies ~17 GB NFS→NVMe (a few minutes at ~400 MB/s), then the server restarts onto the local mount. Subsequent syncs find it present and exit in seconds. Because the Deployment moves to `sync-wave: 1`, the pod restarts — expect the usual card handover plus a normal boot (the torch.compile cache is a separate PVC and survives, so no recompile).

Both PVCs remain `backup-exempt` with fully-qualified reason annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)