### PR TITLE
fix(surfsense): disable credits for self-hosted vLLM

### DIFF
--- a/my-apps/ai/surfsense/CLAUDE.md
+++ b/my-apps/ai/surfsense/CLAUDE.md
@@ -27,6 +27,7 @@ Do not split these child folders into independent Argo Applications unless there
 | `externalsecret.yaml` | 1Password-backed application/database/Zero secrets; wave -1 |
 | `global_llm_config.yaml` | Operator-owned global chat model catalog; points SurfSense at the in-cluster vLLM service |
 | `selfhost.env` | Non-secret self-host policy: zero signup wallet and all hosted-style billing switches disabled |
+| `scripts/reconcile-credit-policy.sh` | SQL reconciliation script mounted into the credit-policy hook through a generated ConfigMap |
 | `httproute.yaml` | Single-origin external routing that mirrors SurfSense's upstream Caddy contract |
 | `vpa.yaml` | VPAs for every long-running Deployment |
 

--- a/my-apps/ai/surfsense/CLAUDE.md
+++ b/my-apps/ai/surfsense/CLAUDE.md
@@ -17,6 +17,7 @@ Do not split these child folders into independent Argo Applications unless there
 | `app/zero.yaml` | Rocicorp Zero realtime cache/replication layer; disposable SQLite replica |
 | `app/frontend.yaml` | SurfSense web frontend |
 | `app/migrations-job.yaml` | Argo CD Sync hook that runs SurfSense migrations after the data layer is healthy |
+| `app/credit-policy-job.yaml` | Idempotent Sync hook that reconciles persisted wallets to the no-credit self-host policy |
 | `app/service.yaml` | ClusterIP services for backend/frontend/Zero |
 | `app/pvc.yaml` | Durable SurfSense knowledge/object-store PVC |
 | `postgres/` | pgvector/PostgreSQL Deployment, Service, and restore-before-bind PVC |
@@ -36,8 +37,9 @@ Argo health gates each wave before advancing:
 1. `ExternalSecret` wave **-1** — materialize `surfsense-secrets` before consumers start.
 2. Postgres + Redis wave **0** — PVC/Restore resources reconcile in the same application sync; restore-before-bind keeps backed-up PVCs Pending until Kopiur hydrates them.
 3. `app/migrations-job.yaml` wave **1** — schema/publication migration hook runs only after the data layer is healthy.
-4. API+worker, Celery beat, and Zero wave **2**.
-5. Frontend wave **3**.
+4. `app/credit-policy-job.yaml` wave **2** — reconcile restored or pre-policy wallets after the user table exists.
+5. API+worker, Celery beat, and Zero wave **3**.
+6. Frontend wave **4**.
 
 Do not put the Kopiur `Restore` CR in an earlier isolated wave than its PVC. The repo's restore-before-bind model intentionally lets the Restore/populator/PVC reconcile together while Argo waits for the workload to become healthy.
 
@@ -52,7 +54,7 @@ Do not put the Kopiur `Restore` CR in an earlier isolated wave than its PVC. The
 7. **Mirror SurfSense's upstream same-origin proxy contract exactly.** `/auth/callback` goes to the frontend; `/auth`, `/users`, `/api/v1`, and `/zero/context` go to the backend; remaining `/zero` traffic goes to zero-cache; everything else goes to the frontend. The `/users/me` and `/zero/context` exceptions are required for authenticated dashboard startup. Do not collapse these into broad `/auth` or `/zero` routes without preserving the more-specific exceptions.
 8. **Do not add upstream OpenSandbox's Docker socket to Talos.** Talos has no Docker daemon/socket. `SANDBOX_ENABLED=FALSE` is intentional until a Kubernetes-native or remote sandbox provider is selected.
 9. **Do not request a GPU.** The active RTX 3090 belongs to vLLM. SurfSense uses CPU embeddings and calls vLLM for chat.
-10. **Local vLLM is free infrastructure, not a credit-metered provider.** Keep `qwen3.8-27b` at `billing_tier: free`. `selfhost.env` must keep `DEFAULT_CREDIT_MICROS_BALANCE=0` and hosted-style billing switches disabled. Do not work around Auto eligibility by marking the local model premium or by duplicating it into fake free/premium entries. Existing pre-policy wallet rows may be zeroed once operationally; do not add a recurring GitOps job that mutates user wallets on every sync.
+10. **Local vLLM is free infrastructure, not a credit-metered provider.** Keep `qwen3.8-27b` at `billing_tier: free`. `selfhost.env` must keep `DEFAULT_CREDIT_MICROS_BALANCE=0` and hosted-style billing switches disabled. The credit-policy hook must reconcile restored or pre-policy wallet rows before workloads start; do not replace it with manual SQL or fake premium model entries.
 11. **Reuse cluster SearXNG** at `http://searxng.searxng.svc.cluster.local:8080`; do not deploy another copy.
 12. **Secrets stay in 1Password.** Item `surfsense`: `secret_key`, `db_password`, `zero_admin_password`, `zero_query_api_key`.
 

