### PR TITLE
fix(project-nomad): deploy embedding identity error fix

### DIFF
--- a/my-apps/home/project-nomad/nomad/deployment.yaml
+++ b/my-apps/home/project-nomad/nomad/deployment.yaml
@@ -25,7 +25,7 @@ spec:
             - name: nomad-storage
               mountPath: /app/storage
         - name: migrate
-          image: ghcr.io/mitchross/project-nomad:sha-bbb6765
+          image: ghcr.io/mitchross/project-nomad:sha-f596b32
           command: ["sh", "-c", "node ace migration:run --force && node ace db:seed"]
           envFrom:
             - configMapRef:
@@ -46,7 +46,7 @@ spec:
               mountPath: /app/storage
       containers:
         - name: project-nomad
-          image: ghcr.io/mitchross/project-nomad:sha-bbb6765
+          image: ghcr.io/mitchross/project-nomad:sha-f596b32
           command: ["sh", "-c", "node ace queue:work --all & exec node bin/server.js"]
           ports:
             - containerPort: 8080

--- a/my-apps/home/project-nomad/project-nomad-config.env
+++ b/my-apps/home/project-nomad/project-nomad-config.env
@@ -27,6 +27,6 @@ EMBEDDING_SEARCH_QUERY_PREFIX=search_query:
 QDRANT_HOST=http://qdrant.project-nomad.svc.cluster.local:6333
 KIWIX_URL=http://kiwix.project-nomad.svc.cluster.local:8080
 KIWIX_BROWSER_URL=https://kiwix.vanillax.me
-KIWIX_CONTENT_MODE=external
+KIWIX_CONTENT_MODE=shared
 CYBERCHEF_URL=https://cyberchef.vanillax.me
 FLATNOTES_URL=https://flatnotes.vanillax.me


### PR DESCRIPTION
## Summary

- deploy project-nomad `sha-f596b32` from project-nomad PR #15
- restore Kiwix content ownership to `shared`, matching the live shared-PVC topology after the external-mode validation

## Validation

- `kubectl kustomize my-apps/home/project-nomad`
- rendered images and Kiwix API/browser/content-mode values inspected
- `PROTOMAPS_URL` remains absent

Follow-up rollout for #2062.