### PR TITLE
fix(surfsense): allow Redis to write PVC

### DIFF
--- a/my-apps/ai/surfsense/redis/deployment.yaml
+++ b/my-apps/ai/surfsense/redis/deployment.yaml
@@ -20,7 +20,9 @@ spec:
         app: surfsense-redis
     spec:
       securityContext:
-        fsGroup: 999
+        # redis:8-alpine runs redis as uid 999 / gid 1000. Fresh Longhorn
+        # volumes mount root-owned, so give the pod the Redis group on /data.
+        fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: redis

--- a/my-apps/ai/surfsense/redis/deployment.yaml
+++ b/my-apps/ai/surfsense/redis/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         app: surfsense-redis
     spec:
+      securityContext:
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: redis
           image: redis:8-alpine


### PR DESCRIPTION
## Summary

- assign the SurfSense Redis pod the Redis Alpine group (`fsGroup: 1000`) so its mounted Longhorn volume is writable
- use `OnRootMismatch` to avoid unnecessary recursive ownership changes

## Root cause

The initial SurfSense rollout reached Redis, but Redis exited with `appendonlydir: Permission denied` because the fresh PVC root was not writable by the Redis process.

The official `redis:8-alpine` image creates Redis as uid `999`, gid `1000`; the pod therefore uses `fsGroup: 1000`. The image entrypoint remains responsible for dropping from root to the Redis user.

The separate Postgres Kopiur restore failure came from Longhorn I/O errors and remains a post-merge operational retry: once storage is stable, recreate the still-unbound `surfsense-postgres-data` PVC and failed `surfsense-postgres-data-restore` so restore-before-bind gets a fresh attempt. The PR does not change the Postgres storage class, Kopiur configuration, or DR model.

## Validation

- Cluster CI on the initial commit passed
- follow-up commit corrects the Alpine Redis GID from 999 to 1000; CI reruns on the updated head
- `kustomize build my-apps/ai/surfsense`
- repository-wide Kopiur and VPA validators
- `git diff --check`