### PR TITLE
Experiment: Qwen3.8-27B EXL3 on single RTX 3090

### DIFF
--- a/my-apps/ai/exl3/README.md
+++ b/my-apps/ai/exl3/README.md
@@ -1,0 +1,57 @@
+# Qwen3.8-27B EXL3 single-RTX-3090 experiment
+
+Experimental sidecar for MiaAI-Lab's Qwen3.8-27B EXL3 3.5 bpw deployment kit and ExLlamaV3 fork.
+
+This app is intentionally parked at `replicas: 0`. It must never run at the same time as the production `my-apps/ai/vllm` deployment because the GPU worker has one RTX 3090.
+
+## First test
+
+The initial profile follows MiaAI-Lab's documented 24 GB recipe:
+
+- target: `Mia-AiLab/Qwen3.8-27B-EXL3-3.5bpw` (~14.2 GB)
+- runtime: MiaAI-Lab ExLlamaV3 fork, pinned to commit `63b32f001d7b2cfed3b3e3aaf25f534ba53cc7ed`
+- deployment kit: pinned to commit `09791b8a9045210cd2e90b49c13ffd3b34fb2d70`
+- speculative decoding: MTP
+- KV: NVFP4
+- context: 262144
+- GPU memory budget: 22 GB
+- CUDA arch: 8.6 (RTX 3090 / Ampere)
+- API: OpenAI-compatible server on port 8888
+
+No DFlash2 on the first pass. Prove MTP + NVFP4 + 262K boot, output quality, tools, and long-context correctness before adding the 1.4 GB DFlash2 drafter.
+
+## Safety / activation
+
+Keep this app at zero replicas in normal operation.
+
+To run the experiment through GitOps:
+
+1. set `my-apps/ai/vllm/deployment.yaml` to `replicas: 0`
+2. set `my-apps/ai/exl3/deployment.yaml` to `replicas: 1`
+3. merge and let ArgoCD reconcile
+4. use `exl3-qwen38.vllm.svc.cluster.local:8888` from inside the cluster, or port-forward the Service for direct testing
+
+Reverse those replica changes to restore production vLLM.
+
+## Storage / first boot
+
+The pod reuses the existing `ai-model-cache-vllm` local-PV-backed PVC in namespace `vllm`, under `/models/exl3`. This avoids adding another Longhorn copy of the model. The first boot installs build dependencies, creates the Mia deployment kit venv, compiles the pinned ExLlamaV3 CUDA extension, and downloads the EXL3 weights. The venv and model files persist on the node-local NVMe cache.
+
+## What to validate
+
+Before considering this backend usable, compare it with production vLLM using the same prompts:
+
+- normal chat with explicit reasoning levels
+- Pi coding/agent loop
+- tool-call correctness and multi-turn tool state
+- long-context needle/retrieval at 64K, 128K, then 262K
+- prefix/multi-turn behavior
+- output quality versus the current W4A16 production quant
+- decode tok/s, prefill tok/s, TTFT, VRAM and GPU errors
+
+Vision is not assumed by this experiment until the Mia ExLlamaV3 OpenAI server path proves multimodal support for this checkpoint.
+
+## Upstream
+
+- deployment kit: https://github.com/MiaAI-Lab/Qwen3.8-27B-DFlash2-EXL3-5.0bpw
+- engine fork: https://github.com/MiaAI-Lab/exllamav3

