### PR TITLE
fix(surfsense): match upstream gateway routing

### DIFF
--- a/my-apps/ai/surfsense/CLAUDE.md
+++ b/my-apps/ai/surfsense/CLAUDE.md
@@ -24,7 +24,7 @@ Do not split these child folders into independent Argo Applications unless there
 | `kopiur/postgres-data.yaml` | Hourly Postgres backup + Restore |
 | `kopiur/object-store.yaml` | Daily knowledge/object-store backup + Restore |
 | `externalsecret.yaml` | 1Password-backed application/database/Zero secrets; wave -1 |
-| `httproute.yaml` | Single-origin external routing for frontend, API/auth, and Zero WebSockets |
+| `httproute.yaml` | Single-origin external routing that mirrors SurfSense's upstream Caddy contract |
 | `vpa.yaml` | VPAs for every long-running Deployment |
 
 ## Sync / health ordering
@@ -47,7 +47,7 @@ Do not put the Kopiur `Restore` CR in an earlier isolated wave than its PVC. The
 4. **`/shared_tmp` is intentionally `emptyDir`.** It only coordinates temporary upload/processing files between API and worker in the same pod.
 5. **Redis is not backed up.** Its PVC exists for ordinary restart continuity only and is explicitly backup-exempt.
 6. **Zero is not backed up and has no PVC.** Its SQLite replica is `emptyDir`; replacement resyncs from Postgres.
-7. **Keep SurfSense same-origin.** `/api/v1` and `/auth` route to backend, `/zero` routes to Zero, and `/` falls through to frontend.
+7. **Mirror SurfSense's upstream same-origin proxy contract exactly.** `/auth/callback` goes to the frontend; `/auth`, `/users`, `/api/v1`, and `/zero/context` go to the backend; remaining `/zero` traffic goes to zero-cache; everything else goes to the frontend. The `/users/me` and `/zero/context` exceptions are required for authenticated dashboard startup. Do not collapse these into broad `/auth` or `/zero` routes without preserving the more-specific exceptions.
 8. **Do not add upstream OpenSandbox's Docker socket to Talos.** Talos has no Docker daemon/socket. `SANDBOX_ENABLED=FALSE` is intentional until a Kubernetes-native or remote sandbox provider is selected.
 9. **Do not request a GPU.** The active RTX 3090 belongs to vLLM. SurfSense uses CPU embeddings and can call vLLM for chat.
 10. **Reuse cluster SearXNG** at `http://searxng.searxng.svc.cluster.local:8080`; do not deploy another copy.

--- a/my-apps/ai/surfsense/README.md
+++ b/my-apps/ai/surfsense/README.md
@@ -63,9 +63,14 @@ Initial embeddings use CPU-local `sentence-transformers/all-MiniLM-L6-v2`, so Su
 
 ## Routing
 
-The external HTTPRoute keeps SurfSense's single-origin contract:
+The external HTTPRoute mirrors SurfSense 0.0.39's upstream Caddy single-origin contract:
 
+- `/auth/callback*` -> frontend
 - `/auth/*` -> backend
+- `/users/*` -> backend
 - `/api/v1/*` -> backend
-- `/zero/*` -> Zero/WebSocket
+- `/zero/context` -> backend
+- remaining `/zero/*` -> Zero/WebSocket
 - everything else -> frontend
+
+The more-specific `/auth/callback` and `/zero/context` matches are intentional. The authenticated dashboard also requires `/users/me` to reach FastAPI; routing `/users/*` to the frontend produces an HTML 404 and the frontend surfaces `Failed to parse response`.

--- a/my-apps/ai/surfsense/httproute.yaml
+++ b/my-apps/ai/surfsense/httproute.yaml
@@ -16,17 +16,36 @@ spec:
   hostnames:
     - surfsense.vanillax.me
   rules:
+    # SurfSense's frontend owns the post-login callback page. This more-specific
+    # prefix must beat the general /auth backend route below.
     - matches:
-        - path: {type: PathPrefix, value: /api/v1}
+        - path: {type: PathPrefix, value: /auth/callback}
+      backendRefs:
+        - name: frontend
+          port: 3000
+
+    # FastAPI owns auth, user profile, REST API, and the Zero auth-context
+    # endpoint. /users/me and /zero/context are required by the dashboard after
+    # login; sending either to Next.js/zero-cache produces the observed 404s.
+    - matches:
         - path: {type: PathPrefix, value: /auth}
+        - path: {type: PathPrefix, value: /users}
+        - path: {type: PathPrefix, value: /api/v1}
+        - path: {type: PathPrefix, value: /zero/context}
       backendRefs:
         - name: backend
           port: 8000
+
+    # Rocicorp Zero handles the remaining /zero sync traffic. Gateway API path
+    # precedence selects the longer /zero/context backend match above.
     - matches:
         - path: {type: PathPrefix, value: /zero}
       backendRefs:
         - name: zero-cache
           port: 4848
+
+    # Next.js application and frontend-owned API routes (/api/zero/*,
+    # /api/search, /api/contact, etc.).
     - matches:
         - path: {type: PathPrefix, value: /}
       backendRefs:


### PR DESCRIPTION
Superseded by #2140. The routing fix and documentation were folded into `fix/surfsense-worker-runtime` so SurfSense runtime stabilization and authenticated dashboard routing ship together in one PR.