### PR TITLE
refactor: extract inline deployment scripts

### DIFF
--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Validate ArgoCD app topology
         run: bash ./scripts/validate-argocd-apps.sh
 
+      - name: Reject inline executable YAML bodies
+        run: bash ./scripts/validate-no-inline-scripts.sh
+
   truenas-csi-contract:
     name: TrueNAS CSI Contract
     runs-on: ubuntu-latest
@@ -245,4 +248,5 @@ jobs:
       - name: Run shellcheck on scripts
         run: |
           set -euo pipefail
-          shellcheck -S warning scripts/*.sh
+          find infrastructure monitoring my-apps scripts -type f -name '*.sh' -not -path '*/charts/*' -print0 \
+            | xargs -0 shellcheck -S warning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ Do **not** write changelog/jira-style comments: no per-version release-note summ
 - Use Gateway API (not Ingress) — this cluster uses Gateway API exclusively
 - On **external** HTTPRoutes: add `labels: external-dns: "true"`, annotation `external-dns.alpha.kubernetes.io/target: vanillax.me`, and `sectionName: https` on the parentRef — **all three are required or DNS/routing silently fails**
 - Follow GitOps workflow for all changes
+- Keep repo-owned multi-line shell, SQL, Python, and JavaScript programs out of Kubernetes YAML and Helm values. Store them under the owning Application's `scripts/`, package them with a hash-suffixed Kustomize `configMapGenerator`, mount the ConfigMap read-only, and execute the file by path so a fresh clone has every deployment step.
+- Direct argv commands, probes, and single-purpose one-line checks may stay inline. Migrations, reconciliation logic, loops, heredocs, and other maintainable programs may not.
 - Store secrets in 1Password, reference via ExternalSecret
 - Add backups to a normal application PVC with **kopiur**: label the namespace `kopiur.home-operations.com/repo: cluster-kopia`, add a per-PVC stub (`SnapshotPolicy`+`SnapshotSchedule`+`Restore` in `kopiur/<pvc>.yaml`) with the **mover `securityContext` set to the data owner uid:gid**, pull in the `../../common/kopiur-backup` component, and point the PVC `dataSourceRef` at `<pvc>-restore`. See `.claude/commands/add-backup.md` and `docs/domains/storage/kopiur-backup-architecture.md`.
 - When marking a PVC `backup-exempt: "true"`, pair it with the fully-qualified reason annotation `storage.vanillax.dev/backup-exempt-reason`. There is **no runtime admission gate anymore** (pvc-plumber is gone) — the bare `backup-exempt-reason` key simply fails to record the reason; the kopiur backup-coverage CI check warns on missing/unqualified keys (it does not block)
@@ -147,6 +149,7 @@ Do **not** write changelog/jira-style comments: no per-version release-note summ
 - Mix Ingress and Gateway API
 - Commit secrets to Git
 - Bypass GitOps workflow for configuration changes
+- Hide deployment or migration behavior in an inline YAML block or an undocumented CLI command
 - Deploy without considering sync wave order
 - Add backup CRs to system namespace PVCs (kube-system, argocd, longhorn-system, kopiur-system)
 - Manually create or delete kopiur `SnapshotPolicy`/`SnapshotSchedule`/`Restore` (or `ReplicationSource`/`ReplicationDestination` — those CRDs are gone) out of band. Manage backups through the per-PVC stub + the `kopiur-backup` component in git.

--- a/infrastructure/controllers/nvidia-gpu-operator/kustomization.yaml
+++ b/infrastructure/controllers/nvidia-gpu-operator/kustomization.yaml
@@ -6,6 +6,11 @@ resources:
 - external-secret.yaml
 - time-slicing-config.yaml
 - powerlimit-daemonset.yaml    # Caps each GPU at 290W and reapplies after driver reloads
+
+configMapGenerator:
+- name: nvidia-powerlimit-scripts
+  files:
+  - scripts/reconcile-power-limit.sh
 # cluster-policy.yaml intentionally not included — the Helm chart generates its
 # own ClusterPolicy from valuesInline below. Keeping both would cause a conflict.
 

--- a/infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml
+++ b/infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml
@@ -44,29 +44,11 @@ spec:
           command:
             - /bin/bash
             - -c
-            - |
-              set -u
-
-              echo "[powerlimit] waiting for nvidia-smi to become available..."
-              until nvidia-smi >/dev/null 2>&1; do sleep 5; done
-
-              echo "[powerlimit] capping all GPUs at ${POWER_LIMIT_WATTS}W; reapplying every ${REAPPLY_SECONDS}s"
-              while true; do
-                # Best-effort: persistence mode keeps the driver loaded between
-                # CUDA processes. The reapply loop covers driver reloads.
-                nvidia-smi -pm 1 >/dev/null 2>&1 \
-                  || echo "[powerlimit] WARN: could not enable persistence mode"
-
-                if nvidia-smi -pl "${POWER_LIMIT_WATTS}" >/dev/null; then
-                  nvidia-smi \
-                    --query-gpu=index,name,power.limit,power.default_limit,power.max_limit,power.draw \
-                    --format=csv,noheader
-                else
-                  echo "[powerlimit] WARN: failed to set power limit; retrying in ${REAPPLY_SECONDS}s"
-                fi
-
-                sleep "${REAPPLY_SECONDS}"
-              done
+            - /opt/repo-scripts/reconcile-power-limit.sh
+          volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
           securityContext:
             # Required for nvidia-smi -pl; the driver rejects the ioctl
             # from an unprivileged user namespace.
@@ -88,3 +70,8 @@ spec:
               memory: 32Mi
             limits:
               memory: 128Mi
+      volumes:
+        - name: repo-scripts
+          configMap:
+            name: nvidia-powerlimit-scripts
+            defaultMode: 0555

--- a/infrastructure/controllers/nvidia-gpu-operator/scripts/reconcile-power-limit.sh
+++ b/infrastructure/controllers/nvidia-gpu-operator/scripts/reconcile-power-limit.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -u
+
+echo "[powerlimit] waiting for nvidia-smi to become available..."
+until nvidia-smi >/dev/null 2>&1; do sleep 5; done
+
+echo "[powerlimit] capping all GPUs at ${POWER_LIMIT_WATTS}W; reapplying every ${REAPPLY_SECONDS}s"
+while true; do
+  # Best-effort: persistence mode keeps the driver loaded between
+  # CUDA processes. The reapply loop covers driver reloads.
+  nvidia-smi -pm 1 >/dev/null 2>&1 \
+    || echo "[powerlimit] WARN: could not enable persistence mode"
+
+  if nvidia-smi -pl "${POWER_LIMIT_WATTS}" >/dev/null; then
+    nvidia-smi \
+      --query-gpu=index,name,power.limit,power.default_limit,power.max_limit,power.draw \
+      --format=csv,noheader
+  else
+    echo "[powerlimit] WARN: failed to set power limit; retrying in ${REAPPLY_SECONDS}s"
+  fi
+
+  sleep "${REAPPLY_SECONDS}"
+done
+

--- a/infrastructure/storage/container-registry/gc-cronjob.yaml
+++ b/infrastructure/storage/container-registry/gc-cronjob.yaml
@@ -26,31 +26,16 @@ spec:
               image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
               command: [/bin/bash, -euo, pipefail, -c]
               args:
-                - |
-                  # Restore writes on every exit path. A failed run that left
-                  # the registry read-only 503'd every pull for 15h once.
-                  restore_writes() {
-                    echo "[gc] restoring writes (trap)"
-                    kubectl -n kube-system set env deploy/registry \
-                      REGISTRY_STORAGE_MAINTENANCE- || true
-                    kubectl -n kube-system rollout status deploy/registry --timeout=180s || true
-                  }
-                  trap restore_writes EXIT
-
-                  # Set the whole maintenance map: on registry:3 the leaf var
-                  # REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED panics at boot or is silently dropped.
-                  echo "[gc] flipping registry to read-only"
-                  kubectl -n kube-system set env deploy/registry \
-                    'REGISTRY_STORAGE_MAINTENANCE={readonly: {enabled: true}}'
-                  kubectl -n kube-system rollout status deploy/registry --timeout=180s
-
-                  echo "[gc] running garbage-collect -m"
-                  POD=$(kubectl -n kube-system get pod -l app=registry \
-                    -o jsonpath='{.items[0].metadata.name}')
-                  kubectl -n kube-system exec "$POD" -- \
-                    registry garbage-collect -m /etc/distribution/config.yml
-
-                  echo "[gc] done"
+                - /opt/repo-scripts/run-garbage-collection.sh
+              volumeMounts:
+                - name: repo-scripts
+                  mountPath: /opt/repo-scripts
+                  readOnly: true
+          volumes:
+            - name: repo-scripts
+              configMap:
+                name: registry-gc-scripts
+                defaultMode: 0555
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/infrastructure/storage/container-registry/kustomization.yaml
+++ b/infrastructure/storage/container-registry/kustomization.yaml
@@ -16,3 +16,6 @@ configMapGenerator:
   - name: registry-config
     files:
       - config.yml
+  - name: registry-gc-scripts
+    files:
+      - scripts/run-garbage-collection.sh

--- a/infrastructure/storage/container-registry/scripts/run-garbage-collection.sh
+++ b/infrastructure/storage/container-registry/scripts/run-garbage-collection.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Restore writes on every exit path. A failed run that left
+# the registry read-only 503'd every pull for 15h once.
+restore_writes() {
+  echo "[gc] restoring writes (trap)"
+  kubectl -n kube-system set env deploy/registry \
+    REGISTRY_STORAGE_MAINTENANCE- || true
+  kubectl -n kube-system rollout status deploy/registry --timeout=180s || true
+}
+trap restore_writes EXIT
+
+# Set the whole maintenance map: on registry:3 the leaf var
+# REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED panics at boot or is silently dropped.
+echo "[gc] flipping registry to read-only"
+kubectl -n kube-system set env deploy/registry \
+  'REGISTRY_STORAGE_MAINTENANCE={readonly: {enabled: true}}'
+kubectl -n kube-system rollout status deploy/registry --timeout=180s
+
+echo "[gc] running garbage-collect -m"
+POD=$(kubectl -n kube-system get pod -l app=registry \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl -n kube-system exec "$POD" -- \
+  registry garbage-collect -m /etc/distribution/config.yml
+
+echo "[gc] done"
+

--- a/infrastructure/storage/rustfs-lifecycle/kustomization.yaml
+++ b/infrastructure/storage/rustfs-lifecycle/kustomization.yaml
@@ -12,3 +12,6 @@ configMapGenerator:
   - name: postgres-backups-lifecycle
     files:
       - lifecycle.json
+  - name: postgres-backups-lifecycle-scripts
+    files:
+      - scripts/apply-postgres-backups-lifecycle.sh

--- a/infrastructure/storage/rustfs-lifecycle/postgres-backups-lifecycle-job.yaml
+++ b/infrastructure/storage/rustfs-lifecycle/postgres-backups-lifecycle-job.yaml
@@ -57,17 +57,7 @@ spec:
           command:
             - sh
             - -c
-            - |
-              set -eu
-              echo "=== Applying lifecycle to s3://postgres-backups ==="
-              aws --endpoint-url http://192.168.10.133:30292 \
-                s3api put-bucket-lifecycle-configuration \
-                --bucket postgres-backups \
-                --lifecycle-configuration file:///lifecycle/lifecycle.json
-              echo "=== Verifying ==="
-              aws --endpoint-url http://192.168.10.133:30292 \
-                s3api get-bucket-lifecycle-configuration \
-                --bucket postgres-backups
+            - /opt/repo-scripts/apply-postgres-backups-lifecycle.sh
           resources:
             requests:
               cpu: 50m
@@ -78,11 +68,18 @@ spec:
             - name: lifecycle
               mountPath: /lifecycle
               readOnly: true
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: tmp
               mountPath: /tmp
       volumes:
         - name: lifecycle
           configMap:
             name: postgres-backups-lifecycle
+        - name: repo-scripts
+          configMap:
+            name: postgres-backups-lifecycle-scripts
+            defaultMode: 0555
         - name: tmp
           emptyDir: {}

--- a/infrastructure/storage/rustfs-lifecycle/scripts/apply-postgres-backups-lifecycle.sh
+++ b/infrastructure/storage/rustfs-lifecycle/scripts/apply-postgres-backups-lifecycle.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+echo "=== Applying lifecycle to s3://postgres-backups ==="
+aws --endpoint-url http://192.168.10.133:30292 \
+  s3api put-bucket-lifecycle-configuration \
+  --bucket postgres-backups \
+  --lifecycle-configuration file:///lifecycle/lifecycle.json
+echo "=== Verifying ==="
+aws --endpoint-url http://192.168.10.133:30292 \
+  s3api get-bucket-lifecycle-configuration \
+  --bucket postgres-backups
+

--- a/infrastructure/storage/talos-fstrim/cronjob.yaml
+++ b/infrastructure/storage/talos-fstrim/cronjob.yaml
@@ -49,20 +49,7 @@ spec:
               imagePullPolicy: IfNotPresent
               command: ["/bin/sh", "-c"]
               args:
-                - |
-                  set -eu
-
-                  for target in \
-                    /var \
-                    /var/mnt/longhorn-nvme1 \
-                    /var/mnt/longhorn-ssd-flash
-                  do
-                    echo "[fstrim] $(date -u +%Y-%m-%dT%H:%M:%SZ) trimming ${target}"
-                    nsenter --mount=/proc/1/ns/mnt -- \
-                      /usr/local/sbin/fstrim --verbose "${target}"
-                  done
-
-                  echo "[fstrim] $(date -u +%Y-%m-%dT%H:%M:%SZ) all targets completed"
+                - /opt/repo-scripts/trim-node-filesystems.sh
               securityContext:
                 privileged: true
                 readOnlyRootFilesystem: true
@@ -74,6 +61,9 @@ spec:
                   cpu: 100m
                   memory: 32Mi
               volumeMounts:
+                - name: repo-scripts
+                  mountPath: /opt/repo-scripts
+                  readOnly: true
                 # This matches Talos's own util-linux extension test pod. The
                 # fstrim binary lives on the host at /usr/local/sbin/fstrim.
                 - name: dev
@@ -82,6 +72,10 @@ spec:
                   mountPath: /host
                   readOnly: true
           volumes:
+            - name: repo-scripts
+              configMap:
+                name: talos-fstrim-scripts
+                defaultMode: 0555
             - name: dev
               hostPath:
                 path: /dev

--- a/infrastructure/storage/talos-fstrim/kustomization.yaml
+++ b/infrastructure/storage/talos-fstrim/kustomization.yaml
@@ -4,3 +4,8 @@ namespace: talos-fstrim
 resources:
   - namespace.yaml
   - cronjob.yaml
+
+configMapGenerator:
+  - name: talos-fstrim-scripts
+    files:
+      - scripts/trim-node-filesystems.sh

--- a/infrastructure/storage/talos-fstrim/scripts/trim-node-filesystems.sh
+++ b/infrastructure/storage/talos-fstrim/scripts/trim-node-filesystems.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+for target in \
+  /var \
+  /var/mnt/longhorn-nvme1 \
+  /var/mnt/longhorn-ssd-flash
+do
+  echo "[fstrim] $(date -u +%Y-%m-%dT%H:%M:%SZ) trimming ${target}"
+  nsenter --mount=/proc/1/ns/mnt -- \
+    /usr/local/sbin/fstrim --verbose "${target}"
+done
+
+echo "[fstrim] $(date -u +%Y-%m-%dT%H:%M:%SZ) all targets completed"
+

--- a/infrastructure/storage/truenas-csi/CANARY.md
+++ b/infrastructure/storage/truenas-csi/CANARY.md
@@ -22,7 +22,7 @@ The node DaemonSet must be Ready on every schedulable node before continuing.
 ## Provision And Mount
 
 ```bash
-kubectl apply -f infrastructure/storage/truenas-csi/canary/nfs-canary.yaml
+kubectl apply -k infrastructure/storage/truenas-csi/canary
 kubectl wait -n truenas-csi-canary \
   --for=jsonpath='{.status.phase}'=Bound pvc/truenas-nfs-canary \
   --timeout=2m

--- a/infrastructure/storage/truenas-csi/canary/kustomization.yaml
+++ b/infrastructure/storage/truenas-csi/canary/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: truenas-csi-canary
+
+resources:
+  - nfs-canary.yaml
+
+configMapGenerator:
+  - name: truenas-csi-canary-scripts
+    files:
+      - scripts/root-writer.sh
+      - scripts/nonroot-writer.sh
+      - scripts/reader.sh

--- a/infrastructure/storage/truenas-csi/canary/nfs-canary.yaml
+++ b/infrastructure/storage/truenas-csi/canary/nfs-canary.yaml
@@ -49,14 +49,18 @@ spec:
       command:
         - /bin/sh
         - -ec
-        - |
-          printf 'root-writer\n' > /data/root-writer.txt
-          stat -c 'root-writer ownership=%u:%g mode=%a' /data/root-writer.txt
-          sleep 3600
+        - /opt/repo-scripts/root-writer.sh
       volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
         - name: data
           mountPath: /data
   volumes:
+    - name: repo-scripts
+      configMap:
+        name: truenas-csi-canary-scripts
+        defaultMode: 0555
     - name: data
       persistentVolumeClaim:
         claimName: truenas-nfs-canary
@@ -96,16 +100,18 @@ spec:
       command:
         - /bin/sh
         - -ec
-        - |
-          printf 'nonroot-writer\n' > /data/nonroot-writer.txt
-          owner="$(stat -c '%u:%g' /data/nonroot-writer.txt)"
-          printf 'nonroot-writer ownership=%s\n' "$owner"
-          test "$owner" = "1000:1000"
-          sleep 3600
+        - /opt/repo-scripts/nonroot-writer.sh
       volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
         - name: data
           mountPath: /data
   volumes:
+    - name: repo-scripts
+      configMap:
+        name: truenas-csi-canary-scripts
+        defaultMode: 0555
     - name: data
       persistentVolumeClaim:
         claimName: truenas-nfs-canary
@@ -133,19 +139,19 @@ spec:
       command:
         - /bin/sh
         - -ec
-        - |
-          until test -f /data/root-writer.txt; do sleep 1; done
-          cat /data/root-writer.txt
-          for file in /data/*; do
-            test -f "$file" || continue
-            stat -c '%n ownership=%u:%g mode=%a' "$file"
-          done
-          sleep 3600
+        - /opt/repo-scripts/reader.sh
       volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
         - name: data
           mountPath: /data
           readOnly: true
   volumes:
+    - name: repo-scripts
+      configMap:
+        name: truenas-csi-canary-scripts
+        defaultMode: 0555
     - name: data
       persistentVolumeClaim:
         claimName: truenas-nfs-canary

--- a/infrastructure/storage/truenas-csi/canary/scripts/nonroot-writer.sh
+++ b/infrastructure/storage/truenas-csi/canary/scripts/nonroot-writer.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+printf 'nonroot-writer\n' > /data/nonroot-writer.txt
+owner="$(stat -c '%u:%g' /data/nonroot-writer.txt)"
+printf 'nonroot-writer ownership=%s\n' "$owner"
+test "$owner" = "1000:1000"
+sleep 3600
+

--- a/infrastructure/storage/truenas-csi/canary/scripts/reader.sh
+++ b/infrastructure/storage/truenas-csi/canary/scripts/reader.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+until test -f /data/root-writer.txt; do sleep 1; done
+cat /data/root-writer.txt
+for file in /data/*; do
+  test -f "$file" || continue
+  stat -c '%n ownership=%u:%g mode=%a' "$file"
+done
+sleep 3600
+

--- a/infrastructure/storage/truenas-csi/canary/scripts/root-writer.sh
+++ b/infrastructure/storage/truenas-csi/canary/scripts/root-writer.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+printf 'root-writer\n' > /data/root-writer.txt
+stat -c 'root-writer ownership=%u:%g mode=%a' /data/root-writer.txt
+sleep 3600
+

--- a/monitoring/pod-cleanup/cronjob.yaml
+++ b/monitoring/pod-cleanup/cronjob.yaml
@@ -20,9 +20,13 @@ spec:
             command:
             - /bin/sh
             - -c
-            - |
-              echo "Cleaning up all Failed pods..."
-              kubectl delete pods --field-selector=status.phase=Failed -A --ignore-not-found
-              echo "Cleaning up all Succeeded pods..."
-              kubectl delete pods --field-selector=status.phase=Succeeded -A --ignore-not-found
-              echo "Done."
+            - /opt/repo-scripts/cleanup-completed-pods.sh
+            volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
+          volumes:
+          - name: repo-scripts
+            configMap:
+              name: pod-cleanup-scripts
+              defaultMode: 0555

--- a/monitoring/pod-cleanup/kustomization.yaml
+++ b/monitoring/pod-cleanup/kustomization.yaml
@@ -6,3 +6,8 @@ resources:
 - namespace.yaml
 - rbac.yaml
 - cronjob.yaml
+
+configMapGenerator:
+- name: pod-cleanup-scripts
+  files:
+  - scripts/cleanup-completed-pods.sh

--- a/monitoring/pod-cleanup/scripts/cleanup-completed-pods.sh
+++ b/monitoring/pod-cleanup/scripts/cleanup-completed-pods.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+echo "Cleaning up all Failed pods..."
+kubectl delete pods --field-selector=status.phase=Failed -A --ignore-not-found
+echo "Cleaning up all Succeeded pods..."
+kubectl delete pods --field-selector=status.phase=Succeeded -A --ignore-not-found
+echo "Done."
+

--- a/monitoring/prometheus-stack/kustomization.yaml
+++ b/monitoring/prometheus-stack/kustomization.yaml
@@ -34,6 +34,11 @@ resources:
   - homelab-power-dashboard.yaml # Homelab cost dashboard ($0.21/kWh, 4 homelab plugs only)
   - radar-ng-dashboard.yaml # radar-ng backend dashboard (logs + tile-server metrics)
   - radar-ng-mobile-dashboard.yaml # radar-ng mobile app dashboard (Tempo spans + Loki errors)
+
+configMapGenerator:
+  - name: prometheus-stack-scripts
+    files:
+      - scripts/prune-retired-dashboards.sh
 # These CRD schemas push client-side apply's last-applied annotation past the 256KB cap — keep per-CRD ServerSideApply+Replace.
 patches:
   - target:

--- a/monitoring/prometheus-stack/scripts/prune-retired-dashboards.sh
+++ b/monitoring/prometheus-stack/scripts/prune-retired-dashboards.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+find /var/lib/grafana/dashboards/kubernetes \
+  -maxdepth 1 -type f -name '*.json' -delete 2>/dev/null || true
+find /var/lib/grafana/dashboards/infrastructure \
+  -maxdepth 1 -type f -name 'vpa-autoscaling.json' -delete 2>/dev/null || true
+

--- a/monitoring/prometheus-stack/values.yaml
+++ b/monitoring/prometheus-stack/values.yaml
@@ -195,6 +195,11 @@ alertmanager:
 # Grafana Configuration
 grafana:
   enabled: true
+  extraVolumes:
+    - name: repo-scripts
+      configMap:
+        name: prometheus-stack-scripts
+        defaultMode: 0555
   deploymentStrategy:
     type: Recreate
   admin:
@@ -242,11 +247,7 @@ grafana:
       imagePullPolicy: IfNotPresent
       command: ["/bin/sh", "-ec"]
       args:
-        - |
-          find /var/lib/grafana/dashboards/kubernetes \
-            -maxdepth 1 -type f -name '*.json' -delete 2>/dev/null || true
-          find /var/lib/grafana/dashboards/infrastructure \
-            -maxdepth 1 -type f -name 'vpa-autoscaling.json' -delete 2>/dev/null || true
+        - /opt/repo-scripts/prune-retired-dashboards.sh
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:
@@ -256,6 +257,9 @@ grafana:
         seccompProfile:
           type: RuntimeDefault
       volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
         - name: storage
           mountPath: /var/lib/grafana
   # Stock dashboard bundle disabled: two dozen overlapping boards made triage a search problem.

--- a/my-apps/ai/comfyui/download-models-job.yaml
+++ b/my-apps/ai/comfyui/download-models-job.yaml
@@ -3,6 +3,9 @@ kind: Job
 metadata:
   name: comfyui-download-models
   namespace: comfyui
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
   ttlSecondsAfterFinished: 86400  # Auto-cleanup after 24h
   activeDeadlineSeconds: 3600     # 1 hour timeout for auxiliary files (~15GB)
@@ -19,97 +22,7 @@ spec:
         command:
         - bash
         - -c
-        - |
-          set -euo pipefail
-
-          pip install -q huggingface_hub
-
-          python3 << 'PYEOF'
-          import os, shutil
-          from huggingface_hub import hf_hub_download
-
-          token = os.environ.get('HF_TOKEN', None)
-          # /models is the shared repo (<share>/models via subPath) — the same
-          # per-type folders ComfyUI Desktop and the deployment use.
-          BASE = '/models'
-          TMP = '/models/.tmp_download'
-
-          def download(repo_id, filename, dest_dir, dest_name=None):
-              """Download a file from HuggingFace. Skips if already exists."""
-              if dest_name is None:
-                  dest_name = os.path.basename(filename)
-              dest = os.path.join(dest_dir, dest_name)
-              if os.path.exists(dest):
-                  size_mb = os.path.getsize(dest) / (1024*1024)
-                  print(f'  SKIP (exists, {size_mb:.0f}MB): {dest_name}')
-                  return
-              os.makedirs(dest_dir, exist_ok=True)
-              print(f'  Downloading {repo_id} / {filename} ...')
-              path = hf_hub_download(
-                  repo_id=repo_id,
-                  filename=filename,
-                  local_dir=TMP,
-                  token=token
-              )
-              shutil.move(path, dest)
-              size_gb = os.path.getsize(dest) / (1024**3)
-              print(f'  DONE ({size_gb:.1f}GB): {dest_name}')
-
-          # Main diffusion models already live in the shared SMB repo; this only fetches missing auxiliary files.
-
-          # FLUX text encoders (for Z-Image-Turbo)
-          print('\n=== FLUX text encoders (for Z-Image-Turbo) ===')
-          download('comfyanonymous/flux_text_encoders',
-                   'clip_l.safetensors',
-                   f'{BASE}/text_encoders')
-
-          download('comfyanonymous/flux_text_encoders',
-                   't5xxl_fp8_e4m3fn.safetensors',
-                   f'{BASE}/text_encoders')
-
-          # FLUX VAE (for Z-Image-Turbo)
-          download('black-forest-labs/FLUX.1-dev',
-                   'ae.safetensors',
-                   f'{BASE}/vae')
-
-          # Wan 2.2 auxiliary files
-          print('\n=== Wan 2.2 auxiliary files ===')
-
-          # UMT5-XXL text encoder (FP8, ~6.7GB)
-          download('Comfy-Org/Wan_2.1_ComfyUI_repackaged',
-                   'split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors',
-                   f'{BASE}/text_encoders',
-                   'umt5_xxl_fp8_e4m3fn_scaled.safetensors')
-
-          # Wan VAE (14B models use the 2.1 VAE, ~254MB)
-          download('Comfy-Org/Wan_2.2_ComfyUI_Repackaged',
-                   'split_files/vae/wan_2.1_vae.safetensors',
-                   f'{BASE}/vae',
-                   'wan_2.1_vae.safetensors')
-
-          # CLIP Vision H (required for I2V only, ~1.3GB)
-          download('Comfy-Org/Wan_2.1_ComfyUI_repackaged',
-                   'split_files/clip_vision/clip_vision_h.safetensors',
-                   f'{BASE}/clip_vision',
-                   'clip_vision_h.safetensors')
-
-          # Cleanup and summary
-          shutil.rmtree(TMP, ignore_errors=True)
-
-          print('\n=== All downloads complete ===')
-          total_gb = 0
-          for subdir in ['diffusion_models', 'vae', 'text_encoders', 'clip_vision']:
-              path = os.path.join(BASE, subdir)
-              if os.path.exists(path):
-                  print(f'\n{subdir}/')
-                  for f in sorted(os.listdir(path)):
-                      fpath = os.path.join(path, f)
-                      if os.path.isfile(fpath):
-                          size_gb = os.path.getsize(fpath) / (1024**3)
-                          total_gb += size_gb
-                          print(f'  {f} ({size_gb:.1f}GB)')
-          print(f'\nTotal: {total_gb:.1f}GB')
-          PYEOF
+        - /opt/repo-scripts/download-models.sh
 
         env:
         - name: HF_TOKEN
@@ -124,10 +37,17 @@ spec:
           limits:
             memory: "4Gi"
         volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
         - name: comfyui-storage
           mountPath: /models
           subPath: models
       volumes:
+      - name: repo-scripts
+        configMap:
+          name: comfyui-download-scripts
+          defaultMode: 0555
       - name: comfyui-storage
         persistentVolumeClaim:
           claimName: comfyui-storage-smb

--- a/my-apps/ai/comfyui/kustomization.yaml
+++ b/my-apps/ai/comfyui/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 - service.yaml
 - httproute.yaml
 - externalsecret.yaml
-# download-models-job.yaml is intentionally excluded — one-time manual kubectl apply; listing it would re-run every sync.
+- download-models-job.yaml
 
 configMapGenerator:
   - name: comfyui-manager-config
@@ -22,6 +22,9 @@ configMapGenerator:
   - name: comfyui-custom-nodes
     files:
       - image_to_llamacpp_base64.py
+  - name: comfyui-download-scripts
+    files:
+      - scripts/download-models.sh
 
 labels:
   # Keep true: selectors are immutable on live Deployments; flipping to false forces delete/recreate.

--- a/my-apps/ai/comfyui/scripts/download-models.sh
+++ b/my-apps/ai/comfyui/scripts/download-models.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -euo pipefail
+
+pip install -q huggingface_hub
+
+python3 << 'PYEOF'
+import os, shutil
+from huggingface_hub import hf_hub_download
+
+token = os.environ.get('HF_TOKEN', None)
+# /models is the shared repo (<share>/models via subPath) — the same
+# per-type folders ComfyUI Desktop and the deployment use.
+BASE = '/models'
+TMP = '/models/.tmp_download'
+
+def download(repo_id, filename, dest_dir, dest_name=None):
+    """Download a file from HuggingFace. Skips if already exists."""
+    if dest_name is None:
+        dest_name = os.path.basename(filename)
+    dest = os.path.join(dest_dir, dest_name)
+    if os.path.exists(dest):
+        size_mb = os.path.getsize(dest) / (1024*1024)
+        print(f'  SKIP (exists, {size_mb:.0f}MB): {dest_name}')
+        return
+    os.makedirs(dest_dir, exist_ok=True)
+    print(f'  Downloading {repo_id} / {filename} ...')
+    path = hf_hub_download(
+        repo_id=repo_id,
+        filename=filename,
+        local_dir=TMP,
+        token=token
+    )
+    shutil.move(path, dest)
+    size_gb = os.path.getsize(dest) / (1024**3)
+    print(f'  DONE ({size_gb:.1f}GB): {dest_name}')
+
+# Main diffusion models already live in the shared SMB repo; this only fetches missing auxiliary files.
+
+# FLUX text encoders (for Z-Image-Turbo)
+print('\n=== FLUX text encoders (for Z-Image-Turbo) ===')
+download('comfyanonymous/flux_text_encoders',
+         'clip_l.safetensors',
+         f'{BASE}/text_encoders')
+
+download('comfyanonymous/flux_text_encoders',
+         't5xxl_fp8_e4m3fn.safetensors',
+         f'{BASE}/text_encoders')
+
+# FLUX VAE (for Z-Image-Turbo)
+download('black-forest-labs/FLUX.1-dev',
+         'ae.safetensors',
+         f'{BASE}/vae')
+
+# Wan 2.2 auxiliary files
+print('\n=== Wan 2.2 auxiliary files ===')
+
+# UMT5-XXL text encoder (FP8, ~6.7GB)
+download('Comfy-Org/Wan_2.1_ComfyUI_repackaged',
+         'split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors',
+         f'{BASE}/text_encoders',
+         'umt5_xxl_fp8_e4m3fn_scaled.safetensors')
+
+# Wan VAE (14B models use the 2.1 VAE, ~254MB)
+download('Comfy-Org/Wan_2.2_ComfyUI_Repackaged',
+         'split_files/vae/wan_2.1_vae.safetensors',
+         f'{BASE}/vae',
+         'wan_2.1_vae.safetensors')
+
+# CLIP Vision H (required for I2V only, ~1.3GB)
+download('Comfy-Org/Wan_2.1_ComfyUI_repackaged',
+         'split_files/clip_vision/clip_vision_h.safetensors',
+         f'{BASE}/clip_vision',
+         'clip_vision_h.safetensors')
+
+# Cleanup and summary
+shutil.rmtree(TMP, ignore_errors=True)
+
+print('\n=== All downloads complete ===')
+total_gb = 0
+for subdir in ['diffusion_models', 'vae', 'text_encoders', 'clip_vision']:
+    path = os.path.join(BASE, subdir)
+    if os.path.exists(path):
+        print(f'\n{subdir}/')
+        for f in sorted(os.listdir(path)):
+            fpath = os.path.join(path, f)
+            if os.path.isfile(fpath):
+                size_gb = os.path.getsize(fpath) / (1024**3)
+                total_gb += size_gb
+                print(f'  {f} ({size_gb:.1f}GB)')
+print(f'\nTotal: {total_gb:.1f}GB')
+PYEOF
+

--- a/my-apps/ai/llama-cpp/cache-sync-job.yaml
+++ b/my-apps/ai/llama-cpp/cache-sync-job.yaml
@@ -29,47 +29,7 @@ spec:
           command:
             - /bin/sh
             - -ec
-            - |
-              SRC=/src/qwen3.8-flash-next-gguf
-              DST=/dst/qwen3.8-flash-next-gguf
-              mkdir -p \
-                "$DST/unsloth-ud-iq4-xs" \
-                "$DST/unsloth-ud-q4-k-xl" \
-                "$DST/atomic-ad-4.27-q4-k-m-m64"
-
-              sync_one() {
-                rel="$1"; s="$SRC/$rel"; d="$DST/$rel"
-                want=$(stat -c %s "$s")
-                if [ -f "$d" ] && [ "$(stat -c %s "$d")" = "$want" ]; then
-                  echo "present: $rel ($want bytes)"; return
-                fi
-                echo "copying: $rel ($want bytes)"
-                cp "$s" "$d.part" || { rm -f "$d.part"; exit 1; }
-                got=$(stat -c %s "$d.part")
-                [ "$got" = "$want" ] || { echo "SIZE MISMATCH $rel: $got != $want"; rm -f "$d.part"; exit 1; }
-                mv "$d.part" "$d"
-              }
-
-              for i in 1 2 3; do
-                sync_one "unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-0000$i-of-00003.gguf"
-              done
-
-              for i in 1 2 3 4; do
-                sync_one "unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-0000$i-of-00004.gguf"
-              done
-              sync_one "mmproj-BF16.gguf"
-
-              i=1
-              while [ "$i" -le 33 ]; do
-                shard=$(printf '%05d' "$i")
-                sync_one "atomic-ad-4.27-q4-k-m-m64/Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-${shard}-of-00033.gguf"
-                i=$((i + 1))
-              done
-              sync_one "mmproj-F16.gguf"
-
-              echo "=== RESULT ==="
-              du -sb "$DST" | awk '{printf "cache: %s bytes (%.2f GiB)\n", $1, $1/1073741824}'
-              df -h /dst
+            - /opt/repo-scripts/sync-model-cache.sh
           resources:
             requests:
               cpu: 500m
@@ -81,12 +41,19 @@ spec:
               cpu: "4"
               memory: 2Gi
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: src
               mountPath: /src
               readOnly: true
             - name: dst
               mountPath: /dst
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: llama-cpp-scripts
+            defaultMode: 0555
         - name: src
           persistentVolumeClaim:
             claimName: llama-cpp-models-pvc

--- a/my-apps/ai/llama-cpp/download-model-job.yaml
+++ b/my-apps/ai/llama-cpp/download-model-job.yaml
@@ -30,119 +30,7 @@ spec:
           command:
             - /bin/sh
             - -ec
-            - |
-              BASE=/models/qwen3.8-flash-next-gguf
-              UNSLOTH_REV=c8b5954a88c2775c546b92593eda40ea041d3176
-              ATOMIC_REV=142262902a46f7daed19c79d0771534c8106ad59
-              UNSLOTH_REPO=https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF/resolve/$UNSLOTH_REV
-              ATOMIC_REPO=https://huggingface.co/AtomicChat/Qwen3.8-Flash-Next-GGUF/resolve/$ATOMIC_REV
-              ATOMIC_DIR=Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64
-              mkdir -p \
-                "$BASE/unsloth-ud-iq4-xs" \
-                "$BASE/unsloth-ud-q4-k-xl" \
-                "$BASE/atomic-ad-4.27-q4-k-m-m64"
-              apk add --no-cache curl
-
-              # This hook re-runs on every sync. Hashing all shards each time is a
-              # ~104 GiB NFS read that contends with the server's mmap of the
-              # same files, so a matching stamp short-circuits it.
-              fetch() {
-                repo="$1" name="$2" dest="$3" size="$4" expected="$5"
-                part="$dest.part" stamp="$dest.sha256"
-                if [ -f "$dest" ] && [ "$(stat -c %s "$dest")" = "$size" ]; then
-                  if [ "$(cat "$stamp" 2>/dev/null)" = "$expected" ]; then
-                    echo "verified (stamp): $name"
-                    return
-                  fi
-                  if [ "$(sha256sum "$dest" | cut -d' ' -f1)" = "$expected" ]; then
-                    printf '%s' "$expected" > "$stamp"
-                    echo "verified: $name"
-                    return
-                  fi
-                fi
-                curl -fL -C - --retry 5 -o "$part" "$repo/$name"
-                actual="$(sha256sum "$part" | cut -d' ' -f1)"
-                [ "$actual" = "$expected" ] || { echo "SHA MISMATCH: $name: $actual"; rm -f "$part"; exit 1; }
-                [ "$(stat -c %s "$part")" = "$size" ] || { echo "SIZE MISMATCH: $name"; rm -f "$part"; exit 1; }
-                mv "$part" "$dest"
-                printf '%s' "$expected" > "$stamp"
-                echo "downloaded and verified: $name"
-              }
-
-              fetch "$UNSLOTH_REPO" UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf \
-                "$BASE/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf" \
-                10946624 5ce89370720f8bf90890f439361282104c1aa1482d4013bb9a50923e758e71a4
-              fetch "$UNSLOTH_REPO" UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf \
-                "$BASE/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf" \
-                49835229856 577a38a2392b40ca2193cea502e1d92f60b8cd370675d308e0ec21885d9daaa7 &
-              iq4_xs_pid_2=$!
-              fetch "$UNSLOTH_REPO" UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf \
-                "$BASE/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf" \
-                43836407744 d4634e6d84f0ebb0940be15c90d3790bf6464e3dea3a1cddc567dc0e83ad8833 &
-              iq4_xs_pid_3=$!
-              wait "$iq4_xs_pid_2"
-              wait "$iq4_xs_pid_3"
-
-              fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf \
-                "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf" \
-                10946624 4448186216b3af4cc558bbce2c3213f01608f8f8b2e5267a9767971dd3ec8082
-              fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00002-of-00004.gguf \
-                "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00002-of-00004.gguf" \
-                49859583136 3f342f1c1580473f1ee94ddd5b28206e8c07a70fa1a366f59d1d6c922919a6c9
-              fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00003-of-00004.gguf \
-                "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00003-of-00004.gguf" \
-                49376141504 56758f40269cad5cd9b0d3d6fbae0f40f6d5be6de49e4ab392dbe83157d9cbd3
-              fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00004-of-00004.gguf \
-                "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00004-of-00004.gguf" \
-                12087983520 753bda48b98ba4f1636134a90a967de1b2d3908a236c026e464777342e53510a
-              fetch "$UNSLOTH_REPO" mmproj-BF16.gguf "$BASE/mmproj-BF16.gguf" \
-                907542944 2e788f8c511d8093c7b43cb87b2fd7e14228340318057f8fb20c86df2efe2355
-
-              # AtomicChat isolates the approximately 38.4 GB N-gram table in
-              # shard 00002 so mmap can page it without pinning ordinary model
-              # tensors. Keep every LFS object immutable and independently
-              # verifiable; the first shard is the llama.cpp model entrypoint.
-              while read -r name size expected; do
-                fetch "$ATOMIC_REPO" "$ATOMIC_DIR/$name" \
-                  "$BASE/atomic-ad-4.27-q4-k-m-m64/$name" "$size" "$expected"
-              done <<'ATOMIC_Q4_ARTIFACTS'
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00001-of-00033.gguf 693380288 d74620aad612239711e0947f58d2614fa8f47335fb01f23e47b24a3315c3e730
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00002-of-00033.gguf 38400184512 77edf6523f6abbd7ba6a78aa1ef4a658dfaca544f9c5f46cf0efd0b0ff00bef0
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00003-of-00033.gguf 1999024832 50a95250ea2cfb5b9359bfbf37e8334959266c38777c134e1c7082c4a668f59d
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00004-of-00033.gguf 1787651072 0a32371569fd1564e82be13301a872847d00dce450db7c7f930f6978c0bccd6d
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00005-of-00033.gguf 1654830080 d545285f60dd11a2dfc46388a86af7ecb4c1bbdd86ac5364bb860ad3eefca8a4
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00006-of-00033.gguf 1993256608 64aacb4a86cc92a5a48f19619393f22af9b1a17d1c2dfbaded21bf936553994d
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00007-of-00033.gguf 1725815808 7cfd22c0de5dda2500643b9e13ef9c4aea338968ca29c1786226b325bc5948c6
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00008-of-00033.gguf 1830961056 408457d6a65f632b62ebec099112fb106ed1c1d3d5bc2bd9e189004bad9af550
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00009-of-00033.gguf 1915366048 c1f962654057e9a4f71af34ccada5d242af62a5c915b0694a0a152b30b24ba99
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00010-of-00033.gguf 1711956000 b85555c695efc1bd6852d005bd20931882b54c2d0f48a0912f846fe5e252b697
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00011-of-00033.gguf 1844820928 e5cb081065b8721583ddc29f5f71f5acb1d537c2d2a3bd8bc18e03d4340d2e43
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00012-of-00033.gguf 1923724224 cc9cb8624556958f65b9763c918ee077542e3d0cc1f6a81a647b2987860f1243
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00013-of-00033.gguf 1703597888 cd4abb2dc631a08f9b3885597f77bc24d1b1d9acd4662cafc17ebfb8e0b8959e
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00014-of-00033.gguf 1844820928 b14050af3b53ee789575a2a8159cb1524a2160a8b251e97fd367f2c0ffcf73d3
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00015-of-00033.gguf 1909864352 d6066a9799e1640b2609fa9c28b19d33ce1441c4737de11d3eb8e283d494c61f
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00016-of-00033.gguf 1717457728 76c95f5229b461e6c648f536a714457913fab50fb2608ffa64ec10ddbf8eabed
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00017-of-00033.gguf 1853179072 5a9428ca9bab16c1ada3b43bc98b60d3a884f7bded0aa9b468fb66dd6c36e68b
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00018-of-00033.gguf 1901506240 d4ad15dfa433fc1d0d09112bb175512321d41fe60a651b720e1c104cdd2c8f97
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00019-of-00033.gguf 1725815872 6ba1501407c639a126e74f483bfa4073da42ea24abecd251a7d560a0810855ba
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00020-of-00033.gguf 1830961088 96fc276c556886d19af5d1514876c59ad7d37005e99c329f35e4d4418515219b
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00021-of-00033.gguf 1915366080 f3c46604b832c24201c1d4d6ac22830ec729830f66e7bb91a2f8895ec41d62f9
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00022-of-00033.gguf 1711956000 5ae92fbdd717a4246620608a441571fd041dfb2a4bd20d969a8f6c8cd411b734
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00023-of-00033.gguf 1844820928 59bc05521ea68a8b6ff4b78fd275a0da975270384db05f2fbc62fbb901f28b15
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00024-of-00033.gguf 1923724224 14216d45769bc6ffec284e1be54ef9b200081fb528b97653ccaeedad896a5396
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00025-of-00033.gguf 1703597888 94bd0311975222d1c62f47fa6cde17bb56ad6f98c47c42c888a19e7d57b704af
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00026-of-00033.gguf 1844820928 b69a8f3b9896f7c0c1b75778d833ef8b0a3aa6d2df587444741a172a39f49c1f
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00027-of-00033.gguf 1909864352 35c3703530a17fcf42b8dbe8a582a3fe1be6e5d58885460fd46fd614585bec8b
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00028-of-00033.gguf 1646472000 8d01bec24d38b8876c8a011e04ccfca22584d9f86ea24c13e7e7b07a781cfbba
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00029-of-00033.gguf 1725375264 2b266e2d2a7f610d0a3de55a626e2f9029594c383074240d29c383a8f70e1064
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00030-of-00033.gguf 1738770080 36af1ca74bbf2bd4d79ac78b61a9f5d24e5ca9aac33d298bfbed7d9dbbe86c69
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00031-of-00033.gguf 1646472000 2cf675a6d3df1ff2eb018323c7e64ab14cd650eb38f954e948df27501822fdc1
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00032-of-00033.gguf 1725375264 59c5ab585958f86cecbd812a9ae34f1475d98ffff235d27734964fb53d8b4951
-              Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00033-of-00033.gguf 1220605344 0a7311b24f8636f5b7c0f0dca4f6275ec6b45e326a5eb7400410ca4e32c269c2
-              ATOMIC_Q4_ARTIFACTS
-              fetch "$ATOMIC_REPO" mmproj-Qwen3.8-Flash-Next-F16.gguf \
-                "$BASE/mmproj-F16.gguf" \
-                904003840 0e61454a76dd154a10aaa8fb1ada32615f55a13e4171014dacd06913e4aa6889
+            - /opt/repo-scripts/download-models.sh
           resources:
             requests:
               cpu: 250m
@@ -151,9 +39,16 @@ spec:
               cpu: "4"
               memory: 4Gi
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: models
               mountPath: /models
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: llama-cpp-scripts
+            defaultMode: 0555
         - name: models
           persistentVolumeClaim:
             claimName: llama-cpp-models-pvc

--- a/my-apps/ai/llama-cpp/kustomization.yaml
+++ b/my-apps/ai/llama-cpp/kustomization.yaml
@@ -13,3 +13,9 @@ resources:
   - service.yaml
   - httproute.yaml
   - servicemonitor.yaml
+
+configMapGenerator:
+  - name: llama-cpp-scripts
+    files:
+      - scripts/download-models.sh
+      - scripts/sync-model-cache.sh

--- a/my-apps/ai/llama-cpp/scripts/download-models.sh
+++ b/my-apps/ai/llama-cpp/scripts/download-models.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+BASE=/models/qwen3.8-flash-next-gguf
+UNSLOTH_REV=c8b5954a88c2775c546b92593eda40ea041d3176
+ATOMIC_REV=142262902a46f7daed19c79d0771534c8106ad59
+UNSLOTH_REPO=https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF/resolve/$UNSLOTH_REV
+ATOMIC_REPO=https://huggingface.co/AtomicChat/Qwen3.8-Flash-Next-GGUF/resolve/$ATOMIC_REV
+ATOMIC_DIR=Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64
+mkdir -p \
+  "$BASE/unsloth-ud-iq4-xs" \
+  "$BASE/unsloth-ud-q4-k-xl" \
+  "$BASE/atomic-ad-4.27-q4-k-m-m64"
+apk add --no-cache curl
+
+# This hook re-runs on every sync. Hashing all shards each time is a
+# ~104 GiB NFS read that contends with the server's mmap of the
+# same files, so a matching stamp short-circuits it.
+fetch() {
+  repo="$1" name="$2" dest="$3" size="$4" expected="$5"
+  part="$dest.part" stamp="$dest.sha256"
+  if [ -f "$dest" ] && [ "$(stat -c %s "$dest")" = "$size" ]; then
+    if [ "$(cat "$stamp" 2>/dev/null)" = "$expected" ]; then
+      echo "verified (stamp): $name"
+      return
+    fi
+    if [ "$(sha256sum "$dest" | cut -d' ' -f1)" = "$expected" ]; then
+      printf '%s' "$expected" > "$stamp"
+      echo "verified: $name"
+      return
+    fi
+  fi
+  curl -fL -C - --retry 5 -o "$part" "$repo/$name"
+  actual="$(sha256sum "$part" | cut -d' ' -f1)"
+  [ "$actual" = "$expected" ] || { echo "SHA MISMATCH: $name: $actual"; rm -f "$part"; exit 1; }
+  [ "$(stat -c %s "$part")" = "$size" ] || { echo "SIZE MISMATCH: $name"; rm -f "$part"; exit 1; }
+  mv "$part" "$dest"
+  printf '%s' "$expected" > "$stamp"
+  echo "downloaded and verified: $name"
+}
+
+fetch "$UNSLOTH_REPO" UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf \
+  "$BASE/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf" \
+  10946624 5ce89370720f8bf90890f439361282104c1aa1482d4013bb9a50923e758e71a4
+fetch "$UNSLOTH_REPO" UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf \
+  "$BASE/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf" \
+  49835229856 577a38a2392b40ca2193cea502e1d92f60b8cd370675d308e0ec21885d9daaa7 &
+iq4_xs_pid_2=$!
+fetch "$UNSLOTH_REPO" UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf \
+  "$BASE/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf" \
+  43836407744 d4634e6d84f0ebb0940be15c90d3790bf6464e3dea3a1cddc567dc0e83ad8833 &
+iq4_xs_pid_3=$!
+wait "$iq4_xs_pid_2"
+wait "$iq4_xs_pid_3"
+
+fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf \
+  "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf" \
+  10946624 4448186216b3af4cc558bbce2c3213f01608f8f8b2e5267a9767971dd3ec8082
+fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00002-of-00004.gguf \
+  "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00002-of-00004.gguf" \
+  49859583136 3f342f1c1580473f1ee94ddd5b28206e8c07a70fa1a366f59d1d6c922919a6c9
+fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00003-of-00004.gguf \
+  "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00003-of-00004.gguf" \
+  49376141504 56758f40269cad5cd9b0d3d6fbae0f40f6d5be6de49e4ab392dbe83157d9cbd3
+fetch "$UNSLOTH_REPO" UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00004-of-00004.gguf \
+  "$BASE/unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-00004-of-00004.gguf" \
+  12087983520 753bda48b98ba4f1636134a90a967de1b2d3908a236c026e464777342e53510a
+fetch "$UNSLOTH_REPO" mmproj-BF16.gguf "$BASE/mmproj-BF16.gguf" \
+  907542944 2e788f8c511d8093c7b43cb87b2fd7e14228340318057f8fb20c86df2efe2355
+
+# AtomicChat isolates the approximately 38.4 GB N-gram table in
+# shard 00002 so mmap can page it without pinning ordinary model
+# tensors. Keep every LFS object immutable and independently
+# verifiable; the first shard is the llama.cpp model entrypoint.
+while read -r name size expected; do
+  fetch "$ATOMIC_REPO" "$ATOMIC_DIR/$name" \
+    "$BASE/atomic-ad-4.27-q4-k-m-m64/$name" "$size" "$expected"
+done <<'ATOMIC_Q4_ARTIFACTS'
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00001-of-00033.gguf 693380288 d74620aad612239711e0947f58d2614fa8f47335fb01f23e47b24a3315c3e730
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00002-of-00033.gguf 38400184512 77edf6523f6abbd7ba6a78aa1ef4a658dfaca544f9c5f46cf0efd0b0ff00bef0
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00003-of-00033.gguf 1999024832 50a95250ea2cfb5b9359bfbf37e8334959266c38777c134e1c7082c4a668f59d
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00004-of-00033.gguf 1787651072 0a32371569fd1564e82be13301a872847d00dce450db7c7f930f6978c0bccd6d
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00005-of-00033.gguf 1654830080 d545285f60dd11a2dfc46388a86af7ecb4c1bbdd86ac5364bb860ad3eefca8a4
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00006-of-00033.gguf 1993256608 64aacb4a86cc92a5a48f19619393f22af9b1a17d1c2dfbaded21bf936553994d
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00007-of-00033.gguf 1725815808 7cfd22c0de5dda2500643b9e13ef9c4aea338968ca29c1786226b325bc5948c6
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00008-of-00033.gguf 1830961056 408457d6a65f632b62ebec099112fb106ed1c1d3d5bc2bd9e189004bad9af550
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00009-of-00033.gguf 1915366048 c1f962654057e9a4f71af34ccada5d242af62a5c915b0694a0a152b30b24ba99
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00010-of-00033.gguf 1711956000 b85555c695efc1bd6852d005bd20931882b54c2d0f48a0912f846fe5e252b697
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00011-of-00033.gguf 1844820928 e5cb081065b8721583ddc29f5f71f5acb1d537c2d2a3bd8bc18e03d4340d2e43
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00012-of-00033.gguf 1923724224 cc9cb8624556958f65b9763c918ee077542e3d0cc1f6a81a647b2987860f1243
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00013-of-00033.gguf 1703597888 cd4abb2dc631a08f9b3885597f77bc24d1b1d9acd4662cafc17ebfb8e0b8959e
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00014-of-00033.gguf 1844820928 b14050af3b53ee789575a2a8159cb1524a2160a8b251e97fd367f2c0ffcf73d3
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00015-of-00033.gguf 1909864352 d6066a9799e1640b2609fa9c28b19d33ce1441c4737de11d3eb8e283d494c61f
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00016-of-00033.gguf 1717457728 76c95f5229b461e6c648f536a714457913fab50fb2608ffa64ec10ddbf8eabed
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00017-of-00033.gguf 1853179072 5a9428ca9bab16c1ada3b43bc98b60d3a884f7bded0aa9b468fb66dd6c36e68b
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00018-of-00033.gguf 1901506240 d4ad15dfa433fc1d0d09112bb175512321d41fe60a651b720e1c104cdd2c8f97
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00019-of-00033.gguf 1725815872 6ba1501407c639a126e74f483bfa4073da42ea24abecd251a7d560a0810855ba
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00020-of-00033.gguf 1830961088 96fc276c556886d19af5d1514876c59ad7d37005e99c329f35e4d4418515219b
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00021-of-00033.gguf 1915366080 f3c46604b832c24201c1d4d6ac22830ec729830f66e7bb91a2f8895ec41d62f9
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00022-of-00033.gguf 1711956000 5ae92fbdd717a4246620608a441571fd041dfb2a4bd20d969a8f6c8cd411b734
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00023-of-00033.gguf 1844820928 59bc05521ea68a8b6ff4b78fd275a0da975270384db05f2fbc62fbb901f28b15
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00024-of-00033.gguf 1923724224 14216d45769bc6ffec284e1be54ef9b200081fb528b97653ccaeedad896a5396
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00025-of-00033.gguf 1703597888 94bd0311975222d1c62f47fa6cde17bb56ad6f98c47c42c888a19e7d57b704af
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00026-of-00033.gguf 1844820928 b69a8f3b9896f7c0c1b75778d833ef8b0a3aa6d2df587444741a172a39f49c1f
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00027-of-00033.gguf 1909864352 35c3703530a17fcf42b8dbe8a582a3fe1be6e5d58885460fd46fd614585bec8b
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00028-of-00033.gguf 1646472000 8d01bec24d38b8876c8a011e04ccfca22584d9f86ea24c13e7e7b07a781cfbba
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00029-of-00033.gguf 1725375264 2b266e2d2a7f610d0a3de55a626e2f9029594c383074240d29c383a8f70e1064
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00030-of-00033.gguf 1738770080 36af1ca74bbf2bd4d79ac78b61a9f5d24e5ca9aac33d298bfbed7d9dbbe86c69
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00031-of-00033.gguf 1646472000 2cf675a6d3df1ff2eb018323c7e64ab14cd650eb38f954e948df27501822fdc1
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00032-of-00033.gguf 1725375264 59c5ab585958f86cecbd812a9ae34f1475d98ffff235d27734964fb53d8b4951
+Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-00033-of-00033.gguf 1220605344 0a7311b24f8636f5b7c0f0dca4f6275ec6b45e326a5eb7400410ca4e32c269c2
+ATOMIC_Q4_ARTIFACTS
+fetch "$ATOMIC_REPO" mmproj-Qwen3.8-Flash-Next-F16.gguf \
+  "$BASE/mmproj-F16.gguf" \
+  904003840 0e61454a76dd154a10aaa8fb1ada32615f55a13e4171014dacd06913e4aa6889
+

--- a/my-apps/ai/llama-cpp/scripts/sync-model-cache.sh
+++ b/my-apps/ai/llama-cpp/scripts/sync-model-cache.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+SRC=/src/qwen3.8-flash-next-gguf
+DST=/dst/qwen3.8-flash-next-gguf
+mkdir -p \
+  "$DST/unsloth-ud-iq4-xs" \
+  "$DST/unsloth-ud-q4-k-xl" \
+  "$DST/atomic-ad-4.27-q4-k-m-m64"
+
+sync_one() {
+  rel="$1"; s="$SRC/$rel"; d="$DST/$rel"
+  want=$(stat -c %s "$s")
+  if [ -f "$d" ] && [ "$(stat -c %s "$d")" = "$want" ]; then
+    echo "present: $rel ($want bytes)"; return
+  fi
+  echo "copying: $rel ($want bytes)"
+  cp "$s" "$d.part" || { rm -f "$d.part"; exit 1; }
+  got=$(stat -c %s "$d.part")
+  [ "$got" = "$want" ] || { echo "SIZE MISMATCH $rel: $got != $want"; rm -f "$d.part"; exit 1; }
+  mv "$d.part" "$d"
+}
+
+for i in 1 2 3; do
+  sync_one "unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-0000$i-of-00003.gguf"
+done
+
+for i in 1 2 3 4; do
+  sync_one "unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-0000$i-of-00004.gguf"
+done
+sync_one "mmproj-BF16.gguf"
+
+i=1
+while [ "$i" -le 33 ]; do
+  shard=$(printf '%05d' "$i")
+  sync_one "atomic-ad-4.27-q4-k-m-m64/Qwen3.8-Flash-Next-AD-4.27bpw-Q4_K_M-M64-${shard}-of-00033.gguf"
+  i=$((i + 1))
+done
+sync_one "mmproj-F16.gguf"
+
+echo "=== RESULT ==="
+du -sb "$DST" | awk '{printf "cache: %s bytes (%.2f GiB)\n", $1, $1/1073741824}'
+df -h /dst
+

--- a/my-apps/ai/ninfer/download-model-job.yaml
+++ b/my-apps/ai/ninfer/download-model-job.yaml
@@ -22,24 +22,7 @@ spec:
         command:
         - /bin/sh
         - -ec
-        - |
-          # Pinned artifact: huggingface.co/neroued/Qwen3.8-27B-NInfer (16.96 GiB, container v2).
-          EXPECTED_SHA="eec39564993d6e9c7d5e383382a760f093465c9d163ec9a1bd6b80199514bf3e"
-          URL="https://huggingface.co/neroued/Qwen3.8-27B-NInfer/resolve/main/qwen3_8_27b.ninfer"
-          F=/models/ninfer/qwen3_8_27b.ninfer
-          mkdir -p /models/ninfer
-          if [ -f "$F" ] && [ "$(stat -c %s "$F")" = "18210531328" ]; then
-            echo "size matches, verifying sha256..."
-            if [ "$(sha256sum "$F" | cut -d' ' -f1)" = "$EXPECTED_SHA" ]; then
-              echo "artifact present and verified"; exit 0
-            fi
-            echo "sha mismatch — re-downloading"
-          fi
-          apk add --no-cache curl
-          curl -fL -C - --retry 5 -o "$F" "$URL"
-          ACTUAL="$(sha256sum "$F" | cut -d' ' -f1)"
-          [ "$ACTUAL" = "$EXPECTED_SHA" ] || { echo "SHA MISMATCH: $ACTUAL"; rm -f "$F"; exit 1; }
-          echo "downloaded and verified: $F"
+        - /opt/repo-scripts/download-model.sh
         resources:
           requests:
             cpu: 100m
@@ -49,9 +32,16 @@ spec:
             # repeatedly killed mid-download (~2-3 GiB per attempt, resume proved it).
             memory: 4Gi
         volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
         - name: models
           mountPath: /models
       volumes:
+      - name: repo-scripts
+        configMap:
+          name: ninfer-scripts
+          defaultMode: 0555
       - name: models
         persistentVolumeClaim:
           claimName: ninfer-models-pvc

--- a/my-apps/ai/ninfer/kustomization.yaml
+++ b/my-apps/ai/ninfer/kustomization.yaml
@@ -10,3 +10,8 @@ resources:
 - service.yaml
 - httproute.yaml
 - vpa.yaml
+
+configMapGenerator:
+- name: ninfer-scripts
+  files:
+  - scripts/download-model.sh

--- a/my-apps/ai/ninfer/scripts/download-model.sh
+++ b/my-apps/ai/ninfer/scripts/download-model.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Pinned artifact: huggingface.co/neroued/Qwen3.8-27B-NInfer (16.96 GiB, container v2).
+EXPECTED_SHA="eec39564993d6e9c7d5e383382a760f093465c9d163ec9a1bd6b80199514bf3e"
+URL="https://huggingface.co/neroued/Qwen3.8-27B-NInfer/resolve/main/qwen3_8_27b.ninfer"
+F=/models/ninfer/qwen3_8_27b.ninfer
+mkdir -p /models/ninfer
+if [ -f "$F" ] && [ "$(stat -c %s "$F")" = "18210531328" ]; then
+  echo "size matches, verifying sha256..."
+  if [ "$(sha256sum "$F" | cut -d' ' -f1)" = "$EXPECTED_SHA" ]; then
+    echo "artifact present and verified"; exit 0
+  fi
+  echo "sha mismatch — re-downloading"
+fi
+apk add --no-cache curl
+curl -fL -C - --retry 5 -o "$F" "$URL"
+ACTUAL="$(sha256sum "$F" | cut -d' ' -f1)"
+[ "$ACTUAL" = "$EXPECTED_SHA" ] || { echo "SHA MISMATCH: $ACTUAL"; rm -f "$F"; exit 1; }
+echo "downloaded and verified: $F"
+

--- a/my-apps/ai/open-webui/function-loader-job.yaml
+++ b/my-apps/ai/open-webui/function-loader-job.yaml
@@ -26,144 +26,14 @@ spec:
         image: ghcr.io/open-webui/open-webui:main@sha256:c792953395b43d4f49085fa4026850c5e923578345ebeaf56eabd980bcfc273a
         command:
         - python3
-        - -c
-        - |
-          import sys
-          import os
-          import asyncio
-
-          sys.path.insert(0, "/app/backend")
-          os.environ.setdefault("DATA_DIR", "/app/backend/data")
-
-          FUNCTIONS = [
-              {
-                  "id": "har_forensics_analyzer",
-                  "name": "HAR Forensics Analyzer",
-                  "path": "/functions/har-analyzer-function.py",
-                  "description": "Filter: preprocesses uploaded .har files into forensic reports for LLM analysis",
-              },
-              {
-                  "id": "tokens_per_second",
-                  "name": "Tokens Per Second",
-                  "path": "/functions/tokens-per-second-function.py",
-                  "description": "Filter: injects response_token/s + prompt_token/s into streamed usage stats",
-              },
-              {
-                  "id": "qwen_non_thinking_default",
-                  "name": "Qwen3.8 Non-Thinking Default",
-                  "path": "/functions/qwen-no-think-filter.py",
-                  "description": "Filter: forces qwen3.8-27b requests to use enable_thinking=false",
-              },
-          ]
-
-          from open_webui.models.functions import Functions, FunctionForm, FunctionMeta
-          from open_webui.models.users import Users
-
-
-          def _maybe_await(value):
-              """Await `value` if it is a coroutine, else return as-is.
-              Open-WebUI converted these ORM methods from sync to async; this
-              keeps the script working across both shapes."""
-              import inspect
-              if inspect.iscoroutine(value):
-                  return value
-              async def _wrap():
-                  return value
-              return _wrap()
-
-
-          def _extract_users_list(users_data):
-              """get_users() may return a dict {"users": [...]}, a list, or a
-              Pydantic model with a `.users` attribute. Normalize all three."""
-              if users_data is None:
-                  return []
-              if isinstance(users_data, dict) and "users" in users_data:
-                  return users_data["users"]
-              if isinstance(users_data, list):
-                  return users_data
-              if hasattr(users_data, "users"):
-                  return users_data.users
-              return []
-
-
-          async def load_function(admin_id, spec):
-              with open(spec["path"]) as f:
-                  code = f.read()
-
-              existing = await _maybe_await(Functions.get_function_by_id(spec["id"]))
-
-              if existing:
-                  result = await _maybe_await(
-                      Functions.update_function_by_id(
-                          spec["id"],
-                          {
-                              "name": spec["name"],
-                              "type": "filter",
-                              "content": code,
-                              "meta": {"description": spec["description"]},
-                              "is_active": True,
-                              "is_global": True,
-                          },
-                      )
-                  )
-                  if result is None:
-                      print(f"ERROR: Failed to update function {spec['id']}")
-                      sys.exit(1)
-                  print(f"Updated function: {result.id}")
-              else:
-                  form = FunctionForm(
-                      id=spec["id"],
-                      name=spec["name"],
-                      type="filter",
-                      content=code,
-                      meta=FunctionMeta(description=spec["description"]),
-                  )
-                  result = await _maybe_await(
-                      Functions.insert_new_function(admin_id, "filter", form)
-                  )
-                  if result is None:
-                      print(f"ERROR: Failed to create function {spec['id']}")
-                      sys.exit(1)
-                  await _maybe_await(
-                      Functions.update_function_by_id(
-                          spec["id"], {"is_active": True, "is_global": True}
-                      )
-                  )
-                  print(f"Created function: {result.id}")
-
-              # Re-read to confirm the active/global flags actually stuck.
-              final = await _maybe_await(Functions.get_function_by_id(spec["id"]))
-              if final is not None:
-                  print(
-                      f"{spec['id']} Active: {getattr(final, 'is_active', '?')}, "
-                      f"Global: {getattr(final, 'is_global', '?')}"
-                  )
-
-
-          async def main():
-              # Find first admin user
-              users_data = await _maybe_await(Users.get_users())
-              admin_id = None
-              for u in _extract_users_list(users_data):
-                  if getattr(u, "role", None) == "admin":
-                      admin_id = u.id
-                      break
-
-              if not admin_id:
-                  print("WARNING: No admin user found, using placeholder ID")
-                  admin_id = "system"
-
-              for spec in FUNCTIONS:
-                  await load_function(admin_id, spec)
-
-              print("Done!")
-
-
-          asyncio.run(main())
+        - /opt/repo-scripts/load-functions.py
         envFrom:
         - configMapRef:
             name: open-webui-configmap
         volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
         - name: har-function
           mountPath: /functions/har-analyzer-function.py
           subPath: har-analyzer-function.py
@@ -176,6 +46,10 @@ spec:
         - name: data
           mountPath: /app/backend/data
       volumes:
+      - name: repo-scripts
+        configMap:
+          name: open-webui-scripts
+          defaultMode: 0555
       - name: har-function
         configMap:
           name: har-analyzer-function

--- a/my-apps/ai/open-webui/kustomization.yaml
+++ b/my-apps/ai/open-webui/kustomization.yaml
@@ -19,6 +19,9 @@ components:
   - ../../common/kopiur-backup
 
 configMapGenerator:
+- name: open-webui-scripts
+  files:
+  - scripts/load-functions.py
 - name: open-webui-loader
   files:
   - loader.js

--- a/my-apps/ai/open-webui/scripts/load-functions.py
+++ b/my-apps/ai/open-webui/scripts/load-functions.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+import sys
+import os
+import asyncio
+
+sys.path.insert(0, "/app/backend")
+os.environ.setdefault("DATA_DIR", "/app/backend/data")
+
+FUNCTIONS = [
+    {
+        "id": "har_forensics_analyzer",
+        "name": "HAR Forensics Analyzer",
+        "path": "/functions/har-analyzer-function.py",
+        "description": "Filter: preprocesses uploaded .har files into forensic reports for LLM analysis",
+    },
+    {
+        "id": "tokens_per_second",
+        "name": "Tokens Per Second",
+        "path": "/functions/tokens-per-second-function.py",
+        "description": "Filter: injects response_token/s + prompt_token/s into streamed usage stats",
+    },
+    {
+        "id": "qwen_non_thinking_default",
+        "name": "Qwen3.8 Non-Thinking Default",
+        "path": "/functions/qwen-no-think-filter.py",
+        "description": "Filter: forces qwen3.8-27b requests to use enable_thinking=false",
+    },
+]
+
+from open_webui.models.functions import Functions, FunctionForm, FunctionMeta
+from open_webui.models.users import Users
+
+
+def _maybe_await(value):
+    """Await `value` if it is a coroutine, else return as-is.
+    Open-WebUI converted these ORM methods from sync to async; this
+    keeps the script working across both shapes."""
+    import inspect
+    if inspect.iscoroutine(value):
+        return value
+    async def _wrap():
+        return value
+    return _wrap()
+
+
+def _extract_users_list(users_data):
+    """get_users() may return a dict {"users": [...]}, a list, or a
+    Pydantic model with a `.users` attribute. Normalize all three."""
+    if users_data is None:
+        return []
+    if isinstance(users_data, dict) and "users" in users_data:
+        return users_data["users"]
+    if isinstance(users_data, list):
+        return users_data
+    if hasattr(users_data, "users"):
+        return users_data.users
+    return []
+
+
+async def load_function(admin_id, spec):
+    with open(spec["path"]) as f:
+        code = f.read()
+
+    existing = await _maybe_await(Functions.get_function_by_id(spec["id"]))
+
+    if existing:
+        result = await _maybe_await(
+            Functions.update_function_by_id(
+                spec["id"],
+                {
+                    "name": spec["name"],
+                    "type": "filter",
+                    "content": code,
+                    "meta": {"description": spec["description"]},
+                    "is_active": True,
+                    "is_global": True,
+                },
+            )
+        )
+        if result is None:
+            print(f"ERROR: Failed to update function {spec['id']}")
+            sys.exit(1)
+        print(f"Updated function: {result.id}")
+    else:
+        form = FunctionForm(
+            id=spec["id"],
+            name=spec["name"],
+            type="filter",
+            content=code,
+            meta=FunctionMeta(description=spec["description"]),
+        )
+        result = await _maybe_await(
+            Functions.insert_new_function(admin_id, "filter", form)
+        )
+        if result is None:
+            print(f"ERROR: Failed to create function {spec['id']}")
+            sys.exit(1)
+        await _maybe_await(
+            Functions.update_function_by_id(
+                spec["id"], {"is_active": True, "is_global": True}
+            )
+        )
+        print(f"Created function: {result.id}")
+
+    # Re-read to confirm the active/global flags actually stuck.
+    final = await _maybe_await(Functions.get_function_by_id(spec["id"]))
+    if final is not None:
+        print(
+            f"{spec['id']} Active: {getattr(final, 'is_active', '?')}, "
+            f"Global: {getattr(final, 'is_global', '?')}"
+        )
+
+
+async def main():
+    # Find first admin user
+    users_data = await _maybe_await(Users.get_users())
+    admin_id = None
+    for u in _extract_users_list(users_data):
+        if getattr(u, "role", None) == "admin":
+            admin_id = u.id
+            break
+
+    if not admin_id:
+        print("WARNING: No admin user found, using placeholder ID")
+        admin_id = "system"
+
+    for spec in FUNCTIONS:
+        await load_function(admin_id, spec)
+
+    print("Done!")
+
+
+asyncio.run(main())
+

--- a/my-apps/ai/perplexica/deployment.yaml
+++ b/my-apps/ai/perplexica/deployment.yaml
@@ -29,26 +29,11 @@ spec:
           command:
             - /bin/sh
             - -c
-            - |
-              set -eu
-              apk add --no-cache jq >/dev/null
-              SEED=/seed/config.json
-              DEST=/data/config.json
-              mkdir -p /data
-              if [ ! -s "$DEST" ]; then
-                echo "[seed] fresh PVC, writing config.json verbatim"
-                cp "$SEED" "$DEST"
-              else
-                echo "[seed] merging modelProviders + search from seed into existing config.json"
-                jq --slurpfile seed "$SEED" \
-                   '.modelProviders = $seed[0].modelProviders
-                    | .search = $seed[0].search' \
-                   "$DEST" > "$DEST.tmp"
-                mv "$DEST.tmp" "$DEST"
-              fi
-              echo "[seed] done. providers now:"
-              jq -r '.modelProviders[] | "  - \(.name) (\(.type)) — \(.chatModels | length) models"' "$DEST"
+            - /opt/repo-scripts/seed-config.sh
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: seed
               mountPath: /seed
             - name: data
@@ -109,6 +94,10 @@ spec:
             limits:
               memory: 4Gi
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: perplexica-scripts
+            defaultMode: 0555
         - name: data
           persistentVolumeClaim:
             claimName: perplexica-data

--- a/my-apps/ai/perplexica/kustomization.yaml
+++ b/my-apps/ai/perplexica/kustomization.yaml
@@ -18,6 +18,9 @@ components:
 # Model-provider seed for the initContainer. Hash-suffixed so any
 # config.json change auto-rolls the deployment.
 configMapGenerator:
+  - name: perplexica-scripts
+    files:
+      - scripts/seed-config.sh
   - name: perplexica-config-seed
     files:
       - config.json

--- a/my-apps/ai/perplexica/scripts/seed-config.sh
+++ b/my-apps/ai/perplexica/scripts/seed-config.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+apk add --no-cache jq >/dev/null
+SEED=/seed/config.json
+DEST=/data/config.json
+mkdir -p /data
+if [ ! -s "$DEST" ]; then
+  echo "[seed] fresh PVC, writing config.json verbatim"
+  cp "$SEED" "$DEST"
+else
+  echo "[seed] merging modelProviders + search from seed into existing config.json"
+  jq --slurpfile seed "$SEED" \
+     '.modelProviders = $seed[0].modelProviders
+      | .search = $seed[0].search' \
+     "$DEST" > "$DEST.tmp"
+  mv "$DEST.tmp" "$DEST"
+fi
+echo "[seed] done. providers now:"
+jq -r '.modelProviders[] | "  - \(.name) (\(.type)) — \(.chatModels | length) models"' "$DEST"
+

--- a/my-apps/ai/vllm/cache-sync-job.yaml
+++ b/my-apps/ai/vllm/cache-sync-job.yaml
@@ -28,55 +28,7 @@ spec:
           command:
             - /bin/sh
             - -ec
-            - |
-              MODEL=Qwen3.8-27B-W4A16-AutoRound-3090-int8lmhead
-              REVISION=$MODEL:r1 # Bump here and in deployment.yaml for in-place source changes.
-              SRC=/src/$MODEL
-              DST=/dst/$MODEL
-              STATE=/dst/.vllm-cache-revision
-              READY=/dst/.vllm-sync-complete
-              STATE_TMP=$STATE.part
-              READY_TMP=$READY.part
-              mkdir -p "$DST"
-
-              # The Deployment may land before this Sync hook, so publish readiness last.
-              LAST_REVISION=$(cat "$STATE" 2>/dev/null || true)
-              FORCE_COPY=0
-              if [ -n "$LAST_REVISION" ] && [ "$LAST_REVISION" != "$REVISION" ]; then
-                FORCE_COPY=1
-              fi
-              rm -f "$READY" "$STATE_TMP" "$READY_TMP"
-
-              [ -d "$SRC" ] || { echo "MISSING SOURCE: $SRC"; exit 1; }
-
-              sync_one() {
-                rel="$1"; s="$SRC/$rel"; d="$DST/$rel"
-                want=$(stat -c %s "$s")
-                if [ "$FORCE_COPY" -eq 0 ] && [ -f "$d" ] && [ "$(stat -c %s "$d")" = "$want" ]; then
-                  echo "present: $rel ($want bytes)"; return
-                fi
-                echo "copying: $rel ($want bytes)"
-                cp "$s" "$d.part" || { rm -f "$d.part"; exit 1; }
-                got=$(stat -c %s "$d.part")
-                [ "$got" = "$want" ] || { echo "SIZE MISMATCH $rel: $got != $want"; rm -f "$d.part"; exit 1; }
-                mv "$d.part" "$d"
-              }
-
-              # Whole checkpoint dir, flat — weights plus tokenizer/config/template
-              # files. vLLM refuses to load if any of them is missing.
-              for f in $(ls -1 "$SRC"); do
-                [ -f "$SRC/$f" ] && sync_one "$f"
-              done
-
-              printf '%s\n' "$REVISION" > "$STATE_TMP"
-              mv "$STATE_TMP" "$STATE"
-              printf '%s\n' "$REVISION" > "$READY_TMP"
-              mv "$READY_TMP" "$READY"
-
-              echo "=== RESULT ==="
-              ls -1 "$DST" | wc -l | awk '{print "files: " $1}'
-              du -sb "$DST" | awk '{printf "model: %s bytes (%.2f GiB)\n", $1, $1/1073741824}'
-              df -h /dst
+            - /opt/repo-scripts/sync-model-cache.sh
           resources:
             requests:
               cpu: 500m
@@ -86,6 +38,9 @@ spec:
             limits:
               memory: 2Gi
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: src
               mountPath: /src
               readOnly: true
@@ -93,6 +48,10 @@ spec:
               mountPath: /dst
               subPath: vllm
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: vllm-scripts
+            defaultMode: 0555
         - name: src
           persistentVolumeClaim:
             claimName: vllm-models-pvc

--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -44,24 +44,14 @@ spec:
           command:
             - /bin/sh
             - -ec
-            - |
-              MODEL=Qwen3.8-27B-W4A16-AutoRound-3090-int8lmhead
-              REVISION=$MODEL:r1
-              READY=/models/.vllm-sync-complete
-              i=0
-              until [ "$(cat "$READY" 2>/dev/null)" = "$REVISION" ]; do
-                i=$((i + 1))
-                if [ "$i" -gt 360 ]; then
-                  echo "TIMEOUT: cache-sync never completed (60m)"; exit 1
-                fi
-                echo "waiting for vllm-cache-sync to finish hydrating the NVMe cache..."
-                sleep 10
-              done
-              echo "cache ready: $MODEL"
+            - /opt/repo-scripts/wait-for-model-cache.sh
           resources:
             requests: { cpu: 10m, memory: 16Mi }
             limits: { memory: 64Mi }
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: models
               mountPath: /models
               subPath: vllm
@@ -182,6 +172,10 @@ spec:
               mountPath: /root/.triton/cache
               subPath: triton
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: vllm-scripts
+            defaultMode: 0555
         # Node-local NVMe, NOT the NFS PVC. cache-sync-job.yaml hydrates it from
         # NFS at wave 0; NFS stays the canonical archive and out of the serve path.
         - name: models

--- a/my-apps/ai/vllm/kustomization.yaml
+++ b/my-apps/ai/vllm/kustomization.yaml
@@ -14,3 +14,9 @@ resources:
   - service.yaml
   - httproute.yaml
   - servicemonitor.yaml
+
+configMapGenerator:
+  - name: vllm-scripts
+    files:
+      - scripts/sync-model-cache.sh
+      - scripts/wait-for-model-cache.sh

--- a/my-apps/ai/vllm/scripts/sync-model-cache.sh
+++ b/my-apps/ai/vllm/scripts/sync-model-cache.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+MODEL=Qwen3.8-27B-W4A16-AutoRound-3090-int8lmhead
+REVISION=$MODEL:r1 # Bump here and in deployment.yaml for in-place source changes.
+SRC=/src/$MODEL
+DST=/dst/$MODEL
+STATE=/dst/.vllm-cache-revision
+READY=/dst/.vllm-sync-complete
+STATE_TMP=$STATE.part
+READY_TMP=$READY.part
+mkdir -p "$DST"
+
+# The Deployment may land before this Sync hook, so publish readiness last.
+LAST_REVISION=$(cat "$STATE" 2>/dev/null || true)
+FORCE_COPY=0
+if [ -n "$LAST_REVISION" ] && [ "$LAST_REVISION" != "$REVISION" ]; then
+  FORCE_COPY=1
+fi
+rm -f "$READY" "$STATE_TMP" "$READY_TMP"
+
+[ -d "$SRC" ] || { echo "MISSING SOURCE: $SRC"; exit 1; }
+
+sync_one() {
+  rel="$1"; s="$SRC/$rel"; d="$DST/$rel"
+  want=$(stat -c %s "$s")
+  if [ "$FORCE_COPY" -eq 0 ] && [ -f "$d" ] && [ "$(stat -c %s "$d")" = "$want" ]; then
+    echo "present: $rel ($want bytes)"; return
+  fi
+  echo "copying: $rel ($want bytes)"
+  cp "$s" "$d.part" || { rm -f "$d.part"; exit 1; }
+  got=$(stat -c %s "$d.part")
+  [ "$got" = "$want" ] || { echo "SIZE MISMATCH $rel: $got != $want"; rm -f "$d.part"; exit 1; }
+  mv "$d.part" "$d"
+}
+
+# Whole checkpoint dir, flat — weights plus tokenizer/config/template
+# files. vLLM refuses to load if any of them is missing.
+for path in "$SRC"/*; do
+  [ -f "$path" ] && sync_one "${path##*/}"
+done
+
+printf '%s\n' "$REVISION" > "$STATE_TMP"
+mv "$STATE_TMP" "$STATE"
+printf '%s\n' "$REVISION" > "$READY_TMP"
+mv "$READY_TMP" "$READY"
+
+echo "=== RESULT ==="
+ls -1 "$DST" | wc -l | awk '{print "files: " $1}'
+du -sb "$DST" | awk '{printf "model: %s bytes (%.2f GiB)\n", $1, $1/1073741824}'
+df -h /dst

