### PR TITLE
fix(surfsense): configure migration embeddings

### DIFF
--- a/my-apps/ai/surfsense/app/migrations-job.yaml
+++ b/my-apps/ai/surfsense/app/migrations-job.yaml
@@ -27,6 +27,8 @@ spec:
                   key: DB_PASSWORD
             - name: DATABASE_URL
               value: postgresql+asyncpg://surfsense:$(DB_PASSWORD)@db:5432/surfsense
+            - name: EMBEDDING_MODEL
+              value: sentence-transformers/all-MiniLM-L6-v2
             - name: PYTHONPATH
               value: /app
             - name: SERVICE_ROLE


### PR DESCRIPTION
## Summary

- pass the CPU-local `EMBEDDING_MODEL` to the SurfSense migration hook
- keep migrations self-contained in GitOps so a fresh Argo deployment needs no manual CLI setup

## Root cause

SurfSense 0.0.39 imports the application configuration while Alembic starts. The migration Job did not receive `EMBEDDING_MODEL`, so `AutoEmbeddings.get_embeddings()` was called with `None` and the sync hook failed before applying migrations.

## Validation

- `kustomize build my-apps/ai/surfsense`
- rendered migration Job includes `sentence-transformers/all-MiniLM-L6-v2`
- repo-wide kopiur coverage: 0 failures
- repo-wide VPA validation: 0 errors (existing unrelated warnings only)
- `git diff --check`