### PR TITLE
fix(project-nomad): remove stalled telemetry injection

### DIFF
--- a/my-apps/home/project-nomad/nomad/deployment.yaml
+++ b/my-apps/home/project-nomad/nomad/deployment.yaml
@@ -16,8 +16,6 @@ spec:
     metadata:
       labels:
         app: project-nomad
-      annotations:
-        instrumentation.opentelemetry.io/inject-nodejs: "opentelemetry/default"
     spec:
       initContainers:
         - name: init-storage


### PR DESCRIPTION
## Summary
- stop injecting the Node.js OpenTelemetry package into Project NOMAD
- restore bounded startup after the injected `cp -r` copied only 13.4 MiB / 2,125 of ~19,000 files over several minutes

The node had no CPU, memory, or disk pressure; the copy was blocked in `folio_wait_bit_common` reading the instrumentation image layer. At the observed rate the app would remain unavailable for well over an hour on every restart. Cluster-level telemetry remains in place.

## Validation
- `kustomize build my-apps/home/project-nomad`

Follow-up to #2062