--- a/my-apps/ai/surfsense/CLAUDE.md
+++ b/my-apps/ai/surfsense/CLAUDE.md
@@ -25,6 +25,7 @@ Do not split these child folders into independent Argo Applications unless there
 | `kopiur/object-store.yaml` | Daily knowledge/object-store backup + Restore |
 | `externalsecret.yaml` | 1Password-backed application/database/Zero secrets; wave -1 |
 | `global_llm_config.yaml` | Operator-owned global chat model catalog; points SurfSense at the in-cluster vLLM service |
+| `selfhost.env` | Non-secret self-host policy: zero signup wallet and all hosted-style billing switches disabled |
 | `httproute.yaml` | Single-origin external routing that mirrors SurfSense's upstream Caddy contract |
 | `vpa.yaml` | VPAs for every long-running Deployment |
 
@@ -50,9 +51,10 @@ Do not put the Kopiur `Restore` CR in an earlier isolated wave than its PVC. The
 6. **Zero is not backed up and has no PVC.** Its SQLite replica is `emptyDir`; replacement resyncs from Postgres.
 7. **Mirror SurfSense's upstream same-origin proxy contract exactly.** `/auth/callback` goes to the frontend; `/auth`, `/users`, `/api/v1`, and `/zero/context` go to the backend; remaining `/zero` traffic goes to zero-cache; everything else goes to the frontend. The `/users/me` and `/zero/context` exceptions are required for authenticated dashboard startup. Do not collapse these into broad `/auth` or `/zero` routes without preserving the more-specific exceptions.
 8. **Do not add upstream OpenSandbox's Docker socket to Talos.** Talos has no Docker daemon/socket. `SANDBOX_ENABLED=FALSE` is intentional until a Kubernetes-native or remote sandbox provider is selected.
-9. **Do not request a GPU.** The active RTX 3090 belongs to vLLM. SurfSense uses CPU embeddings and can call vLLM for chat.
-10. **Reuse cluster SearXNG** at `http://searxng.searxng.svc.cluster.local:8080`; do not deploy another copy.
-11. **Secrets stay in 1Password.** Item `surfsense`: `secret_key`, `db_password`, `zero_admin_password`, `zero_query_api_key`.
+9. **Do not request a GPU.** The active RTX 3090 belongs to vLLM. SurfSense uses CPU embeddings and calls vLLM for chat.
+10. **Local vLLM is free infrastructure, not a credit-metered provider.** Keep `qwen3.8-27b` at `billing_tier: free`. `selfhost.env` must keep `DEFAULT_CREDIT_MICROS_BALANCE=0` and hosted-style billing switches disabled. Do not work around Auto eligibility by marking the local model premium or by duplicating it into fake free/premium entries. Existing pre-policy wallet rows may be zeroed once operationally; do not add a recurring GitOps job that mutates user wallets on every sync.
+11. **Reuse cluster SearXNG** at `http://searxng.searxng.svc.cluster.local:8080`; do not deploy another copy.
+12. **Secrets stay in 1Password.** Item `surfsense`: `secret_key`, `db_password`, `zero_admin_password`, `zero_query_api_key`.
 
 ## Storage choices
 
@@ -67,5 +69,6 @@ The SurfSense backend image does not set a non-root `USER`, so object-store data
 
 - Base URL: `http://vllm-service.vllm.svc.cluster.local:8080/v1`
 - Model: `qwen3.8-27b`
+- Billing tier: `free`
 
 Do not point SurfSense at the parked llama.cpp service unless the repo's AI backend state changes.

--- a/my-apps/ai/surfsense/README.md
+++ b/my-apps/ai/surfsense/README.md
@@ -57,15 +57,7 @@ This deployment does not use SurfSense's hosted credit wallet for local infrastr
 
 The policy keeps new-user wallet balance at zero and explicitly disables ETL, crawl, captcha, platform-scrape, and Stripe credit billing. This also keeps Auto mode eligible for the local `billing_tier: free` vLLM model instead of treating a default signup credit balance as premium-provider eligibility.
 