--- a/my-apps/ai/vllm/scripts/wait-for-model-cache.sh
+++ b/my-apps/ai/vllm/scripts/wait-for-model-cache.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+MODEL=Qwen3.8-27B-W4A16-AutoRound-3090-int8lmhead
+REVISION=$MODEL:r1
+READY=/models/.vllm-sync-complete
+i=0
+until [ "$(cat "$READY" 2>/dev/null)" = "$REVISION" ]; do
+  i=$((i + 1))
+  if [ "$i" -gt 360 ]; then
+    echo "TIMEOUT: cache-sync never completed (60m)"; exit 1
+  fi
+  echo "waiting for vllm-cache-sync to finish hydrating the NVMe cache..."
+  sleep 10
+done
+echo "cache ready: $MODEL"
+

--- a/my-apps/development/gitea-actions/deployment.yaml
+++ b/my-apps/development/gitea-actions/deployment.yaml
@@ -93,20 +93,9 @@ spec:
           command:
             - sh
             - -c
-            - |
-              while true; do
-                # Wait for dockerd before first prune (pod fresh-start case)
-                for i in $(seq 1 30); do
-                  docker info >/dev/null 2>&1 && break
-                  sleep 2
-                done
-                echo "[prune] starting cycle at $(date -u)"
-                docker buildx prune -af --keep-storage 20GB --filter until=24h 2>&1 || true
-                docker system prune -af --filter "until=72h" 2>&1 || true
-                df -h /var/lib/docker 2>/dev/null || true
-                sleep 21600
-              done
+            - /opt/repo-scripts/prune-docker-cache.sh
           volumeMounts:
+            - { name: repo-scripts, mountPath: /opt/repo-scripts, readOnly: true }
             - { name: var-run, mountPath: /var/run }
           resources:
             requests:
@@ -116,6 +105,10 @@ spec:
               memory: 128Mi
 
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: gitea-actions-scripts
+            defaultMode: 0555
         - { name: var-run, emptyDir: {} }
         - { name: data,    emptyDir: {} }
         # PVC, not emptyDir: keeps the 3 GB catthehacker image + base layers warm across restarts (pvc.yaml).

--- a/my-apps/development/gitea-actions/kustomization.yaml
+++ b/my-apps/development/gitea-actions/kustomization.yaml
@@ -9,4 +9,9 @@ resources:
   - pvc.yaml
   - deployment.yaml
 
+configMapGenerator:
+  - name: gitea-actions-scripts
+    files:
+      - scripts/prune-docker-cache.sh
+
 # act-runner-token: 1Password item `gitea` field `act_runner_token`; it survives nukes via the restored gitea DB.

--- a/my-apps/development/gitea-actions/scripts/prune-docker-cache.sh
+++ b/my-apps/development/gitea-actions/scripts/prune-docker-cache.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+while true; do
+  # Wait for dockerd before first prune (pod fresh-start case)
+  for _ in $(seq 1 30); do
+    docker info >/dev/null 2>&1 && break
+    sleep 2
+  done
+  echo "[prune] starting cycle at $(date -u)"
+  docker buildx prune -af --keep-storage 20GB --filter until=24h 2>&1 || true
+  docker system prune -af --filter "until=72h" 2>&1 || true
+  df -h /var/lib/docker 2>/dev/null || true
+  sleep 21600
+done

