### PR TITLE
fix(surfsense): configure vLLM global model

### DIFF
--- a/my-apps/ai/surfsense/CLAUDE.md
+++ b/my-apps/ai/surfsense/CLAUDE.md
@@ -24,6 +24,7 @@ Do not split these child folders into independent Argo Applications unless there
 | `kopiur/postgres-data.yaml` | Hourly Postgres backup + Restore |
 | `kopiur/object-store.yaml` | Daily knowledge/object-store backup + Restore |
 | `externalsecret.yaml` | 1Password-backed application/database/Zero secrets; wave -1 |
+| `global_llm_config.yaml` | Operator-owned global chat model catalog; points SurfSense at the in-cluster vLLM service |
 | `httproute.yaml` | Single-origin external routing that mirrors SurfSense's upstream Caddy contract |
 | `vpa.yaml` | VPAs for every long-running Deployment |
 

--- a/my-apps/ai/surfsense/README.md
+++ b/my-apps/ai/surfsense/README.md
@@ -41,10 +41,12 @@ Fields:
 
 ## Local AI
 
-SurfSense can use the existing in-cluster OpenAI-compatible backend:
+SurfSense uses the existing in-cluster OpenAI-compatible backend through its
+operator-owned global model catalog:
 
 - Base URL: `http://vllm-service.vllm.svc.cluster.local:8080/v1`
 - Model: `qwen3.8-27b`
+- Config: `global_llm_config.yaml`, mounted at `/app/app/config/global_llm_config.yaml`
 
 Initial embeddings use CPU-local `sentence-transformers/all-MiniLM-L6-v2`, so SurfSense does not request a GPU.
 

--- a/my-apps/ai/surfsense/app/beat.yaml
+++ b/my-apps/ai/surfsense/app/beat.yaml
@@ -57,3 +57,12 @@ spec:
               memory: 128Mi
             limits:
               memory: 2Gi
+          volumeMounts:
+            - name: global-llm-config
+              mountPath: /app/app/config/global_llm_config.yaml
+              subPath: global_llm_config.yaml
+              readOnly: true
+      volumes:
+        - name: global-llm-config
+          configMap:
+            name: surfsense-global-llm-config

--- a/my-apps/ai/surfsense/app/deployment.yaml
+++ b/my-apps/ai/surfsense/app/deployment.yaml
@@ -71,6 +71,7 @@ spec:
           volumeMounts:
             - {name: object-store, mountPath: /app/.local_object_store}
             - {name: shared-temp, mountPath: /shared_tmp}
+            - {name: global-llm-config, mountPath: /app/app/config/global_llm_config.yaml, subPath: global_llm_config.yaml, readOnly: true}
         - name: worker
           image: ghcr.io/modsetter/surfsense-backend:0.0.39
           env:
@@ -99,9 +100,13 @@ spec:
           volumeMounts:
             - {name: object-store, mountPath: /app/.local_object_store}
             - {name: shared-temp, mountPath: /shared_tmp}
+            - {name: global-llm-config, mountPath: /app/app/config/global_llm_config.yaml, subPath: global_llm_config.yaml, readOnly: true}
       volumes:
         - name: object-store
           persistentVolumeClaim:
             claimName: surfsense-object-store
         - name: shared-temp
           emptyDir: {}
+        - name: global-llm-config
+          configMap:
+            name: surfsense-global-llm-config

--- a/my-apps/ai/surfsense/app/migrations-job.yaml
+++ b/my-apps/ai/surfsense/app/migrations-job.yaml
@@ -41,3 +41,12 @@ spec:
               memory: 256Mi
             limits:
               memory: 1Gi
+          volumeMounts:
+            - name: global-llm-config
+              mountPath: /app/app/config/global_llm_config.yaml
+              subPath: global_llm_config.yaml
+              readOnly: true
+      volumes:
+        - name: global-llm-config
+          configMap:
+            name: surfsense-global-llm-config

--- a/my-apps/ai/surfsense/global_llm_config.yaml
+++ b/my-apps/ai/surfsense/global_llm_config.yaml
@@ -1,0 +1,23 @@
+global_llm_configs:
+  - id: -1
+    name: Qwen 3.8 27B (vLLM)
+    billing_tier: free
+    anonymous_enabled: false
+    seo_enabled: false
+    quota_reserve_tokens: 4000
+    provider: openai
+    model_name: qwen3.8-27b
+    supports_image_input: true
+    supports_tools: true
+    max_input_tokens: 65536
+    api_key: sk-required
+    api_base: http://vllm-service.vllm.svc.cluster.local:8080/v1
+    rpm: 60
+    tpm: 1000000
+    litellm_params:
+      max_tokens: 16384
+      input_cost_per_token: 0
+      output_cost_per_token: 0
+    system_instructions: ""
+    use_default_system_instructions: true
+    citations_enabled: true

--- a/my-apps/ai/surfsense/kustomization.yaml
+++ b/my-apps/ai/surfsense/kustomization.yaml
@@ -25,3 +25,8 @@ resources:
 
 components:
   - ../../common/kopiur-backup
+
+configMapGenerator:
+  - name: surfsense-global-llm-config
+    files:
+      - global_llm_config.yaml


### PR DESCRIPTION
## Summary

- add SurfSense's operator-owned global LLM catalog
- wire `qwen3.8-27b` to the same direct vLLM Service and dummy key used by Open WebUI
- mount the catalog at SurfSense's required path for API, worker, Beat, and migrations
- document the Git-managed model source of truth

## Root cause

The manifests documented vLLM but never created `/app/app/config/global_llm_config.yaml`. SurfSense 0.0.39 therefore initialized with an empty global model list and disabled its Auto pool. `EMBEDDING_MODEL` configures vector embeddings only; it does not configure chat inference.

## Configuration

- provider: `openai`
- base URL: `http://vllm-service.vllm.svc.cluster.local:8080/v1`
- API key: `sk-required` (non-secret compatibility value, matching Open WebUI)
- model: `qwen3.8-27b`
- context: `65536`
- tools + image input enabled

## Validation

- real LiteLLM completion from the SurfSense pod returned `OK` through the configured Service/key/model
- `kustomize build my-apps/ai/surfsense`
- generated ConfigMap hash is propagated to every backend pod template
- repo-wide kopiur validation: 0 failures
- repo-wide VPA validation: 0 errors (existing unrelated warnings only)
- `git diff --check`