### PR TITLE
deal-scout: v0.12.2

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.12.1@sha256:1ee8855a4273c33b070141606f8362c7ca2e9b57a9c0daae9979f051dc4a837c
+          image: ghcr.io/mitchross/deal-scout:v0.12.2@sha256:7b36c18bc5fa036e764c75d0ee5a3d3b9e595c8fba8f8b29a9db3ebbe21094f3
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.12.1@sha256:2e5d0b2e1b96db146e6413b12c5d3a51e2703fdeddf0086b87687977f263684c
+          image: ghcr.io/mitchross/deal-scout-worker:v0.12.2@sha256:74f796bd2569109cdd57fffb6aef9ad166707fb43a45ebe384205f8aba801b2d
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.12.2.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.12.2`.