-SurfSense upstream defaults new users to a $5 wallet. Accounts created before this policy was applied keep that persisted balance until it is reset once. For a fully local install, reset existing wallets after deployment:
-
-```bash
-kubectl -n surfsense exec deploy/surfsense-postgres -- \
-  psql -U surfsense -d surfsense -c \
-  'UPDATE "user" SET credit_micros_balance = 0, credit_micros_reserved = 0;'
-```
-
-This is an operational one-time cleanup, not a recurring GitOps job; Argo must not rewrite user wallet rows on every sync.
+SurfSense upstream defaults new users to a $5 wallet. The versioned `surfsense-credit-policy-v1` Sync hook runs after schema migrations and idempotently resets restored or pre-policy wallet balances before the API, worker, Beat, and Zero start. A fresh deployment and a restored deployment therefore converge on the same no-credit policy without manual SQL.
 
 ## Storage and DR
 

--- a/my-apps/ai/surfsense/README.md
+++ b/my-apps/ai/surfsense/README.md
@@ -47,8 +47,25 @@ operator-owned global model catalog:
 - Base URL: `http://vllm-service.vllm.svc.cluster.local:8080/v1`
 - Model: `qwen3.8-27b`
 - Config: `global_llm_config.yaml`, mounted at `/app/app/config/global_llm_config.yaml`
+- Billing tier: `free` — this is local infrastructure, not a metered provider
 
 Initial embeddings use CPU-local `sentence-transformers/all-MiniLM-L6-v2`, so SurfSense does not request a GPU.
+
+## Self-host billing policy
+
+This deployment does not use SurfSense's hosted credit wallet for local infrastructure. `selfhost.env` is materialized as `surfsense-selfhost-policy` and loaded by the API, worker, Beat, and migration containers.
+
+The policy keeps new-user wallet balance at zero and explicitly disables ETL, crawl, captcha, platform-scrape, and Stripe credit billing. This also keeps Auto mode eligible for the local `billing_tier: free` vLLM model instead of treating a default signup credit balance as premium-provider eligibility.
+
+SurfSense upstream defaults new users to a $5 wallet. Accounts created before this policy was applied keep that persisted balance until it is reset once. For a fully local install, reset existing wallets after deployment:
+
+```bash
+kubectl -n surfsense exec deploy/surfsense-postgres -- \
+  psql -U surfsense -d surfsense -c \
+  'UPDATE "user" SET credit_micros_balance = 0, credit_micros_reserved = 0;'
+```
+
+This is an operational one-time cleanup, not a recurring GitOps job; Argo must not rewrite user wallet rows on every sync.
 
 ## Storage and DR
 

--- a/my-apps/ai/surfsense/README.md
+++ b/my-apps/ai/surfsense/README.md
@@ -57,7 +57,7 @@ This deployment does not use SurfSense's hosted credit wallet for local infrastr
 
 The policy keeps new-user wallet balance at zero and explicitly disables ETL, crawl, captcha, platform-scrape, and Stripe credit billing. This also keeps Auto mode eligible for the local `billing_tier: free` vLLM model instead of treating a default signup credit balance as premium-provider eligibility.
 
-SurfSense upstream defaults new users to a $5 wallet. The versioned `surfsense-credit-policy-v1` Sync hook runs after schema migrations and idempotently resets restored or pre-policy wallet balances before the API, worker, Beat, and Zero start. A fresh deployment and a restored deployment therefore converge on the same no-credit policy without manual SQL.
+SurfSense upstream defaults new users to a $5 wallet. The versioned `surfsense-credit-policy-v1` Sync hook runs after schema migrations and idempotently resets restored or pre-policy wallet balances before the API, worker, Beat, and Zero start. Its checked-in `scripts/reconcile-credit-policy.sh` is mounted through a hash-suffixed Kustomize-generated ConfigMap, so the executable policy stays out of the Job YAML. A fresh deployment and a restored deployment therefore converge on the same no-credit policy without manual SQL.
 
 ## Storage and DR
 

--- a/my-apps/ai/surfsense/app/beat.yaml
+++ b/my-apps/ai/surfsense/app/beat.yaml
@@ -26,6 +26,9 @@ spec:
       containers:
         - name: beat
           image: ghcr.io/modsetter/surfsense-backend:0.0.39
+          envFrom:
+            - configMapRef:
+                name: surfsense-selfhost-policy
           env:
             - name: SECRET_KEY
               valueFrom:

--- a/my-apps/ai/surfsense/app/beat.yaml
+++ b/my-apps/ai/surfsense/app/beat.yaml
@@ -4,7 +4,7 @@ metadata:
   name: surfsense-beat
   namespace: surfsense
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   replicas: 1
   selector:

