### PR TITLE
fix(temporal): self-heal stale worker ownership

### DIFF
--- a/infrastructure/controllers/argocd/values.yaml
+++ b/infrastructure/controllers/argocd/values.yaml
@@ -161,6 +161,7 @@ configs:
         end
       end
       return hs
+    # Maps Temporal WorkerDeployment readiness into Argo CD health status.
     resource.customizations.health.temporal.io_WorkerDeployment: |
       hs = {}
       hs.status = "Progressing"

--- a/infrastructure/controllers/argocd/values.yaml
+++ b/infrastructure/controllers/argocd/values.yaml
@@ -161,6 +161,24 @@ configs:
         end
       end
       return hs
+    resource.customizations.health.temporal.io_WorkerDeployment: |
+      hs = {}
+      hs.status = "Progressing"
+      hs.message = "Waiting for Temporal WorkerDeployment reconciliation"
+      if obj.status ~= nil and obj.status.conditions ~= nil then
+        for _, c in ipairs(obj.status.conditions) do
+          if c.type == "Ready" then
+            hs.message = c.message or c.reason or hs.message
+            if c.status == "True" then
+              hs.status = "Healthy"
+            elseif c.reason == "PlanExecutionFailed" then
+              hs.status = "Degraded"
+            end
+            return hs
+          end
+        end
+      end
+      return hs
 # Argo CD server settings
 server:
   # One schedulable worker / one physical failure domain: extra replicas do

--- a/infrastructure/controllers/argocd/values.yaml
+++ b/infrastructure/controllers/argocd/values.yaml
@@ -161,9 +161,8 @@ configs:
         end
       end
       return hs
-    # Reads the Temporal WorkerDeployment Ready condition and reports it to Argo CD.
-    # Ready=True becomes Healthy, PlanExecutionFailed becomes Degraded, and any
-    # unresolved state remains Progressing while the controller reconciles it.
+    # Maps Temporal's Ready condition into Argo CD health: True becomes Healthy,
+    # PlanExecutionFailed becomes Degraded, and unresolved states stay Progressing.
     resource.customizations.health.temporal.io_WorkerDeployment: |
       hs = {}
       hs.status = "Progressing"

--- a/infrastructure/controllers/argocd/values.yaml
+++ b/infrastructure/controllers/argocd/values.yaml
@@ -161,7 +161,9 @@ configs:
         end
       end
       return hs
-    # Maps Temporal WorkerDeployment readiness into Argo CD health status.
+    # Reads the Temporal WorkerDeployment Ready condition and reports it to Argo CD.
+    # Ready=True becomes Healthy, PlanExecutionFailed becomes Degraded, and any
+    # unresolved state remains Progressing while the controller reconciles it.
     resource.customizations.health.temporal.io_WorkerDeployment: |
       hs = {}
       hs.status = "Progressing"

--- a/infrastructure/controllers/temporal-worker-controller/kustomization.yaml
+++ b/infrastructure/controllers/temporal-worker-controller/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: temporal-worker-controller
 
 resources:
   - namespace.yaml
+  - manager-identity-recovery.yaml
 
 # Two OCI charts: CRDs (upgradeable independently) and the controller itself.
 helmCharts:

--- a/infrastructure/controllers/temporal-worker-controller/kustomization.yaml
+++ b/infrastructure/controllers/temporal-worker-controller/kustomization.yaml
@@ -6,6 +6,11 @@ resources:
   - namespace.yaml
   - manager-identity-recovery.yaml
 
+configMapGenerator:
+  - name: temporal-worker-controller-identity-recovery-scripts
+    files:
+      - recover-manager-identity.sh=scripts/recover-manager-identity.sh
+
 # Two OCI charts: CRDs (upgradeable independently) and the controller itself.
 helmCharts:
   # Chart versions (0.x) are separate from the controller image version (v1.x), which is pinned in chart values.

