### PR TITLE
fix(surfsense): stabilize runtime and gateway routing

### DIFF
--- a/my-apps/ai/surfsense/CLAUDE.md
+++ b/my-apps/ai/surfsense/CLAUDE.md
@@ -24,7 +24,7 @@ Do not split these child folders into independent Argo Applications unless there
 | `kopiur/postgres-data.yaml` | Hourly Postgres backup + Restore |
 | `kopiur/object-store.yaml` | Daily knowledge/object-store backup + Restore |
 | `externalsecret.yaml` | 1Password-backed application/database/Zero secrets; wave -1 |
-| `httproute.yaml` | Single-origin external routing for frontend, API/auth, and Zero WebSockets |
+| `httproute.yaml` | Single-origin external routing that mirrors SurfSense's upstream Caddy contract |
 | `vpa.yaml` | VPAs for every long-running Deployment |
 
 ## Sync / health ordering
@@ -47,7 +47,7 @@ Do not put the Kopiur `Restore` CR in an earlier isolated wave than its PVC. The
 4. **`/shared_tmp` is intentionally `emptyDir`.** It only coordinates temporary upload/processing files between API and worker in the same pod.
 5. **Redis is not backed up.** Its PVC exists for ordinary restart continuity only and is explicitly backup-exempt.
 6. **Zero is not backed up and has no PVC.** Its SQLite replica is `emptyDir`; replacement resyncs from Postgres.
-7. **Keep SurfSense same-origin.** `/api/v1` and `/auth` route to backend, `/zero` routes to Zero, and `/` falls through to frontend.
+7. **Mirror SurfSense's upstream same-origin proxy contract exactly.** `/auth/callback` goes to the frontend; `/auth`, `/users`, `/api/v1`, and `/zero/context` go to the backend; remaining `/zero` traffic goes to zero-cache; everything else goes to the frontend. The `/users/me` and `/zero/context` exceptions are required for authenticated dashboard startup. Do not collapse these into broad `/auth` or `/zero` routes without preserving the more-specific exceptions.
 8. **Do not add upstream OpenSandbox's Docker socket to Talos.** Talos has no Docker daemon/socket. `SANDBOX_ENABLED=FALSE` is intentional until a Kubernetes-native or remote sandbox provider is selected.
 9. **Do not request a GPU.** The active RTX 3090 belongs to vLLM. SurfSense uses CPU embeddings and can call vLLM for chat.
 10. **Reuse cluster SearXNG** at `http://searxng.searxng.svc.cluster.local:8080`; do not deploy another copy.

--- a/my-apps/ai/surfsense/README.md
+++ b/my-apps/ai/surfsense/README.md
@@ -63,9 +63,14 @@ Initial embeddings use CPU-local `sentence-transformers/all-MiniLM-L6-v2`, so Su
 
 ## Routing
 
-The external HTTPRoute keeps SurfSense's single-origin contract:
+The external HTTPRoute mirrors SurfSense 0.0.39's upstream Caddy single-origin contract:
 
+- `/auth/callback*` -> frontend
 - `/auth/*` -> backend
+- `/users/*` -> backend
 - `/api/v1/*` -> backend
-- `/zero/*` -> Zero/WebSocket
+- `/zero/context` -> backend
+- remaining `/zero/*` -> Zero/WebSocket
 - everything else -> frontend
+
+The more-specific `/auth/callback` and `/zero/context` matches are intentional. The authenticated dashboard also requires `/users/me` to reach FastAPI; routing `/users/*` to the frontend produces an HTML 404 and the frontend surfaces `Failed to parse response`.

--- a/my-apps/ai/surfsense/app/beat.yaml
+++ b/my-apps/ai/surfsense/app/beat.yaml
@@ -45,6 +45,8 @@ spec:
               value: redis://redis:6379/0
             - name: CELERY_TASK_DEFAULT_QUEUE
               value: surfsense
+            - name: EMBEDDING_MODEL
+              value: sentence-transformers/all-MiniLM-L6-v2
             - name: PYTHONPATH
               value: /app
             - name: SERVICE_ROLE
@@ -54,4 +56,4 @@ spec:
               cpu: 50m
               memory: 128Mi
             limits:
-              memory: 512Mi
+              memory: 2Gi

