### PR TITLE
fix(surfsense): reserve vLLM output context

### DIFF
--- a/my-apps/ai/surfsense/README.md
+++ b/my-apps/ai/surfsense/README.md
@@ -47,6 +47,7 @@ operator-owned global model catalog:
 - Base URL: `http://vllm-service.vllm.svc.cluster.local:8080/v1`
 - Model: `qwen3.8-27b`
 - Config: `global_llm_config.yaml`, mounted at `/app/app/config/global_llm_config.yaml`
+- Context budget: 48,000 input + 16,384 output, leaving 1,152 tokens for request/tool overhead inside vLLM's 65,536-token window
 - Billing tier: `free` — this is local infrastructure, not a metered provider
 
 Initial embeddings use CPU-local `sentence-transformers/all-MiniLM-L6-v2`, so SurfSense does not request a GPU.

--- a/my-apps/ai/surfsense/global_llm_config.yaml
+++ b/my-apps/ai/surfsense/global_llm_config.yaml
@@ -9,7 +9,7 @@ global_llm_configs:
     model_name: qwen3.8-27b
     supports_image_input: true
     supports_tools: true
-    max_input_tokens: 65536
+    max_input_tokens: 48000 # reserves output/tool-call headroom inside vLLM's 65,536-token window
     api_key: sk-required
     api_base: http://vllm-service.vllm.svc.cluster.local:8080/v1
     rpm: 60


### PR DESCRIPTION
## Summary
- cap SurfSense model input at 48,000 tokens
- retain the 16,384-token output allowance with 1,152 tokens of request/tool overhead
- document the shared 65,536-token vLLM context budget

## Incident evidence
A news-agent run performed 32 searches and reached a 49,136-token prompt. The final chat-completions request returned HTTP 400 while SurfSense and vLLM remained healthy with zero restarts. The old configuration advertised the entire 65,536-token vLLM window as input while separately requesting up to 16,384 output tokens.

## Validation
- kustomize build my-apps/ai/surfsense
- bash scripts/validate-no-inline-scripts.sh
- git diff --check