### PR TITLE
fix(temporal): deploy bounded worker schedules

### DIFF
--- a/my-apps/development/news-reader/deployment.yaml
+++ b/my-apps/development/news-reader/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: news-reader
-          image: registry.vanillax.me/news-reader:v0.2.12
+          image: registry.vanillax.me/news-reader:v0.2.13
           imagePullPolicy: IfNotPresent
           env:
             - name: HOSTNAME

--- a/my-apps/development/news-reader/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/news-reader/temporal-workers/temporal-worker-deployment.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
         - name: worker
           # Do NOT pin :latest — the controller keys build_id off the tag and cannot tell two pushes apart.
-          image: registry.vanillax.me/news-reader-temporal-worker:v1.0.12
+          image: registry.vanillax.me/news-reader-temporal-worker:v1.0.13
           imagePullPolicy: IfNotPresent
           # Controller injects TEMPORAL_ADDRESS/NAMESPACE/DEPLOYMENT_NAME/WORKER_BUILD_ID — do not set them here.
           env:

--- a/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
@@ -49,7 +49,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.23
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.24
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Deploys the worker releases that bound scheduled workflow execution time and reconcile only stale schedule-owned actions at startup, plus the rebuilt News Reader frontend after registry recovery.

- Radar NG worker: v1.1.24
- News Reader worker: v1.0.13
- News Reader frontend: v0.2.13

Both app manifests render successfully with `kubectl kustomize`.