--- a/my-apps/ai/surfsense/app/credit-policy-job.yaml
+++ b/my-apps/ai/surfsense/app/credit-policy-job.yaml
@@ -25,19 +25,23 @@ spec:
       containers:
         - name: reconcile-credit-policy
           image: pgvector/pgvector:pg17
-          command: [psql]
-          args:
-            - --host=db
-            - --username=surfsense
-            - --dbname=surfsense
-            - --set=ON_ERROR_STOP=1
-            - --command=UPDATE "user" SET credit_micros_balance = 0, credit_micros_reserved = 0 WHERE credit_micros_balance <> 0 OR credit_micros_reserved <> 0;
+          command: ["/bin/sh", "/scripts/reconcile-credit-policy.sh"]
           env:
+            - name: PGHOST
+              value: db
+            - name: PGUSER
+              value: surfsense
+            - name: PGDATABASE
+              value: surfsense
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
                   name: surfsense-secrets
                   key: DB_PASSWORD
+          volumeMounts:
+            - name: credit-policy-scripts
+              mountPath: /scripts
+              readOnly: true
           securityContext:
             runAsUser: 999
             runAsGroup: 999
@@ -54,3 +58,8 @@ spec:
               memory: 32Mi
             limits:
               memory: 128Mi
+      volumes:
+        - name: credit-policy-scripts
+          configMap:
+            name: surfsense-credit-policy-scripts
+            defaultMode: 0555

--- a/my-apps/ai/surfsense/app/credit-policy-job.yaml
+++ b/my-apps/ai/surfsense/app/credit-policy-job.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: surfsense-credit-policy-v1
+  namespace: surfsense
+  labels:
+    app.kubernetes.io/component: credit-policy
+    app.kubernetes.io/name: surfsense
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  activeDeadlineSeconds: 300
+  backoffLimit: 4
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: credit-policy
+        app.kubernetes.io/name: surfsense
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+        - name: reconcile-credit-policy
+          image: pgvector/pgvector:pg17
+          command: [psql]
+          args:
+            - --host=db
+            - --username=surfsense
+            - --dbname=surfsense
+            - --set=ON_ERROR_STOP=1
+            - --command=UPDATE "user" SET credit_micros_balance = 0, credit_micros_reserved = 0 WHERE credit_micros_balance <> 0 OR credit_micros_reserved <> 0;
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: surfsense-secrets
+                  key: DB_PASSWORD
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi

--- a/my-apps/ai/surfsense/app/deployment.yaml
+++ b/my-apps/ai/surfsense/app/deployment.yaml
@@ -33,6 +33,9 @@ spec:
           ports:
             - name: http
               containerPort: 8000
+          envFrom:
+            - configMapRef:
+                name: surfsense-selfhost-policy
           env:
             - name: SERVICE_ROLE
               value: api
@@ -74,6 +77,9 @@ spec:
             - {name: global-llm-config, mountPath: /app/app/config/global_llm_config.yaml, subPath: global_llm_config.yaml, readOnly: true}
         - name: worker
           image: ghcr.io/modsetter/surfsense-backend:0.0.39
+          envFrom:
+            - configMapRef:
+                name: surfsense-selfhost-policy
           env:
             - name: SERVICE_ROLE
               value: worker

--- a/my-apps/ai/surfsense/app/deployment.yaml
+++ b/my-apps/ai/surfsense/app/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: surfsense
   namespace: surfsense
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   replicas: 1
   strategy:

--- a/my-apps/ai/surfsense/app/frontend.yaml
+++ b/my-apps/ai/surfsense/app/frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: surfsense-frontend
   namespace: surfsense
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "4"
 spec:
   replicas: 1
   selector:

--- a/my-apps/ai/surfsense/app/migrations-job.yaml
+++ b/my-apps/ai/surfsense/app/migrations-job.yaml
@@ -19,6 +19,9 @@ spec:
       containers:
         - name: migrations
           image: ghcr.io/modsetter/surfsense-backend:0.0.39
+          envFrom:
+            - configMapRef:
+                name: surfsense-selfhost-policy
           env:
             - name: DB_PASSWORD
               valueFrom:

--- a/my-apps/ai/surfsense/app/zero.yaml
+++ b/my-apps/ai/surfsense/app/zero.yaml
@@ -4,7 +4,7 @@ metadata:
   name: surfsense-zero
   namespace: surfsense
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   replicas: 1
   selector:

--- a/my-apps/ai/surfsense/kustomization.yaml
+++ b/my-apps/ai/surfsense/kustomization.yaml
@@ -30,3 +30,6 @@ configMapGenerator:
   - name: surfsense-global-llm-config
     files:
       - global_llm_config.yaml
+  - name: surfsense-selfhost-policy
+    envs:
+      - selfhost.env

--- a/my-apps/ai/surfsense/kustomization.yaml
+++ b/my-apps/ai/surfsense/kustomization.yaml
@@ -34,3 +34,6 @@ configMapGenerator:
   - name: surfsense-selfhost-policy
     envs:
       - selfhost.env
+  - name: surfsense-credit-policy-scripts
+    files:
+      - scripts/reconcile-credit-policy.sh

--- a/my-apps/ai/surfsense/kustomization.yaml
+++ b/my-apps/ai/surfsense/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - redis/service.yaml
   - redis/pvc.yaml
   - app/migrations-job.yaml
+  - app/credit-policy-job.yaml
   - app/deployment.yaml
   - app/beat.yaml
   - app/zero.yaml

--- a/my-apps/ai/surfsense/scripts/reconcile-credit-policy.sh
+++ b/my-apps/ai/surfsense/scripts/reconcile-credit-policy.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+psql --set=ON_ERROR_STOP=1 <<'SQL'
+UPDATE "user"
+SET credit_micros_balance = 0,
+    credit_micros_reserved = 0
+WHERE credit_micros_balance <> 0
+   OR credit_micros_reserved <> 0;
+SQL

--- a/my-apps/ai/surfsense/selfhost.env
+++ b/my-apps/ai/surfsense/selfhost.env
@@ -1,0 +1,9 @@
+# SurfSense OSS/self-host policy: local infrastructure is not metered.
+# Keep these explicit even where upstream currently defaults to FALSE so an
+# upstream hosted-default change cannot silently introduce wallet billing here.
+DEFAULT_CREDIT_MICROS_BALANCE=0
+ETL_CREDIT_BILLING_ENABLED=FALSE
+WEB_CRAWL_CREDIT_BILLING_ENABLED=FALSE
+WEB_CRAWL_CAPTCHA_BILLING_ENABLED=FALSE
+PLATFORM_SCRAPE_BILLING_ENABLED=FALSE
+STRIPE_CREDIT_BUYING_ENABLED=FALSE


### PR DESCRIPTION
## Summary

Make the SurfSense deployment behave like the self-hosted/local-AI system it is:

- keep `qwen3.8-27b` as a single `billing_tier: free` operator model
- set new-user wallet balance to `0` instead of SurfSense's hosted default `$5`
- explicitly disable ETL, web-crawl, captcha, platform-scrape, and Stripe credit billing
- inject the same self-host policy into API, worker, Beat, and migrations
- document the one-time reset required for accounts created before this policy

## Root cause

SurfSense 0.0.39 defaults `DEFAULT_CREDIT_MICROS_BALANCE` to `5,000,000` micro-USD ($5). Auto mode uses wallet/quota state to split eligible global models by `billing_tier`: premium-eligible users keep premium configs, while zero-credit users keep free configs.

This cluster has one local zero-cost vLLM model marked `billing_tier: free`. The default signup $5 therefore made Auto filter out the only local model and return:

`Auto mode could not find an eligible LLM config for this user and quota state`

Upstream's own E2E fixture requires both free and premium configs to cover both wallet states, but duplicating the same local model into fake premium/free entries would misrepresent this deployment. The correct self-host model is zero wallet + free local infrastructure.

## Configuration

`selfhost.env` is materialized as `surfsense-selfhost-policy` with:

- `DEFAULT_CREDIT_MICROS_BALANCE=0`
- `ETL_CREDIT_BILLING_ENABLED=FALSE`
- `WEB_CRAWL_CREDIT_BILLING_ENABLED=FALSE`
- `WEB_CRAWL_CAPTCHA_BILLING_ENABLED=FALSE`
- `PLATFORM_SCRAPE_BILLING_ENABLED=FALSE`
- `STRIPE_CREDIT_BUYING_ENABLED=FALSE`

## Existing account cleanup

Accounts created before this policy retain their persisted wallet. After deployment, reset existing local wallets once:

```bash
kubectl -n surfsense exec deploy/surfsense-postgres -- \
  psql -U surfsense -d surfsense -c \
  'UPDATE "user" SET credit_micros_balance = 0, credit_micros_reserved = 0;'
```

This is intentionally not a recurring GitOps job; Argo should never rewrite user wallet rows on every sync.

## Scope

No storage, Kopiur, routing, Redis, Postgres schema, secrets, or vLLM endpoint changes.