--- a/my-apps/development/gitea/fix-permissions-patch.yaml
+++ b/my-apps/development/gitea/fix-permissions-patch.yaml
@@ -11,8 +11,11 @@ spec:
         command:
         - sh
         - -c
-        - chown -R 1000:1000 /data && chmod -R 700 /data/git/.ssh 2>/dev/null; true
+        - /opt/repo-scripts/fix-permissions.sh
         volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
         - name: data
           mountPath: /data
         securityContext:
@@ -24,3 +27,8 @@ spec:
             - DAC_OVERRIDE
             drop:
             - NET_RAW
+      volumes:
+      - name: repo-scripts
+        configMap:
+          name: gitea-scripts
+          defaultMode: 0555

--- a/my-apps/development/gitea/kustomization.yaml
+++ b/my-apps/development/gitea/kustomization.yaml
@@ -27,6 +27,11 @@ helmCharts:
   namespace: gitea
   valuesFile: values.yaml
 
+configMapGenerator:
+- name: gitea-scripts
+  files:
+  - scripts/fix-permissions.sh
+
 patches:
 - path: fix-permissions-patch.yaml
   target:

--- a/my-apps/development/gitea/scripts/fix-permissions.sh
+++ b/my-apps/development/gitea/scripts/fix-permissions.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+chown -R 1000:1000 /data
+chmod -R 700 /data/git/.ssh 2>/dev/null || true