--- a/my-apps/ai/surfsense/app/deployment.yaml
+++ b/my-apps/ai/surfsense/app/deployment.yaml
@@ -86,6 +86,7 @@ spec:
             - {name: REDIS_APP_URL, value: redis://redis:6379/0}
             - {name: CELERY_TASK_DEFAULT_QUEUE, value: surfsense}
             - {name: FILE_STORAGE_LOCAL_PATH, value: /app/.local_object_store}
+            - {name: EMBEDDING_MODEL, value: sentence-transformers/all-MiniLM-L6-v2}
             - {name: SEARXNG_URL, value: http://searxng.searxng.svc.cluster.local:8080}
             - {name: SANDBOX_ENABLED, value: "FALSE"}
             - {name: TMPDIR, value: /shared_tmp}

--- a/my-apps/ai/surfsense/httproute.yaml
+++ b/my-apps/ai/surfsense/httproute.yaml
@@ -16,17 +16,36 @@ spec:
   hostnames:
     - surfsense.vanillax.me
   rules:
+    # SurfSense's frontend owns the post-login callback page. This more-specific
+    # prefix must beat the general /auth backend route below.
     - matches:
-        - path: {type: PathPrefix, value: /api/v1}
+        - path: {type: PathPrefix, value: /auth/callback}
+      backendRefs:
+        - name: frontend
+          port: 3000
+
+    # FastAPI owns auth, user profile, REST API, and the Zero auth-context
+    # endpoint. /users/me and /zero/context are required by the dashboard after
+    # login; sending either to Next.js/zero-cache produces the observed 404s.
+    - matches:
         - path: {type: PathPrefix, value: /auth}
+        - path: {type: PathPrefix, value: /users}
+        - path: {type: PathPrefix, value: /api/v1}
+        - path: {type: PathPrefix, value: /zero/context}
       backendRefs:
         - name: backend
           port: 8000
+
+    # Rocicorp Zero handles the remaining /zero sync traffic. Gateway API path
+    # precedence selects the longer /zero/context backend match above.
     - matches:
         - path: {type: PathPrefix, value: /zero}
       backendRefs:
         - name: zero-cache
           port: 4848
+
+    # Next.js application and frontend-owned API routes (/api/zero/*,
+    # /api/search, /api/contact, etc.).
     - matches:
         - path: {type: PathPrefix, value: /}
       backendRefs:


### PR DESCRIPTION
## Summary

Stabilize the first SurfSense rollout in two areas:

- pass the required CPU-local `EMBEDDING_MODEL` to the Celery worker and Beat
- raise Beat memory limit from `512Mi` to `2Gi`
- make the Cilium HTTPRoute match SurfSense 0.0.39's upstream same-origin Caddy contract
- document the routing invariants so `/users/me` and `/zero/context` do not regress

## Runtime root causes

The worker imported SurfSense configuration without `EMBEDDING_MODEL` and exited with code 2 when Chonkie received `None`. Beat repeatedly exited 137 with `OOMKilled` under its `512Mi` hard limit. Live VPA target was about 729 MiB, while the API embedding warmup reached about 1.06 GiB RSS, so the 2 GiB cap provides startup headroom.

## Dashboard/auth routing root cause

The deployed route only sent `/api/v1` and `/auth` to FastAPI and sent all `/zero` traffic to zero-cache. SurfSense 0.0.39 also requires:

- `/auth/callback*` -> frontend
- `/auth/*` -> backend
- `/users/*` -> backend (`/users/me` is loaded after login)
- `/api/v1/*` -> backend
- `/zero/context` -> backend (Zero auth context)
- remaining `/zero/*` -> zero-cache
- everything else -> frontend

The observed browser failures line up with that mismatch: `/users/me` and `/zero/context` returned 404s, and the frontend surfaced `Failed to parse response` after receiving the wrong response type.

Gateway API longest-path precedence keeps `/auth/callback` ahead of `/auth` and `/zero/context` ahead of `/zero`.

## Scope

No PVC, Kopiur, Postgres, Redis, secret, or storage-model changes. The merged Redis `fsGroup: 1000` fix remains unchanged.

## Validation

- `kustomize build my-apps/ai/surfsense`
- rendered API, worker, migration, and Beat use the same embedding model
- HTTPRoute mirrors SurfSense 0.0.39 `docker/proxy/Caddyfile`
- repo-wide Kopiur validation: 0 failures
- repo-wide VPA validation: 0 errors (existing unrelated warnings only)
- `git diff --check`

Routing changes were folded in from superseded PR #2141.