### PR TITLE
deal-scout: v0.12.4

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.12.3@sha256:060b6dcb56dbb804a492f690d4ab08140720f0630527e3ba6059ce840b21e7d9
+          image: ghcr.io/mitchross/deal-scout:v0.12.4@sha256:2a5bddfb0bc536fd44d979a572000f9e14d3b18e21e8d878dde048056cb0898d
           imagePullPolicy: IfNotPresent
           env:
             - name: DATA_DIR

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.12.3@sha256:4577e81f6ec2c548848505ef5e677f78a62bccc4556168f1e190de3f933a4916
+          image: ghcr.io/mitchross/deal-scout-worker:v0.12.4@sha256:a418834c39b59d3d92cb90789800f762d299cbb5dda8ee59739cd41fb7fdad93
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.12.4.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.12.4`.