--- a/my-apps/development/posthog/core/capture.yaml
+++ b/my-apps/development/posthog/core/capture.yaml
@@ -176,11 +176,11 @@ spec:
           command:
             - /bin/sh
             - -c
-            - |
-              cp /code/share/GeoLite2-City.mmdb /share/GeoLite2-City.mmdb
-              ls -la /share/GeoLite2-City.mmdb
-              echo "GeoIP database copied successfully"
+            - /opt/repo-scripts/copy-geoip.sh
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: geoip-data
               mountPath: /share
       containers:
@@ -251,6 +251,10 @@ spec:
             limits:
               memory: 512Mi
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: posthog-scripts
+            defaultMode: 0555
         - name: geoip-data
           emptyDir: {}
 ---

--- a/my-apps/development/posthog/core/clickhouse-init.yaml
+++ b/my-apps/development/posthog/core/clickhouse-init.yaml
@@ -26,78 +26,13 @@ spec:
         command:
         - sh
         - -c
-        - |
-          set -e
-          echo "Waiting for ClickHouse..."
-          TIMEOUT=120
-          ELAPSED=0
-          until clickhouse-client --host=clickhouse --port=9000 --query="SELECT 1" &> /dev/null; do
-            echo "ClickHouse not ready yet (elapsed: ${ELAPSED}s)..."
-            sleep 2
-            ELAPSED=$((ELAPSED + 2))
-            if [ $ELAPSED -ge $TIMEOUT ]; then
-                echo "Timeout waiting for ClickHouse after ${TIMEOUT}s"
-                exit 1
-            fi
-          done
-          echo "ClickHouse is ready."
-
-          echo "Initializing ClickHouse migration tables..."
-
-          # Create the base migration tracking table (Replicated)
-          clickhouse-client --host=clickhouse --port=9000 --query "
-          CREATE TABLE IF NOT EXISTS posthog.infi_clickhouse_orm_migrations (
-            module_name String,
-            package_name String,
-            applied Date
-          ) ENGINE = ReplicatedMergeTree(
-            '/posthog/tables/infi_clickhouse_orm_migrations',
-            'replica_{replica}'
-          )
-          ORDER BY (module_name, package_name)
-          SETTINGS index_granularity = 8192;
-          "
-
-          # Create the distributed view for cross-shard queries
-          clickhouse-client --host=clickhouse --port=9000 --query "
-          CREATE TABLE IF NOT EXISTS posthog.infi_clickhouse_orm_migrations_distributed AS posthog.infi_clickhouse_orm_migrations
-          ENGINE = Distributed(
-            'posthog_migrations',
-            'posthog',
-            'infi_clickhouse_orm_migrations'
-          );
-          "
-
-          echo "ClickHouse migration tables initialized successfully"
-
-          # sharded_events must be a real local table cloned from posthog.events: migration 0031 ALTERs it, and
-          # ingest (writable_events Distributed -> sharded_events) silently drops rows without it.
-          echo "Creating sharded_events local table mirroring events columns..."
-          clickhouse-client --host=clickhouse --port=9000 --query "
-          CREATE TABLE IF NOT EXISTS posthog.sharded_events ON CLUSTER 'posthog'
-          AS posthog.events
-          ENGINE = ReplicatedReplacingMergeTree(
-            '/clickhouse/tables/{shard}/posthog.sharded_events',
-            '{replica}',
-            _timestamp
-          )
-          PARTITION BY toYYYYMM(timestamp)
-          ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
-          SAMPLE BY cityHash64(distinct_id)
-          SETTINGS index_granularity = 8192;
-          " || echo "  sharded_events likely already exists with prior schema — skipping"
-          echo "  sharded_events ready"
-
-          # Force-create lazy system log tables that PostHog migrations depend on
-          echo "Ensuring system log tables exist..."
-          clickhouse-client --host=clickhouse --port=9000 --query "SYSTEM FLUSH LOGS" || true
-          for table in crash_log part_log trace_log; do
-            clickhouse-client --host=clickhouse --port=9000 --query "SELECT 1 FROM system.${table} LIMIT 0" 2>/dev/null && \
-              echo "  system.${table} exists" || \
-              echo "  system.${table} not yet created (ok - not needed until first event)"
-          done
-
-          # Verify tables exist
-          clickhouse-client --host=clickhouse --port=9000 --query "
-          SHOW TABLES IN posthog WHERE name LIKE '%infi_clickhouse_orm_migrations%'
-          "
+        - /opt/repo-scripts/init-clickhouse.sh
+        volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
+      volumes:
+      - name: repo-scripts
+        configMap:
+          name: posthog-scripts
+          defaultMode: 0555

