### PR TITLE
fix(project-nomad): deploy browser URL UI fix

### DIFF
--- a/my-apps/home/project-nomad/nomad/deployment.yaml
+++ b/my-apps/home/project-nomad/nomad/deployment.yaml
@@ -25,7 +25,7 @@ spec:
             - name: nomad-storage
               mountPath: /app/storage
         - name: migrate
-          image: ghcr.io/mitchross/project-nomad:sha-e91efd1
+          image: ghcr.io/mitchross/project-nomad:sha-bbb6765
           command: ["sh", "-c", "node ace migration:run --force && node ace db:seed"]
           envFrom:
             - configMapRef:
@@ -46,7 +46,7 @@ spec:
               mountPath: /app/storage
       containers:
         - name: project-nomad
-          image: ghcr.io/mitchross/project-nomad:sha-e91efd1
+          image: ghcr.io/mitchross/project-nomad:sha-bbb6765
           command: ["sh", "-c", "node ace queue:work --all & exec node bin/server.js"]
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Deploy `project-nomad` image `sha-bbb6765`, built from mitchross/project-nomad#14, so Command Center and Supply Depot consume the resolved browser URL from the integration descriptor.

Validation: `kustomize build my-apps/home/project-nomad`

Tracks #2062.