### PR TITLE
fix(vllm): gate the server on cache-sync instead of crashlooping through it

### DIFF
--- a/my-apps/ai/vllm/cache-sync-job.yaml
+++ b/my-apps/ai/vllm/cache-sync-job.yaml
@@ -1,6 +1,5 @@
-# Hydrates the node-local NVMe cache from the NFS source PVC before the server
-# starts. Name+size only: a sha256 pass would stream the checkpoint through page
-# cache on every sync, which is the exact thrash the cache exists to avoid.
+# Hydrates node-local NVMe from NFS; name+size avoids rereading the whole
+# checkpoint on warm syncs.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -31,21 +30,29 @@ spec:
             - -ec
             - |
               MODEL=Qwen3.8-27B-W4A16-AutoRound-3090-int8lmhead
+              REVISION=$MODEL:r1 # Bump here and in deployment.yaml for in-place source changes.
               SRC=/src/$MODEL
               DST=/dst/$MODEL
+              STATE=/dst/.vllm-cache-revision
               READY=/dst/.vllm-sync-complete
+              STATE_TMP=$STATE.part
+              READY_TMP=$READY.part
               mkdir -p "$DST"
 
-              # Clear first, write last: the server's init container gates on this
-              # marker, so it must never exist over a half-copied checkpoint.
-              rm -f "$READY"
+              # The Deployment may land before this Sync hook, so publish readiness last.
+              LAST_REVISION=$(cat "$STATE" 2>/dev/null || true)
+              FORCE_COPY=0
+              if [ -n "$LAST_REVISION" ] && [ "$LAST_REVISION" != "$REVISION" ]; then
+                FORCE_COPY=1
+              fi
+              rm -f "$READY" "$STATE_TMP" "$READY_TMP"
 
               [ -d "$SRC" ] || { echo "MISSING SOURCE: $SRC"; exit 1; }
 
               sync_one() {
                 rel="$1"; s="$SRC/$rel"; d="$DST/$rel"
                 want=$(stat -c %s "$s")
-                if [ -f "$d" ] && [ "$(stat -c %s "$d")" = "$want" ]; then
+                if [ "$FORCE_COPY" -eq 0 ] && [ -f "$d" ] && [ "$(stat -c %s "$d")" = "$want" ]; then
                   echo "present: $rel ($want bytes)"; return
                 fi
                 echo "copying: $rel ($want bytes)"
@@ -61,7 +68,10 @@ spec:
                 [ -f "$SRC/$f" ] && sync_one "$f"
               done
 
-              echo "$MODEL" > "$READY"
+              printf '%s\n' "$REVISION" > "$STATE_TMP"
+              mv "$STATE_TMP" "$STATE"
+              printf '%s\n' "$REVISION" > "$READY_TMP"
+              mv "$READY_TMP" "$READY"
 
               echo "=== RESULT ==="
               ls -1 "$DST" | wc -l | awk '{print "files: " $1}'

--- a/my-apps/ai/vllm/cache-sync-job.yaml
+++ b/my-apps/ai/vllm/cache-sync-job.yaml
@@ -33,7 +33,12 @@ spec:
               MODEL=Qwen3.8-27B-W4A16-AutoRound-3090-int8lmhead
               SRC=/src/$MODEL
               DST=/dst/$MODEL
+              READY=/dst/.vllm-sync-complete
               mkdir -p "$DST"
+
+              # Clear first, write last: the server's init container gates on this
+              # marker, so it must never exist over a half-copied checkpoint.
+              rm -f "$READY"
 
               [ -d "$SRC" ] || { echo "MISSING SOURCE: $SRC"; exit 1; }
 
@@ -55,6 +60,8 @@ spec:
               for f in $(ls -1 "$SRC"); do
                 [ -f "$SRC/$f" ] && sync_one "$f"
               done
+
+              echo "$MODEL" > "$READY"
 
               echo "=== RESULT ==="
               ls -1 "$DST" | wc -l | awk '{print "files: " $1}'

--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -37,6 +37,36 @@ spec:
       securityContext:
         fsGroup: 10001
         fsGroupChangePolicy: "OnRootMismatch"
+      initContainers:
+        # Without this the server races the wave-0 cache-sync hook: on a cold NVMe
+        # it finds no checkpoint, vLLM treats /models/... as a HF repo id and dies
+        # with HFValidationError, then CrashLoopBackOff pushes retries out to 5 min
+        # long after the copy landed. Costs no GPU time — a crashlooping pod holds
+        # the card anyway.
+        - name: wait-for-model-cache
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              i=0
+              until [ -f /models/.vllm-sync-complete ]; do
+                i=$((i + 1))
+                if [ "$i" -gt 360 ]; then
+                  echo "TIMEOUT: cache-sync never completed (60m)"; exit 1
+                fi
+                echo "waiting for vllm-cache-sync to finish hydrating the NVMe cache..."
+                sleep 10
+              done
+              echo "cache ready: $(cat /models/.vllm-sync-complete)"
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits: { memory: 64Mi }
+          volumeMounts:
+            - name: models
+              mountPath: /models
+              subPath: vllm
+              readOnly: true
       containers:
         - name: vllm-server
           # Digest-pinned (== `latest` at pin time, 2026-06). Renovate-trackable + immutable.

--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -38,19 +38,18 @@ spec:
         fsGroup: 10001
         fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
-        # Without this the server races the wave-0 cache-sync hook: on a cold NVMe
-        # it finds no checkpoint, vLLM treats /models/... as a HF repo id and dies
-        # with HFValidationError, then CrashLoopBackOff pushes retries out to 5 min
-        # long after the copy landed. Costs no GPU time — a crashlooping pod holds
-        # the card anyway.
+        # Argo self-heal can apply the Deployment before its Sync hook.
         - name: wait-for-model-cache
           image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
           command:
             - /bin/sh
             - -ec
             - |
+              MODEL=Qwen3.8-27B-W4A16-AutoRound-3090-int8lmhead
+              REVISION=$MODEL:r1
+              READY=/models/.vllm-sync-complete
               i=0
-              until [ -f /models/.vllm-sync-complete ]; do
+              until [ "$(cat "$READY" 2>/dev/null)" = "$REVISION" ]; do
                 i=$((i + 1))
                 if [ "$i" -gt 360 ]; then
                   echo "TIMEOUT: cache-sync never completed (60m)"; exit 1
@@ -58,7 +57,7 @@ spec:
                 echo "waiting for vllm-cache-sync to finish hydrating the NVMe cache..."
                 sleep 10
               done
-              echo "cache ready: $(cat /models/.vllm-sync-complete)"
+              echo "cache ready: $MODEL"
           resources:
             requests: { cpu: 10m, memory: 16Mi }
             limits: { memory: 64Mi }


### PR DESCRIPTION
## Fix

- Syncs the NFS checkpoint into the node-local NVMe cache with atomic per-file renames.
- Publishes a revisioned ready marker atomically after the checkpoint is complete.
- Rejects missing or stale markers for up to 60 minutes before failing.
- Forces a full copy when the checkpoint revision changes, including same-size files.

The initial `r1` adoption reuses the current warm cache after name-and-size validation, so it does not recopy 17 GiB. If the NFS checkpoint changes in place, bump `r1` in both manifests.

This makes the pod tolerate the Deployment landing before the Sync hook. It does not change ArgoCD ordering.