### PR TITLE
fix(project-nomad): deploy pipeline mismatch fix

### DIFF
--- a/my-apps/home/project-nomad/nomad/deployment.yaml
+++ b/my-apps/home/project-nomad/nomad/deployment.yaml
@@ -25,7 +25,7 @@ spec:
             - name: nomad-storage
               mountPath: /app/storage
         - name: migrate
-          image: ghcr.io/mitchross/project-nomad:sha-f596b32
+          image: ghcr.io/mitchross/project-nomad:sha-35016fd
           command: ["sh", "-c", "node ace migration:run --force && node ace db:seed"]
           envFrom:
             - configMapRef:
@@ -46,7 +46,7 @@ spec:
               mountPath: /app/storage
       containers:
         - name: project-nomad
-          image: ghcr.io/mitchross/project-nomad:sha-f596b32
+          image: ghcr.io/mitchross/project-nomad:sha-35016fd
           command: ["sh", "-c", "node ace queue:work --all & exec node bin/server.js"]
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Deploy project-nomad `sha-35016fd` from project-nomad PR #16 so embedding identity/dimension mismatches retain their typed error through the file pipeline and terminate as unrecoverable queue jobs.

Validated with `kubectl kustomize my-apps/home/project-nomad`. Follow-up rollout for #2062.