### PR TITLE
fix(posthog): authenticate remote config object storage

### DIFF
--- a/my-apps/development/posthog/core/jobs.yaml
+++ b/my-apps/development/posthog/core/jobs.yaml
@@ -253,6 +253,16 @@ spec:
             secretKeyRef:
               name: posthog-secrets
               key: posthog-db-url
+        - name: OBJECT_STORAGE_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: posthog-secrets
+              key: rustfs-access-key
+        - name: OBJECT_STORAGE_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: posthog-secrets
+              key: rustfs-secret-key
         resources:
           requests:
             cpu: 250m


### PR DESCRIPTION
## Summary

- provide the PostHog remote-config sync hook with the existing RustFS object-storage credentials
- use the same `OBJECT_STORAGE_ACCESS_KEY_ID` and `OBJECT_STORAGE_SECRET_ACCESS_KEY` bindings as the healthy web and worker workloads

## Root cause

During the PR #2122 rollout, `posthog-remote-config-sync` successfully force-synced Redis but its HyperCache S3 write raised `NoCredentialsError`. The hook had database secrets but no generic object-storage credential environment variables.

## Validation

- PostHog kustomization renders successfully
- rendered Job references `posthog-secrets` keys `rustfs-access-key` and `rustfs-secret-key`
- rendered ExternalSecret provides both referenced keys
- all 99 repository kustomizations render with Helm enabled
- Kopiur coverage: 0 failures
- VPA validation: 0 errors
- ArgoCD application topology validation: passed
- `git diff --check`: passed

## Post-merge verification

After Argo sync reruns the hook, confirm `object_storage.write_failed` / `NoCredentialsError` is absent and the remote config object is written to the PostHog bucket. No direct cluster apply is part of this PR.