--- a/my-apps/development/posthog/core/jobs.yaml
+++ b/my-apps/development/posthog/core/jobs.yaml
@@ -26,34 +26,16 @@ spec:
         command:
         - /bin/sh
         - -c
-        - |
-          set -x
-          echo "Waiting for Kafka broker to accept connections..."
-          TIMEOUT=120
-          ELAPSED=0
-          until rpk topic list --brokers kafka:9092 2>/dev/null; do
-              echo "Kafka broker not ready yet (elapsed: ${ELAPSED}s)..."
-              sleep 2
-              ELAPSED=$((ELAPSED + 2))
-              if [ $ELAPSED -ge $TIMEOUT ]; then
-                  echo "Timeout waiting for Kafka broker after ${TIMEOUT}s"
-                  exit 1
-              fi
-          done
-          echo "Kafka broker is accepting requests, creating topics..."
-          for topic in events_plugin_ingestion exceptions_ingestion clickhouse_events_json session_recording_events session_recording_events2 session_recording_snapshot_item_events clickhouse_app_metrics2 logs_ingestion ai_events_ingestion clickhouse_ai_events_json; do
-              if rpk topic create "$topic" --brokers kafka:9092 -p 1 -r 1 2>&1; then
-                  echo "Topic $topic created successfully"
-              else
-                  if rpk topic list --brokers kafka:9092 | grep -q "$topic"; then
-                      echo "Topic $topic already exists, continuing"
-                  else
-                      echo "Failed to create topic $topic"
-                      exit 1
-                  fi
-              fi
-          done
-          echo "Topics ready"
+        - /opt/repo-scripts/init-kafka.sh
+        volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
+      volumes:
+      - name: repo-scripts
+        configMap:
+          name: posthog-scripts
+          defaultMode: 0555
 ---
 apiVersion: batch/v1
 kind: Job
@@ -86,56 +68,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - |
-          set -e
-          echo "Waiting for Postgres..."
-          TIMEOUT=120; ELAPSED=0
-          until python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('db', 5432))" 2>/dev/null; do
-            sleep 2; ELAPSED=$((ELAPSED + 2))
-            [ $ELAPSED -ge $TIMEOUT ] && echo "Postgres timeout" && exit 1
-          done
-          echo "Postgres ready"
-          echo "Waiting for ClickHouse..."
-          ELAPSED=0
-          until wget -q --spider --timeout=2 http://clickhouse:8123/ping 2>/dev/null; do
-            sleep 2; ELAPSED=$((ELAPSED + 2))
-            [ $ELAPSED -ge $TIMEOUT ] && echo "ClickHouse timeout" && exit 1
-          done
-          echo "ClickHouse ready"
-          echo "Flushing ClickHouse system logs..."
-          wget -q -O- "http://clickhouse:8123/?query=SYSTEM+FLUSH+LOGS" 2>/dev/null || true
-          echo "Running Django migrations..."
-          python manage.py migrate --noinput
-          # MUST run AFTER manage.py migrate: posthog_person doesn't exist on a fresh DB. IF NOT EXISTS keeps it idempotent.
-          echo "Applying self-hosted Postgres schema guards..."
-          python - <<'PY'
-          import os
-
-          os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
-
-          import django
-
-          django.setup()
-
-          from django.db import connection
-
-          with connection.cursor() as cursor:
-              cursor.execute(
-                  "ALTER TABLE public.posthog_person "
-                  "ADD COLUMN IF NOT EXISTS last_seen_at timestamptz NULL"
-              )
-              # Library is preloaded via postgres args; without the extension the
-              # hourly monitoring task errors in the db log.
-              cursor.execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
-          PY
-          echo "Running ClickHouse migrations..."
-          python manage.py migrate_clickhouse
-          # --check is the gate: a pending required migration fails the Job and the sync (beats a silent worker CrashLoop). Never remove.
-          # Single-node CH gotcha: 0007* queries posthog.sharded_events; if hit, mark Complete in the PostHog admin and re-sync.
-          echo "Running async ClickHouse migrations..."
-          python manage.py run_async_migrations || true
-          python manage.py run_async_migrations --check
-          echo "All migrations complete"
+        - /opt/repo-scripts/migrate.sh
         envFrom:
         - configMapRef:
             name: posthog-env
@@ -166,6 +99,15 @@ spec:
             memory: 2Gi
           limits:
             memory: 4Gi
+        volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
+      volumes:
+      - name: repo-scripts
+        configMap:
+          name: posthog-scripts
+          defaultMode: 0555
 ---
 apiVersion: batch/v1
 kind: Job
@@ -197,38 +139,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - |
-          set -e
-          echo "Waiting for Postgres..."
-          TIMEOUT=120; ELAPSED=0
-          until python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('db', 5432))" 2>/dev/null; do
-            sleep 2; ELAPSED=$((ELAPSED + 2))
-            [ $ELAPSED -ge $TIMEOUT ] && echo "Postgres timeout" && exit 1
-          done
-          echo "Waiting for Redis..."
-          ELAPSED=0
-          until python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('redis7', 6379))" 2>/dev/null; do
-            sleep 2; ELAPSED=$((ELAPSED + 2))
-            [ $ELAPSED -ge $TIMEOUT ] && echo "Redis timeout" && exit 1
-          done
-          # RemoteConfig.sync() diffs against Postgres, not Redis — a wiped Redis is never repaired without force=True (flags go all-false, replay stops).
-          echo "Force-syncing RemoteConfig to Redis..."
-          python - <<'PY'
-          import os
-
-          os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
-
-          import django
-
-          django.setup()
-
-          from posthog.models.remote_config import RemoteConfig
-
-          for remote_config in RemoteConfig.objects.all():
-              remote_config.sync(force=True)
-              print(f"force-synced team {remote_config.team_id}")
-          PY
-          echo "RemoteConfig sync complete"
+        - /opt/repo-scripts/sync-remote-config.sh
         envFrom:
         - configMapRef:
             name: posthog-env
@@ -269,3 +180,12 @@ spec:
             memory: 1Gi
           limits:
             memory: 2Gi
+        volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
+      volumes:
+      - name: repo-scripts
+        configMap:
+          name: posthog-scripts
+          defaultMode: 0555

--- a/my-apps/development/posthog/data-layer/kafka.yaml
+++ b/my-apps/development/posthog/data-layer/kafka.yaml
@@ -61,22 +61,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - |
-          rpk redpanda config set redpanda.auto_create_topics_enabled true &&
-          rpk redpanda config set redpanda.empty_seed_starts_cluster true &&
-          exec rpk redpanda start \
-            --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092 \
-            --advertise-kafka-addr internal://kafka:9092,external://localhost:19092 \
-            --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082 \
-            --advertise-pandaproxy-addr internal://kafka:8082,external://localhost:18082 \
-            --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081 \
-            --rpc-addr 0.0.0.0:33145 \
-            --advertise-rpc-addr kafka:33145 \
-            --smp 1 \
-            --memory 1G \
-            --reserve-memory 200M \
-            --overprovisioned \
-            --unsafe-bypass-fsync
+        - /opt/repo-scripts/start-kafka.sh
         env:
         - name: ALLOW_PLAINTEXT_LISTENER
           value: "true"
@@ -102,9 +87,16 @@ spec:
           limits:
             memory: 4Gi
         volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
         - name: redpanda-data
           mountPath: /var/lib/redpanda/data
       volumes:
+      - name: repo-scripts
+        configMap:
+          name: posthog-scripts
+          defaultMode: 0555
       - name: redpanda-data
         persistentVolumeClaim:
           claimName: redpanda-data-kafka-0

--- a/my-apps/development/posthog/kustomization.yaml
+++ b/my-apps/development/posthog/kustomization.yaml
@@ -33,6 +33,14 @@ resources:
 
 # Hash-suffixed: Kustomize rewrites every configMapRef.name, so any env edit rolls all consumers.
 configMapGenerator:
+  - name: posthog-scripts
+    files:
+      - scripts/copy-geoip.sh
+      - scripts/init-clickhouse.sh
+      - scripts/init-kafka.sh
+      - scripts/migrate.sh
+      - scripts/start-kafka.sh
+      - scripts/sync-remote-config.sh
   - name: posthog-env
     envs:
       - posthog-env.env

--- a/my-apps/development/posthog/scripts/copy-geoip.sh
+++ b/my-apps/development/posthog/scripts/copy-geoip.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cp /code/share/GeoLite2-City.mmdb /share/GeoLite2-City.mmdb
+ls -la /share/GeoLite2-City.mmdb
+echo "GeoIP database copied successfully"
+

--- a/my-apps/development/posthog/scripts/init-clickhouse.sh
+++ b/my-apps/development/posthog/scripts/init-clickhouse.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -e
+echo "Waiting for ClickHouse..."
+TIMEOUT=120
+ELAPSED=0
+until clickhouse-client --host=clickhouse --port=9000 --query="SELECT 1" >/dev/null 2>&1; do
+  echo "ClickHouse not ready yet (elapsed: ${ELAPSED}s)..."
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+  if [ $ELAPSED -ge $TIMEOUT ]; then
+      echo "Timeout waiting for ClickHouse after ${TIMEOUT}s"
+      exit 1
+  fi
+done
+echo "ClickHouse is ready."
+
+echo "Initializing ClickHouse migration tables..."
+
+# Create the base migration tracking table (Replicated)
+clickhouse-client --host=clickhouse --port=9000 --query "
+CREATE TABLE IF NOT EXISTS posthog.infi_clickhouse_orm_migrations (
+  module_name String,
+  package_name String,
+  applied Date
+) ENGINE = ReplicatedMergeTree(
+  '/posthog/tables/infi_clickhouse_orm_migrations',
+  'replica_{replica}'
+)
+ORDER BY (module_name, package_name)
+SETTINGS index_granularity = 8192;
+"
+
+# Create the distributed view for cross-shard queries
+clickhouse-client --host=clickhouse --port=9000 --query "
+CREATE TABLE IF NOT EXISTS posthog.infi_clickhouse_orm_migrations_distributed AS posthog.infi_clickhouse_orm_migrations
+ENGINE = Distributed(
+  'posthog_migrations',
+  'posthog',
+  'infi_clickhouse_orm_migrations'
+);
+"
+
+echo "ClickHouse migration tables initialized successfully"
+
+# sharded_events must be a real local table cloned from posthog.events: migration 0031 ALTERs it, and
+# ingest (writable_events Distributed -> sharded_events) silently drops rows without it.
+echo "Creating sharded_events local table mirroring events columns..."
+clickhouse-client --host=clickhouse --port=9000 --query "
+CREATE TABLE IF NOT EXISTS posthog.sharded_events ON CLUSTER 'posthog'
+AS posthog.events
+ENGINE = ReplicatedReplacingMergeTree(
+  '/clickhouse/tables/{shard}/posthog.sharded_events',
+  '{replica}',
+  _timestamp
+)
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
+SAMPLE BY cityHash64(distinct_id)
+SETTINGS index_granularity = 8192;
+" || echo "  sharded_events likely already exists with prior schema — skipping"
+echo "  sharded_events ready"
+
+# Force-create lazy system log tables that PostHog migrations depend on
+echo "Ensuring system log tables exist..."
+clickhouse-client --host=clickhouse --port=9000 --query "SYSTEM FLUSH LOGS" || true
+for table in crash_log part_log trace_log; do
+  clickhouse-client --host=clickhouse --port=9000 --query "SELECT 1 FROM system.${table} LIMIT 0" 2>/dev/null && \
+    echo "  system.${table} exists" || \
+    echo "  system.${table} not yet created (ok - not needed until first event)"
+done
+
+# Verify tables exist
+clickhouse-client --host=clickhouse --port=9000 --query "
+SHOW TABLES IN posthog WHERE name LIKE '%infi_clickhouse_orm_migrations%'
+"