--- a/infrastructure/controllers/temporal-worker-controller/manager-identity-recovery.yaml
+++ b/infrastructure/controllers/temporal-worker-controller/manager-identity-recovery.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: temporal-worker-controller-identity-recovery
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 3600
+      template:
+        spec:
+          serviceAccountName: temporal-worker-controller-service-account
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: recover-manager-identity
+              image: temporalio/admin-tools:1.31.2@sha256:dbc5fcd6ee8f0f4d808bf765af9a87dea9d8a283abfdcfbd2fc148496ba66107
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  api="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}"
+                  token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+                  ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                  namespace_json="$(SSL_CERT_FILE="${ca}" wget -qO- --header="Authorization: Bearer ${token}" "${api}/api/v1/namespaces/${POD_NAMESPACE}")"
+                  namespace_uid="$(printf '%s' "${namespace_json}" | sed -n 's/.*"uid"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+                  test -n "${namespace_uid}"
+
+                  desired_identity="${CONTROLLER_IDENTITY}/${namespace_uid}"
+                  deployment_names="$(temporal --disable-config-file --address "${TEMPORAL_ADDRESS}" --namespace "${TEMPORAL_NAMESPACE}" worker deployment list -o json | sed -n 's/^  "name": "\([^"]*\)",$/\1/p')"
+
+                  printf '%s\n' "${deployment_names}" | while IFS= read -r deployment_name; do
+                    test -n "${deployment_name}" || continue
+                    manager_identity="$(temporal --disable-config-file --address "${TEMPORAL_ADDRESS}" --namespace "${TEMPORAL_NAMESPACE}" worker deployment describe --name "${deployment_name}" -o json | sed -n 's/^  "managerIdentity": "\([^"]*\)"$/\1/p')"
+                    case "${manager_identity}" in
+                      "${CONTROLLER_IDENTITY}"/*)
+                        if [ "${manager_identity}" != "${desired_identity}" ]; then
+                          temporal --disable-config-file --address "${TEMPORAL_ADDRESS}" --namespace "${TEMPORAL_NAMESPACE}" --identity "${manager_identity}" worker deployment manager-identity unset --deployment-name "${deployment_name}" -y
+                          echo "cleared stale controller identity for ${deployment_name}"
+                        fi
+                        ;;
+                    esac
+                  done
+              env:
+                - name: CONTROLLER_IDENTITY
+                  value: temporal-worker-controller/temporal-worker-controller
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: TEMPORAL_ADDRESS
+                  value: temporal-frontend.temporal.svc.cluster.local:7233
+                - name: TEMPORAL_NAMESPACE
+                  value: default
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL

--- a/infrastructure/controllers/temporal-worker-controller/manager-identity-recovery.yaml
+++ b/infrastructure/controllers/temporal-worker-controller/manager-identity-recovery.yaml
@@ -27,31 +27,7 @@ spec:
               image: temporalio/admin-tools:1.31.2@sha256:dbc5fcd6ee8f0f4d808bf765af9a87dea9d8a283abfdcfbd2fc148496ba66107
               imagePullPolicy: IfNotPresent
               command:
-                - /bin/sh
-                - -ec
-                - |
-                  api="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}"
-                  token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-                  ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                  namespace_json="$(SSL_CERT_FILE="${ca}" wget -qO- --header="Authorization: Bearer ${token}" "${api}/api/v1/namespaces/${POD_NAMESPACE}")"
-                  namespace_uid="$(printf '%s' "${namespace_json}" | sed -n 's/.*"uid"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
-                  test -n "${namespace_uid}"
-
-                  desired_identity="${CONTROLLER_IDENTITY}/${namespace_uid}"
-                  deployment_names="$(temporal --disable-config-file --address "${TEMPORAL_ADDRESS}" --namespace "${TEMPORAL_NAMESPACE}" worker deployment list -o json | sed -n 's/^  "name": "\([^"]*\)",$/\1/p')"
-
-                  printf '%s\n' "${deployment_names}" | while IFS= read -r deployment_name; do
-                    test -n "${deployment_name}" || continue
-                    manager_identity="$(temporal --disable-config-file --address "${TEMPORAL_ADDRESS}" --namespace "${TEMPORAL_NAMESPACE}" worker deployment describe --name "${deployment_name}" -o json | sed -n 's/^  "managerIdentity": "\([^"]*\)"$/\1/p')"
-                    case "${manager_identity}" in
-                      "${CONTROLLER_IDENTITY}"/*)
-                        if [ "${manager_identity}" != "${desired_identity}" ]; then
-                          temporal --disable-config-file --address "${TEMPORAL_ADDRESS}" --namespace "${TEMPORAL_NAMESPACE}" --identity "${manager_identity}" worker deployment manager-identity unset --deployment-name "${deployment_name}" -y
-                          echo "cleared stale controller identity for ${deployment_name}"
-                        fi
-                        ;;
-                    esac
-                  done
+                - /scripts/recover-manager-identity.sh
               env:
                 - name: CONTROLLER_IDENTITY
                   value: temporal-worker-controller/temporal-worker-controller
@@ -75,3 +51,12 @@ spec:
                 capabilities:
                   drop:
                     - ALL
+              volumeMounts:
+                - name: recovery-script
+                  mountPath: /scripts
+                  readOnly: true
+          volumes:
+            - name: recovery-script
+              configMap:
+                name: temporal-worker-controller-identity-recovery-scripts
+                defaultMode: 0555

--- a/infrastructure/controllers/temporal-worker-controller/namespace.yaml
+++ b/infrastructure/controllers/temporal-worker-controller/namespace.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: temporal-worker-controller
   annotations:
-    # This namespace's UID is the controller's Temporal ManagerIdentity suffix.
-    # Recreating it rotates the UID and wedges every WorkerDeployment at once.
+    # The namespace UID is the ManagerIdentity suffix; preserve it during normal Argo operations.
+    # The recovery CronJob repairs persisted identities after full namespace reconstruction.
     argocd.argoproj.io/sync-options: Prune=false,Delete=false

--- a/infrastructure/controllers/temporal-worker-controller/scripts/recover-manager-identity.sh
+++ b/infrastructure/controllers/temporal-worker-controller/scripts/recover-manager-identity.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+
+api="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}"
+token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+namespace_json="$(SSL_CERT_FILE="${ca}" wget -qO- \
+  --header="Authorization: Bearer ${token}" \
+  "${api}/api/v1/namespaces/${POD_NAMESPACE}")"
+namespace_uid="$(printf '%s' "${namespace_json}" | \
+  sed -n 's/.*"uid"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+test -n "${namespace_uid}"
+
+desired_identity="${CONTROLLER_IDENTITY}/${namespace_uid}"
+deployment_names="$(temporal --disable-config-file \
+  --address "${TEMPORAL_ADDRESS}" \
+  --namespace "${TEMPORAL_NAMESPACE}" \
+  worker deployment list -o json | \
+  sed -n 's/^  "name": "\([^"]*\)",$/\1/p')"
+
+printf '%s\n' "${deployment_names}" | while IFS= read -r deployment_name; do
+  test -n "${deployment_name}" || continue
+  manager_identity="$(temporal --disable-config-file \
+    --address "${TEMPORAL_ADDRESS}" \
+    --namespace "${TEMPORAL_NAMESPACE}" \
+    worker deployment describe --name "${deployment_name}" -o json | \
+    sed -n 's/^  "managerIdentity": "\([^"]*\)"$/\1/p')"
+
+  case "${manager_identity}" in
+    "${CONTROLLER_IDENTITY}"/*)
+      if [ "${manager_identity}" != "${desired_identity}" ]; then
+        temporal --disable-config-file \
+          --address "${TEMPORAL_ADDRESS}" \
+          --namespace "${TEMPORAL_NAMESPACE}" \
+          --identity "${manager_identity}" \
+          worker deployment manager-identity unset \
+          --deployment-name "${deployment_name}" -y
+        echo "cleared stale controller identity for ${deployment_name}"
+      fi
+      ;;
+  esac
+done

--- a/infrastructure/controllers/temporal-worker-controller/values.yaml
+++ b/infrastructure/controllers/temporal-worker-controller/values.yaml
@@ -9,6 +9,10 @@ webhookCertificate:
   certManager:
     enabled: true
 
+# Chart releases do not advance appVersion monotonically, so pin the controller independently.
+image:
+  tag: v1.9.0
+
 # Top-level, not under `controller:` — the chart has no such key and ignores it.
 # Two managers contend for the same ManagerIdentity, so keep this at 1.
 replicas: 1


### PR DESCRIPTION
## Summary

- preserve the Temporal Worker Controller namespace UID during normal Argo operations and document reconstruction recovery
- run a least-privilege CronJob every five minutes that clears only stale controller-owned `ManagerIdentity` values after the namespace UID changes
- pin the controller image to v1.9.0 because chart `appVersion` releases are not monotonic
- teach Argo CD to report blocked `WorkerDeployment` rollouts as Degraded instead of falsely Healthy

## Root cause

Temporal persists each WorkerDeployment's exclusive manager identity. The controller derives that identity from its namespace UID. After cluster/namespace reconstruction, Temporal still held the old UID-backed identity (`d5ad9924-...`) while the new controller presented `541504b2-...`, blocking every subsequent rollout with `PlanExecutionFailed`. Argo had no custom health rule for the CRD and continued to show the app Healthy.

The existing namespace preservation annotation protects normal Argo prune/delete operations, but cannot preserve a UID across a full cluster reconstruction. The recovery CronJob closes that gap without clearing current or manually owned deployments.

## Live recovery

- Deal Scout v0.12.2 is current and Ready; v0.11.1 scaled down after its configured drain delay
- radar-ng remains current and Ready
- news-digest's stale identity was cleared and its existing progressive rollout resumed
- the local Deal Scout Facebook runner was separately rebuilt from current master with its profile volume preserved

## Validation

- `git diff --check`
- embedded recovery script passes `shellcheck`
- exact pinned admin-tools image passed an in-cluster smoke test using the real service account, Kubernetes CA/API, Temporal service DNS, and Temporal deployment parsing
- `kustomize build infrastructure/controllers/temporal-worker-controller --enable-helm`
- recovery CronJob passed Kubernetes server-side dry-run
- Argo health Lua syntax and Healthy/Degraded/Progressing fixtures passed
- `scripts/validate-argocd-apps.sh`
- `scripts/validate-otel-configs.sh`
- `scripts/validate-truenas-csi.sh`

This PR intentionally does not change any application images or workload rollout policy.