--- a/my-apps/ai/exl3/deployment.yaml
+++ b/my-apps/ai/exl3/deployment.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: exl3-qwen38
+  namespace: vllm
+  labels:
+    app: exl3-qwen38
+spec:
+  # Experimental only. The production vLLM pod owns the sole RTX 3090.
+  # To test: scale vllm-server to 0 in Git, then scale this Deployment to 1.
+  replicas: 0
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: exl3-qwen38
+  template:
+    metadata:
+      labels:
+        app: exl3-qwen38
+    spec:
+      enableServiceLinks: false
+      restartPolicy: Always
+      runtimeClassName: nvidia
+      priorityClassName: gpu-workload-high
+      terminationGracePeriodSeconds: 120
+      nodeSelector:
+        feature.node.kubernetes.io/pci-0300_10de.present: "true"
+        gpu-worker: "true"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: exl3-qwen38
+          # Mia publishes a deployment kit rather than a prebuilt x86 image.
+          # This devel image compiles the pinned ExLlamaV3 fork on first boot;
+          # the venv and weights persist on the existing node-local NVMe PVC.
+          image: nvidia/cuda:13.0.1-devel-ubuntu24.04
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-lc"]
+          args:
+            - |
+              set -euo pipefail
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update
+              apt-get install -y --no-install-recommends \
+                git ca-certificates python3 python3-venv python3-pip build-essential ninja-build
+              rm -rf /var/lib/apt/lists/*
+
+              ROOT=/models/exl3
+              KIT="$ROOT/kit"
+              mkdir -p "$ROOT/models"
+
+              if [ ! -d "$KIT/.git" ]; then
+                git clone https://github.com/MiaAI-Lab/Qwen3.8-27B-DFlash2-EXL3-5.0bpw.git "$KIT"
+              fi
+              cd "$KIT"
+              git fetch --all --tags --prune
+              git checkout --detach 09791b8a9045210cd2e90b49c13ffd3b34fb2d70
+
+              cat > .env <<'EOF'
+              MODEL_DIR=/models/exl3/models/Qwen3.8-27B-EXL3-3.5bpw
+              HF_TARGET_REPO=Mia-AiLab/Qwen3.8-27B-EXL3-3.5bpw
+              GPU_MEM_GB=22
+              CONTEXT_SIZE=262144
+              CACHE_QUANT=nvfp4
+              DRAFT=mtp
+              HOST=0.0.0.0
+              PORT=8888
+              TORCH_CUDA_ARCH_LIST=8.6
+              MAX_JOBS=8
+              EXL3_REPO=git+https://github.com/MiaAI-Lab/exllamav3.git@63b32f001d7b2cfed3b3e3aaf25f534ba53cc7ed
+              EOF
+
+              exec ./start.sh
+          env:
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: compute,utility
+            - name: HF_HOME
+              value: /models/exl3/hf-cache
+            - name: PIP_DISABLE_PIP_VERSION_CHECK
+              value: "1"
+          ports:
+            - name: http
+              containerPort: 8888
+              protocol: TCP
+          startupProbe:
+            httpGet: { path: /health, port: http }
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 240
+          livenessProbe:
+            httpGet: { path: /health, port: http }
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /health, port: http }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            requests:
+              nvidia.com/gpu: "1"
+              cpu: "2"
+              memory: 4Gi
+            limits:
+              nvidia.com/gpu: "1"
+              memory: 32Gi
+          volumeMounts:
+            - name: models
+              mountPath: /models
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            # Same node-local NVMe cache used by vLLM; EXL3 gets its own /exl3 tree.
+            claimName: ai-model-cache-vllm
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 4Gi

--- a/my-apps/ai/exl3/deployment.yaml
+++ b/my-apps/ai/exl3/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           # Mia publishes a deployment kit rather than a prebuilt x86 image.
           # This devel image compiles the pinned ExLlamaV3 fork on first boot;
           # the venv and weights persist on the existing node-local NVMe PVC.
-          image: nvidia/cuda:13.0.1-devel-ubuntu24.04
+          image: nvidia/cuda:13.0.1-devel-ubuntu24.04@sha256:7d2f6a8c2071d911524f95061a0db363e24d27aa51ec831fcccf9e76eb72bc92
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash", "-lc"]
           args:

--- a/my-apps/ai/exl3/kustomization.yaml
+++ b/my-apps/ai/exl3/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: vllm
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/my-apps/ai/exl3/service.yaml
+++ b/my-apps/ai/exl3/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: exl3-qwen38
+  namespace: vllm
+spec:
+  selector:
+    app: exl3-qwen38
+  ports:
+    - name: http
+      port: 8888
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
Adds an opt-in EXL3 experiment for Qwen3.8-27B on the existing single RTX 3090 GPU worker.

What this PR does:
- adds a new `my-apps/ai/exl3` Argo-discovered app
- keeps it parked at `replicas: 0` so merging cannot take the production GPU
- follows MiaAI-Lab's documented 24 GB MTP/NVFP4 recipe: EXL3 3.5 bpw target, 262144 context, 22 GB VRAM budget
- pins the Mia deployment-kit commit and ExLlamaV3 fork commit
- pins the CUDA devel image by digest
- reuses the existing node-local `ai-model-cache-vllm` NVMe PVC under `/models/exl3`
- exposes only an internal ClusterIP Service; no public HTTPRoute

First-pass goal: validate boot, 262K resident context, MTP, NVFP4 KV, tool/multi-turn correctness, quality, and performance before testing DFlash2.

Safety: production `my-apps/ai/vllm` remains unchanged at 1 replica; EXL3 remains 0. To test, use a separate GitOps change that scales vLLM 1→0 and EXL3 0→1.

Important caveats:
- this is MiaAI-Lab's ExLlamaV3 fork, not stock ExLlamaV3
- first boot compiles the CUDA extension in-pod and downloads the EXL3 model
- vision is not claimed until the server path is proven multimodal on this checkpoint
- no DFlash2 in the initial profile