--- a/my-apps/development/posthog/scripts/init-kafka.sh
+++ b/my-apps/development/posthog/scripts/init-kafka.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -x
+echo "Waiting for Kafka broker to accept connections..."
+TIMEOUT=120
+ELAPSED=0
+until rpk topic list --brokers kafka:9092 2>/dev/null; do
+    echo "Kafka broker not ready yet (elapsed: ${ELAPSED}s)..."
+    sleep 2
+    ELAPSED=$((ELAPSED + 2))
+    if [ $ELAPSED -ge $TIMEOUT ]; then
+        echo "Timeout waiting for Kafka broker after ${TIMEOUT}s"
+        exit 1
+    fi
+done
+echo "Kafka broker is accepting requests, creating topics..."
+for topic in events_plugin_ingestion exceptions_ingestion clickhouse_events_json session_recording_events session_recording_events2 session_recording_snapshot_item_events clickhouse_app_metrics2 logs_ingestion ai_events_ingestion clickhouse_ai_events_json; do
+    if rpk topic create "$topic" --brokers kafka:9092 -p 1 -r 1 2>&1; then
+        echo "Topic $topic created successfully"
+    else
+        if rpk topic list --brokers kafka:9092 | grep -q "$topic"; then
+            echo "Topic $topic already exists, continuing"
+        else
+            echo "Failed to create topic $topic"
+            exit 1
+        fi
+    fi
+done
+echo "Topics ready"
+

--- a/my-apps/development/posthog/scripts/migrate.sh
+++ b/my-apps/development/posthog/scripts/migrate.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -e
+echo "Waiting for Postgres..."
+TIMEOUT=120; ELAPSED=0
+until python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('db', 5432))" 2>/dev/null; do
+  sleep 2; ELAPSED=$((ELAPSED + 2))
+  [ $ELAPSED -ge $TIMEOUT ] && echo "Postgres timeout" && exit 1
+done
+echo "Postgres ready"
+echo "Waiting for ClickHouse..."
+ELAPSED=0
+until wget -q --spider --timeout=2 http://clickhouse:8123/ping 2>/dev/null; do
+  sleep 2; ELAPSED=$((ELAPSED + 2))
+  [ $ELAPSED -ge $TIMEOUT ] && echo "ClickHouse timeout" && exit 1
+done
+echo "ClickHouse ready"
+echo "Flushing ClickHouse system logs..."
+wget -q -O- "http://clickhouse:8123/?query=SYSTEM+FLUSH+LOGS" 2>/dev/null || true
+echo "Running Django migrations..."
+python manage.py migrate --noinput
+# MUST run AFTER manage.py migrate: posthog_person doesn't exist on a fresh DB. IF NOT EXISTS keeps it idempotent.
+echo "Applying self-hosted Postgres schema guards..."
+python - <<'PY'
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+
+import django
+
+django.setup()
+
+from django.db import connection
+
+with connection.cursor() as cursor:
+    cursor.execute(
+        "ALTER TABLE public.posthog_person "
+        "ADD COLUMN IF NOT EXISTS last_seen_at timestamptz NULL"
+    )
+    # Library is preloaded via postgres args; without the extension the
+    # hourly monitoring task errors in the db log.
+    cursor.execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+PY
+echo "Running ClickHouse migrations..."
+python manage.py migrate_clickhouse
+# --check is the gate: a pending required migration fails the Job and the sync (beats a silent worker CrashLoop). Never remove.
+# Single-node CH gotcha: 0007* queries posthog.sharded_events; if hit, mark Complete in the PostHog admin and re-sync.
+echo "Running async ClickHouse migrations..."
+python manage.py run_async_migrations || true
+python manage.py run_async_migrations --check
+echo "All migrations complete"
+

--- a/my-apps/development/posthog/scripts/start-kafka.sh
+++ b/my-apps/development/posthog/scripts/start-kafka.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+rpk redpanda config set redpanda.auto_create_topics_enabled true &&
+rpk redpanda config set redpanda.empty_seed_starts_cluster true &&
+exec rpk redpanda start \
+  --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092 \
+  --advertise-kafka-addr internal://kafka:9092,external://localhost:19092 \
+  --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082 \
+  --advertise-pandaproxy-addr internal://kafka:8082,external://localhost:18082 \
+  --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081 \
+  --rpc-addr 0.0.0.0:33145 \
+  --advertise-rpc-addr kafka:33145 \
+  --smp 1 \
+  --memory 1G \
+  --reserve-memory 200M \
+  --overprovisioned \
+  --unsafe-bypass-fsync
+

--- a/my-apps/development/posthog/scripts/sync-remote-config.sh
+++ b/my-apps/development/posthog/scripts/sync-remote-config.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+echo "Waiting for Postgres..."
+TIMEOUT=120; ELAPSED=0
+until python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('db', 5432))" 2>/dev/null; do
+  sleep 2; ELAPSED=$((ELAPSED + 2))
+  [ $ELAPSED -ge $TIMEOUT ] && echo "Postgres timeout" && exit 1
+done
+echo "Waiting for Redis..."
+ELAPSED=0
+until python -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('redis7', 6379))" 2>/dev/null; do
+  sleep 2; ELAPSED=$((ELAPSED + 2))
+  [ $ELAPSED -ge $TIMEOUT ] && echo "Redis timeout" && exit 1
+done
+# RemoteConfig.sync() diffs against Postgres, not Redis — a wiped Redis is never repaired without force=True (flags go all-false, replay stops).
+echo "Force-syncing RemoteConfig to Redis..."
+python - <<'PY'
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+
+import django
+
+django.setup()
+
+from posthog.models.remote_config import RemoteConfig
+
+for remote_config in RemoteConfig.objects.all():
+    remote_config.sync(force=True)
+    print(f"force-synced team {remote_config.team_id}")
+PY
+echo "RemoteConfig sync complete"
+

--- a/my-apps/development/radar-ng/deployment-basemap.yaml
+++ b/my-apps/development/radar-ng/deployment-basemap.yaml
@@ -35,17 +35,15 @@ spec:
           command:
             - sh
             - -c
-            - |
-              echo "waiting for /data/basemap.pmtiles..."
-              until [ -s /data/basemap.pmtiles ]; do
-                sleep 5
-              done
-              echo "found $(ls -lh /data/basemap.pmtiles)"
+            - /opt/repo-scripts/wait-for-basemap.sh
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ALL]
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: pmtiles
               mountPath: /data
               readOnly: true
@@ -73,6 +71,10 @@ spec:
               cpu: 500m
               memory: 512Mi
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: radar-ng-scripts
+            defaultMode: 0555
         - name: pmtiles
           persistentVolumeClaim:
             claimName: pmtiles

--- a/my-apps/development/radar-ng/kustomization.yaml
+++ b/my-apps/development/radar-ng/kustomization.yaml
@@ -22,3 +22,8 @@ resources:
   - temporal-workers/temporal-worker-deployment.yaml
 
 namespace: radar-ng
+
+configMapGenerator:
+  - name: radar-ng-scripts
+    files:
+      - scripts/wait-for-basemap.sh

--- a/my-apps/development/radar-ng/scripts/wait-for-basemap.sh
+++ b/my-apps/development/radar-ng/scripts/wait-for-basemap.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+echo "waiting for /data/basemap.pmtiles..."
+until [ -s /data/basemap.pmtiles ]; do
+  sleep 5
+done
+echo "found $(ls -lh /data/basemap.pmtiles)"
+

--- a/my-apps/home/home-assistant/deployment.yaml
+++ b/my-apps/home/home-assistant/deployment.yaml
@@ -47,21 +47,11 @@ spec:
             runAsUser: 0
           command: ["/bin/sh", "-c"]
           args:
-            - |
-              # Copy config from ConfigMap to PVC (HA needs writable config files)
-              cp /config-source/configuration.yaml /config/configuration.yaml
-              cp /config-source/automations.yaml /config/automations.yaml
-              cp /config-source/scripts.yaml /config/scripts.yaml
-              cp /config-source/scenes.yaml /config/scenes.yaml
-              cp /config-source/customize.yaml /config/customize.yaml
-              cp /config-source/lovelace-homelab-power.yaml /config/lovelace-homelab-power.yaml
-              # Ensure themes directory exists
-              mkdir -p /config/themes
-              # AirCube ZHA quirk -> custom_zha_quirks/ (loaded via zha.custom_quirks_path)
-              mkdir -p /config/custom_zha_quirks
-              cp /config-source/aircube.py /config/custom_zha_quirks/aircube.py
-              echo "Config files copied to PVC"
+            - /opt/repo-scripts/copy-config.sh
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: config
               mountPath: /config
             - name: config-files
@@ -74,19 +64,11 @@ spec:
             runAsUser: 0
           command: ["/bin/sh", "-c"]
           args:
-            - |
-              if [ ! -d "/config/custom_components/hacs" ]; then
-                echo "HACS not found, installing..."
-                apk add --no-cache bash wget unzip curl
-                # Try to install HACS with timeout, skip if fails
-                timeout 120 sh -c 'wget -O - https://get.hacs.xyz | bash -' || {
-                  echo "HACS install timed out or failed, continuing anyway..."
-                  echo "You can install HACS manually later from https://hacs.xyz"
-                }
-              else
-                echo "HACS already installed"
-              fi
+            - /opt/repo-scripts/install-hacs.sh
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: config
               mountPath: /config
       containers:
@@ -135,6 +117,10 @@ spec:
             limits:
               memory: 4Gi
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: home-assistant-scripts
+            defaultMode: 0555
         - name: config
           persistentVolumeClaim:
             claimName: config

--- a/my-apps/home/home-assistant/kustomization.yaml
+++ b/my-apps/home/home-assistant/kustomization.yaml
@@ -33,6 +33,10 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
+- name: home-assistant-scripts
+  files:
+  - scripts/copy-config.sh
+  - scripts/install-hacs.sh
 - name: config
   files:
   - configuration.yaml

--- a/my-apps/home/home-assistant/scripts/copy-config.sh
+++ b/my-apps/home/home-assistant/scripts/copy-config.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Copy config from ConfigMap to PVC (HA needs writable config files)
+cp /config-source/configuration.yaml /config/configuration.yaml
+cp /config-source/automations.yaml /config/automations.yaml
+cp /config-source/scripts.yaml /config/scripts.yaml
+cp /config-source/scenes.yaml /config/scenes.yaml
+cp /config-source/customize.yaml /config/customize.yaml
+cp /config-source/lovelace-homelab-power.yaml /config/lovelace-homelab-power.yaml
+# Ensure themes directory exists
+mkdir -p /config/themes
+# AirCube ZHA quirk -> custom_zha_quirks/ (loaded via zha.custom_quirks_path)
+mkdir -p /config/custom_zha_quirks
+cp /config-source/aircube.py /config/custom_zha_quirks/aircube.py
+echo "Config files copied to PVC"
+

--- a/my-apps/home/home-assistant/scripts/install-hacs.sh
+++ b/my-apps/home/home-assistant/scripts/install-hacs.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+if [ ! -d "/config/custom_components/hacs" ]; then
+  echo "HACS not found, installing..."
+  apk add --no-cache bash wget unzip curl
+  # Try to install HACS with timeout, skip if fails
+  timeout 120 sh -c 'wget -O - https://get.hacs.xyz | bash -' || {
+    echo "HACS install timed out or failed, continuing anyway..."
+    echo "You can install HACS manually later from https://hacs.xyz"
+  }
+else
+  echo "HACS already installed"
+fi
+

--- a/my-apps/home/intercept/deployment.yaml
+++ b/my-apps/home/intercept/deployment.yaml
@@ -36,12 +36,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - >-
-              mkdir -p /persist/instance
-              /persist/weather_sat
-              /persist/radiosonde
-              /persist/subghz
-              /persist/adsb
+            - /opt/repo-scripts/initialize-data.sh
           securityContext:
             runAsUser: 0
             runAsNonRoot: false
@@ -53,6 +48,9 @@ spec:
               cpu: 100m
               memory: 32Mi
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: data
               mountPath: /persist
       containers:
@@ -150,6 +148,10 @@ spec:
             - name: usb-bus
               mountPath: /dev/bus/usb
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: intercept-scripts
+            defaultMode: 0555
         - name: data
           persistentVolumeClaim:
             claimName: intercept-data

--- a/my-apps/home/intercept/kustomization.yaml
+++ b/my-apps/home/intercept/kustomization.yaml
@@ -18,3 +18,8 @@ resources:
 
 components:
   - ../../common/kopiur-backup
+
+configMapGenerator:
+  - name: intercept-scripts
+    files:
+      - scripts/initialize-data.sh

--- a/my-apps/home/intercept/scripts/initialize-data.sh
+++ b/my-apps/home/intercept/scripts/initialize-data.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+mkdir -p \
+  /persist/instance \
+  /persist/weather_sat \
+  /persist/radiosonde \
+  /persist/subghz \
+  /persist/adsb

--- a/my-apps/home/project-nomad/kiwix/deployment.yaml
+++ b/my-apps/home/project-nomad/kiwix/deployment.yaml
@@ -29,14 +29,7 @@ spec:
           image: ghcr.io/kiwix/kiwix-serve:3.8.2
           command: ["sh", "-c"]
           args:
-            - |
-              ZIM_FILES=$(find /data -name '*.zim' 2>/dev/null)
-              if [ -z "$ZIM_FILES" ]; then
-                echo "No ZIM files found in /data, sleeping..."
-                sleep infinity
-              else
-                exec kiwix-serve --address=0.0.0.0 --port=8080 /data/*.zim
-              fi
+            - /opt/repo-scripts/start-kiwix.sh
           ports:
             - containerPort: 8080
               name: http
@@ -47,10 +40,17 @@ spec:
             limits:
               memory: 256Mi
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: nomad-storage
               mountPath: /data
               subPath: zim
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: project-nomad-scripts
+            defaultMode: 0555
         - name: nomad-storage
           persistentVolumeClaim:
             claimName: nomad-storage

--- a/my-apps/home/project-nomad/kustomization.yaml
+++ b/my-apps/home/project-nomad/kustomization.yaml
@@ -57,6 +57,11 @@ components:
   - ../../common/kopiur-backup
 
 configMapGenerator:
+  - name: project-nomad-scripts
+    files:
+      - scripts/migrate.sh
+      - scripts/start.sh
+      - scripts/start-kiwix.sh
   - name: project-nomad-config
     envs:
       - project-nomad-config.env

--- a/my-apps/home/project-nomad/nomad/deployment.yaml
+++ b/my-apps/home/project-nomad/nomad/deployment.yaml
@@ -26,7 +26,7 @@ spec:
               mountPath: /app/storage
         - name: migrate
           image: ghcr.io/mitchross/project-nomad:sha-35016fd
-          command: ["sh", "-c", "node ace migration:run --force && node ace db:seed"]
+          command: ["sh", "-c", "/opt/repo-scripts/migrate.sh"]
           envFrom:
             - configMapRef:
                 name: project-nomad-config
@@ -42,12 +42,15 @@ spec:
                   name: project-nomad-secrets
                   key: DB_PASSWORD
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: nomad-storage
               mountPath: /app/storage
       containers:
         - name: project-nomad
           image: ghcr.io/mitchross/project-nomad:sha-35016fd
-          command: ["sh", "-c", "node ace queue:work --all & exec node bin/server.js"]
+          command: ["sh", "-c", "/opt/repo-scripts/start.sh"]
           ports:
             - containerPort: 8080
               name: http
@@ -72,6 +75,9 @@ spec:
             limits:
               memory: 1Gi
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: nomad-storage
               mountPath: /app/storage
           livenessProbe:
@@ -89,6 +95,10 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: project-nomad-scripts
+            defaultMode: 0555
         - name: nomad-storage
           persistentVolumeClaim:
             claimName: nomad-storage

--- a/my-apps/home/project-nomad/scripts/migrate.sh
+++ b/my-apps/home/project-nomad/scripts/migrate.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+node ace migration:run --force
+node ace db:seed

--- a/my-apps/home/project-nomad/scripts/start-kiwix.sh
+++ b/my-apps/home/project-nomad/scripts/start-kiwix.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+ZIM_FILES=$(find /data -name '*.zim' 2>/dev/null)
+if [ -z "$ZIM_FILES" ]; then
+  echo "No ZIM files found in /data, sleeping..."
+  sleep infinity
+else
+  exec kiwix-serve --address=0.0.0.0 --port=8080 /data/*.zim
+fi
+

--- a/my-apps/home/project-nomad/scripts/start.sh
+++ b/my-apps/home/project-nomad/scripts/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+node ace queue:work --all &
+exec node bin/server.js

--- a/my-apps/home/project-zomboid/deployment.yaml
+++ b/my-apps/home/project-zomboid/deployment.yaml
@@ -23,12 +23,11 @@ spec:
           command:
             - /bin/bash
             - -c
-            - |
-              echo "Pre-warming SteamCMD to complete self-update..."
-              /home/steam/steamcmd/steamcmd.sh +quit || true
-              cp -a /home/steam/steamcmd/* /steam-cache/ 2>/dev/null || true
-              echo "SteamCMD pre-warm complete."
+            - /opt/repo-scripts/prewarm-steamcmd.sh
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: steam-cache
               mountPath: /steam-cache
         - name: copy-config
@@ -36,12 +35,11 @@ spec:
           command:
             - sh
             - -c
-            - |
-              mkdir -p /project-zomboid-config/Server
-              cp /config/vanillax.ini /project-zomboid-config/Server/vanillax.ini
-              cp /config/vanillax_SandboxVars.lua /project-zomboid-config/Server/vanillax_SandboxVars.lua
-              echo "Config files copied to /project-zomboid-config/Server/"
+            - /opt/repo-scripts/copy-config.sh
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: config-data
               mountPath: /project-zomboid-config
             - name: config
@@ -115,11 +113,7 @@ spec:
                 command:
                   - /bin/bash
                   - -c
-                  - |
-                    rcon-cli -c /home/steam/server/rcon.yml "save" || true
-                    sleep 5
-                    rcon-cli -c /home/steam/server/rcon.yml "quit" || true
-                    sleep 15
+                  - /opt/repo-scripts/stop-server.sh
           startupProbe:
             exec:
               command:
@@ -147,6 +141,9 @@ spec:
             periodSeconds: 30
             failureThreshold: 3
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: server-files
               mountPath: /project-zomboid
             - name: config-data
@@ -160,6 +157,10 @@ spec:
             limits:
               memory: 20Gi
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: project-zomboid-scripts
+            defaultMode: 0555
         - name: server-files
           persistentVolumeClaim:
             claimName: zomboid-server-files

--- a/my-apps/home/project-zomboid/kustomization.yaml
+++ b/my-apps/home/project-zomboid/kustomization.yaml
@@ -18,6 +18,11 @@ components:
   - ../../common/kopiur-backup
 
 configMapGenerator:
+  - name: project-zomboid-scripts
+    files:
+      - scripts/prewarm-steamcmd.sh
+      - scripts/copy-config.sh
+      - scripts/stop-server.sh
   - name: zomboid-server-config
     files:
       - vanillax.ini

--- a/my-apps/home/project-zomboid/scripts/copy-config.sh
+++ b/my-apps/home/project-zomboid/scripts/copy-config.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+mkdir -p /project-zomboid-config/Server
+cp /config/vanillax.ini /project-zomboid-config/Server/vanillax.ini
+cp /config/vanillax_SandboxVars.lua /project-zomboid-config/Server/vanillax_SandboxVars.lua
+echo "Config files copied to /project-zomboid-config/Server/"
+

--- a/my-apps/home/project-zomboid/scripts/prewarm-steamcmd.sh
+++ b/my-apps/home/project-zomboid/scripts/prewarm-steamcmd.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "Pre-warming SteamCMD to complete self-update..."
+/home/steam/steamcmd/steamcmd.sh +quit || true
+cp -a /home/steam/steamcmd/* /steam-cache/ 2>/dev/null || true
+echo "SteamCMD pre-warm complete."
+

--- a/my-apps/home/project-zomboid/scripts/stop-server.sh
+++ b/my-apps/home/project-zomboid/scripts/stop-server.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+rcon-cli -c /home/steam/server/rcon.yml "save" || true
+sleep 5
+rcon-cli -c /home/steam/server/rcon.yml "quit" || true
+sleep 15
+

--- a/my-apps/maps/versatiles/deployment.yaml
+++ b/my-apps/maps/versatiles/deployment.yaml
@@ -33,17 +33,15 @@ spec:
           command:
             - sh
             - -c
-            - |
-              echo "waiting for /data/osm.versatiles..."
-              until [ -s /data/osm.versatiles ]; do
-                sleep 5
-              done
-              echo "found archive, starting server"
+            - /opt/repo-scripts/wait-for-map.sh
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ALL]
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: map-data
               mountPath: /data
               readOnly: true
@@ -95,6 +93,10 @@ spec:
               mountPath: /config
               readOnly: true
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: versatiles-scripts
+            defaultMode: 0555
         - name: map-data
           persistentVolumeClaim:
             claimName: map-data-smb

--- a/my-apps/maps/versatiles/job-bootstrap.yaml
+++ b/my-apps/maps/versatiles/job-bootstrap.yaml
@@ -39,45 +39,7 @@ spec:
           command:
             - sh
             - -c
-            - |
-              set -eu
-              TARGET="/data/${TARGET_FILE}"
-              TMP="${TARGET}.tmp"
-              MARKER="/data/.bootstrap-marker"
-
-              # Fast path: the hook re-runs every sync; a marker matching DATASET_URL means nothing to do.
-              if [ -s "$TARGET" ] && [ -f "$MARKER" ] && [ "$(head -n1 "$MARKER")" = "$DATASET_URL" ]; then
-                echo "marker matches (${DATASET_URL}); archive already present, nothing to do"
-                exit 0
-              fi
-
-              # The origin drops long single streams; restarting from byte 0 never finishes 62GB, so resume with wget -c.
-              # A stale partial from a different DATASET_URL is caught by the sha256 check (mismatch deletes the tmp).
-              echo "downloading ${DATASET_URL} -> ${TMP}"
-              attempt=0
-              while ! wget -q -c -O "$TMP" "$DATASET_URL"; do
-                attempt=$((attempt + 1))
-                if [ "$attempt" -ge 200 ]; then
-                  echo "FATAL: download did not complete after ${attempt} resume attempts" >&2
-                  exit 1
-                fi
-                echo "connection dropped at $(wc -c <"$TMP" 2>/dev/null || echo 0) bytes, resuming (attempt ${attempt})"
-                sleep 5
-              done
-
-              echo "verifying sha256 (${DATASET_SHA256_URL})"
-              EXPECTED="$(wget -q -O - "$DATASET_SHA256_URL" | cut -d' ' -f1)"
-              ACTUAL="$(sha256sum "$TMP" | cut -d' ' -f1)"
-              if [ "$EXPECTED" != "$ACTUAL" ]; then
-                echo "FATAL: sha256 mismatch: expected ${EXPECTED}, got ${ACTUAL}" >&2
-                rm -f "$TMP"
-                exit 1
-              fi
-
-              # Atomic swap (same filesystem); a running server keeps the OLD file open until the Deployment restarts.
-              mv -f "$TMP" "$TARGET"
-              printf '%s\nsize=%s downloaded=%s\n' "$DATASET_URL" "$(wc -c <"$TARGET")" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$MARKER"
-              echo "done: ${TARGET} ($(wc -c <"$TARGET") bytes)"
+            - /opt/repo-scripts/bootstrap-map.sh
           envFrom:
             - configMapRef:
                 name: bootstrap-env
@@ -92,9 +54,16 @@ spec:
             limits:
               memory: 512Mi
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: map-data
               mountPath: /data
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: versatiles-scripts
+            defaultMode: 0555
         - name: map-data
           persistentVolumeClaim:
             claimName: map-data-smb

--- a/my-apps/maps/versatiles/kustomization.yaml
+++ b/my-apps/maps/versatiles/kustomization.yaml
@@ -16,6 +16,10 @@ resources:
   - httproute-viewer.yaml
 
 configMapGenerator:
+  - name: versatiles-scripts
+    files:
+      - scripts/bootstrap-map.sh
+      - scripts/wait-for-map.sh
   # Hash suffix is the update mechanism: changing DATASET_URL (+ sha256) or config.yaml re-runs the bootstrap hook.
   # Newer planet snapshots: https://download.versatiles.org/ (see README).
   - name: versatiles-config

--- a/my-apps/maps/versatiles/scripts/bootstrap-map.sh
+++ b/my-apps/maps/versatiles/scripts/bootstrap-map.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+TARGET="/data/${TARGET_FILE}"
+TMP="${TARGET}.tmp"
+MARKER="/data/.bootstrap-marker"
+
+# Fast path: the hook re-runs every sync; a marker matching DATASET_URL means nothing to do.
+if [ -s "$TARGET" ] && [ -f "$MARKER" ] && [ "$(head -n1 "$MARKER")" = "$DATASET_URL" ]; then
+  echo "marker matches (${DATASET_URL}); archive already present, nothing to do"
+  exit 0
+fi
+
+# The origin drops long single streams; restarting from byte 0 never finishes 62GB, so resume with wget -c.
+# A stale partial from a different DATASET_URL is caught by the sha256 check (mismatch deletes the tmp).
+echo "downloading ${DATASET_URL} -> ${TMP}"
+attempt=0
+while ! wget -q -c -O "$TMP" "$DATASET_URL"; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 200 ]; then
+    echo "FATAL: download did not complete after ${attempt} resume attempts" >&2
+    exit 1
+  fi
+  echo "connection dropped at $(wc -c <"$TMP" 2>/dev/null || echo 0) bytes, resuming (attempt ${attempt})"
+  sleep 5
+done
+
+echo "verifying sha256 (${DATASET_SHA256_URL})"
+EXPECTED="$(wget -q -O - "$DATASET_SHA256_URL" | cut -d' ' -f1)"
+ACTUAL="$(sha256sum "$TMP" | cut -d' ' -f1)"
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo "FATAL: sha256 mismatch: expected ${EXPECTED}, got ${ACTUAL}" >&2
+  rm -f "$TMP"
+  exit 1
+fi
+
+# Atomic swap (same filesystem); a running server keeps the OLD file open until the Deployment restarts.
+mv -f "$TMP" "$TARGET"
+printf '%s\nsize=%s downloaded=%s\n' "$DATASET_URL" "$(wc -c <"$TARGET")" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$MARKER"
+echo "done: ${TARGET} ($(wc -c <"$TARGET") bytes)"
+

--- a/my-apps/maps/versatiles/scripts/wait-for-map.sh
+++ b/my-apps/maps/versatiles/scripts/wait-for-map.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+echo "waiting for /data/osm.versatiles..."
+until [ -s /data/osm.versatiles ]; do
+  sleep 5
+done
+echo "found archive, starting server"
+

--- a/my-apps/media/immich/deployment-server.yaml
+++ b/my-apps/media/immich/deployment-server.yaml
@@ -38,12 +38,11 @@ spec:
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "-c"]
         args:
-          - |
-            for d in thumbs upload backups library profile encoded-video; do
-              mkdir -p "/library/$d" && touch "/library/$d/.immich"
-            done
-            echo "immich /library folder markers ensured"
+          - /opt/repo-scripts/prepare-library.sh
         volumeMounts:
+        - name: repo-scripts
+          mountPath: /opt/repo-scripts
+          readOnly: true
         - name: library
           mountPath: /library
       containers:
@@ -133,6 +132,10 @@ spec:
         - name: transformers
           mountPath: /usr/src/app/.transformers_cache
       volumes:
+      - name: repo-scripts
+        configMap:
+          name: immich-scripts
+          defaultMode: 0555
       - name: library
         persistentVolumeClaim:
           claimName: library

--- a/my-apps/media/immich/kustomization.yaml
+++ b/my-apps/media/immich/kustomization.yaml
@@ -24,6 +24,11 @@ resources:
   - kopiur/library.yaml
   - kopiur/immich-postgres-data.yaml
 
+configMapGenerator:
+  - name: immich-scripts
+    files:
+      - scripts/prepare-library.sh
+
 # Injects the uniform kopiur fields (repository, copyMethod, populator) into the per-PVC stubs in kopiur/.
 components:
   - ../../common/kopiur-backup

--- a/my-apps/media/immich/scripts/prepare-library.sh
+++ b/my-apps/media/immich/scripts/prepare-library.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+for d in thumbs upload backups library profile encoded-video; do
+  mkdir -p "/library/$d" && touch "/library/$d/.immich"
+done
+echo "immich /library folder markers ensured"
+

--- a/my-apps/privacy/searxng/deployment.yaml
+++ b/my-apps/privacy/searxng/deployment.yaml
@@ -28,19 +28,17 @@ spec:
           command:
             - sh
             - -c
-            - |
-              echo "Waiting for redis to be ready..."
-              until nc -z redis 6379; do
-                echo "Redis not ready, retrying in 2s..."
-                sleep 2
-              done
-              echo "Redis is ready!"
+            - /opt/repo-scripts/wait-for-redis.sh
           resources:
             requests:
               cpu: 10m
               memory: 16Mi
             limits:
               memory: 32Mi
+          volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
       containers:
         - name: searxng
           image: ghcr.io/searxng/searxng:2026.8.29-d226b78bc
@@ -76,6 +74,10 @@ spec:
               mountPath: /etc/searxng/limiter.toml
               subPath: limiter.toml
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: searxng-scripts
+            defaultMode: 0555
         - name: searxng-settings
           configMap:
             name: searxng-config-settings

--- a/my-apps/privacy/searxng/kustomization.yaml
+++ b/my-apps/privacy/searxng/kustomization.yaml
@@ -9,6 +9,9 @@ resources:
   - externalsecret.yaml
   - redis.yaml
 configMapGenerator:
+  - name: searxng-scripts
+    files:
+      - scripts/wait-for-redis.sh
   - name: searxng-config-settings
     files:
       - settings.yaml

--- a/my-apps/privacy/searxng/scripts/wait-for-redis.sh
+++ b/my-apps/privacy/searxng/scripts/wait-for-redis.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+echo "Waiting for redis to be ready..."
+until nc -z redis 6379; do
+  echo "Redis not ready, retrying in 2s..."
+  sleep 2
+done
+echo "Redis is ready!"
+

--- a/my-apps/system/restore-canary/deployment.yaml
+++ b/my-apps/system/restore-canary/deployment.yaml
@@ -35,8 +35,11 @@ spec:
         - name: sleeper
           image: ghcr.io/home-operations/busybox:1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df
           imagePullPolicy: IfNotPresent
-          command: ["sh", "-c", "while true; do sleep 3600; done"]
+          command: ["sh", "-c", "/opt/repo-scripts/sleep.sh"]
           volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
             - name: data
               mountPath: /data
           resources:
@@ -51,6 +54,10 @@ spec:
             capabilities:
               drop: ["ALL"]
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: restore-canary-scripts
+            defaultMode: 0555
         - name: data
           persistentVolumeClaim:
             claimName: restore-canary-data

--- a/my-apps/system/restore-canary/kustomization.yaml
+++ b/my-apps/system/restore-canary/kustomization.yaml
@@ -9,6 +9,11 @@ resources:
 
 namespace: restore-canary
 
+configMapGenerator:
+  - name: restore-canary-scripts
+    files:
+      - scripts/sleep.sh
+
 # Uniform kopiur backup fields (repository, copyMethod, populator) for the per-PVC stub(s) in kopiur/.
 components:
   - ../../common/kopiur-backup

--- a/my-apps/system/restore-canary/scripts/sleep.sh
+++ b/my-apps/system/restore-canary/scripts/sleep.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+while true; do
+  sleep 3600
+done

--- a/scripts/validate-no-inline-scripts.sh
+++ b/scripts/validate-no-inline-scripts.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SEARCH_ROOTS=(infrastructure monitoring my-apps)
+readonly BLOCK_PATTERN='(^[[:space:]]*-[[:space:]]*[|>][-+]?[[:space:]]*$)|(^[[:space:]]*(command|args):[[:space:]]*[|>][-+]?[[:space:]]*$)'
+
+if matches="$(rg -n --glob '*.yaml' --glob '*.yml' "$BLOCK_PATTERN" "${SEARCH_ROOTS[@]}")"; then
+  echo "ERROR: executable-style YAML block bodies are not allowed:"
+  echo "$matches"
+  echo "Move the program into the owning app's scripts/ directory, generate a ConfigMap, and mount it read-only."
+  exit 1
+fi
+
+echo "No inline executable YAML block bodies found."


### PR DESCRIPTION
## Summary
- extract 40 repo-owned shell/Python execution bodies from Kubernetes YAML into app-owned `scripts/` files
- package scripts with hash-suffixed Kustomize ConfigMaps and mount them read-only at `/opt/repo-scripts`
- make the ComfyUI model downloader an idempotent Argo Sync hook instead of an undocumented manual apply
- add a repository rule and blocking CI check that reject future inline executable block bodies
- make the manual TrueNAS canary Kustomize-renderable so its script ConfigMap is included

Direct argv commands, probes, and single-purpose one-line checks remain inline by policy. Docker Compose folded command values under `omni/` are argument lists, not scripts.

## Validation
- full render of every `infrastructure/`, `monitoring/`, and `my-apps/` kustomization
- verified all 40 rendered script consumers have a read-only mount and ConfigMap-backed volume
- `scripts/validate-no-inline-scripts.sh`
- `scripts/validate-argocd-apps.sh`
- `scripts/validate-truenas-csi.sh`
- kopiur coverage validator
- VPA policy validator
- ShellCheck and shell/Python syntax checks
- `git diff --check`