### PR TITLE
radar-ng + Temporal: reliability fixes from the 2026-09-01/02 outage review

### DIFF
--- a/my-apps/development/radar-ng/RUNBOOK.md
+++ b/my-apps/development/radar-ng/RUNBOOK.md
@@ -96,3 +96,27 @@ pool until an image containing those roles is running. Then:
 
 This ordering prevents a schedule update from routing work to a queue with no
 poller and keeps existing pinned workflows replayable.
+
+## Schedule stops firing (timer never fires)
+
+Signature: `temporal schedule describe --schedule-id <id>` shows `NextRunTime`
+in the past, `RunningWorkflows []`, not paused, and `ActionCounts.MissedCatchupWindow`
+climbing. The schedule answers RPCs instantly, so the seed self-heal (which only
+recreates schedules whose RPCs hang) does nothing. The backing
+`temporal-sys-scheduler:<id>` workflow set a timer that the 1-shard history
+service never fired; it stays asleep until something signals it.
+
+Any signal wakes it — `describe` and `trigger` both do:
+
+```sh
+kubectl -n temporal exec deploy/temporal-admintools -- \
+  temporal schedule trigger \
+  --address temporal-frontend.temporal.svc.cluster.local:7233 \
+  --namespace default \
+  --schedule-id poll-alerts --overlap-policy Skip
+```
+
+Expect it to wedge again after the next run until the worker image carries the
+schedule watchdog (it re-triggers overdue schedules itself). Verify recovery by
+the state file the workflow writes, e.g. `alerts_active_snapshot.json` mtime on
+the `state` PVC moving.

--- a/my-apps/development/radar-ng/deployment-open-meteo.yaml
+++ b/my-apps/development/radar-ng/deployment-open-meteo.yaml
@@ -50,7 +50,7 @@ spec:
             limits:
               cpu: 2000m
               memory: 2Gi
-        # Sidecar, not a standalone WorkerDeployment: the WorkerController strips podAffinity and this RWO volume needs co-location.
+        # Sidecar, not a standalone WorkerDeployment: it must share this RWO volume with the serve container (same pod).
         # Runs non-versioned (no TEMPORAL_DEPLOYMENT_NAME/BUILD_ID env).
         - name: sync-worker
           # Base image must match the serve container's (1.5.3 base lacks libparquet-glib.so.2400 -> HRRR sync rc=127).

--- a/my-apps/development/radar-ng/deployment-tile-server.yaml
+++ b/my-apps/development/radar-ng/deployment-tile-server.yaml
@@ -22,7 +22,7 @@ spec:
         app: tile-server
       annotations:
         # Bump to force a ReplicaSet roll when only env changes — a stale field-manager can mask env diffs under SSA.
-        config-rev: "2026-05-10-forecast-ttl-300"
+        config-rev: "2026-09-02-alerts-queue"
     spec:
       # Prefer the node holding the worker that shares these RWO volumes (preferred, so tile-server can bootstrap first).
       affinity:
@@ -97,6 +97,9 @@ spec:
               value: temporal-frontend.temporal.svc.cluster.local:7233
             - name: TEMPORAL_NAMESPACE
               value: default
+            # Until a dedicated `alerts` worker pool exists, watch workflows must land on the queue that has a poller.
+            - name: TEMPORAL_ALERTS_TASK_QUEUE
+              value: radar-ng
           # Probe /api/livez through Caddy so a dead backgrounded uvicorn restarts the pod.
           # Do NOT probe /api/health: it degrades on stale NOAA data fleet-wide and would restart every replica.
           livenessProbe:

--- a/my-apps/development/radar-ng/kustomization.yaml
+++ b/my-apps/development/radar-ng/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
   - deployment-open-meteo.yaml
   - servicemonitor.yaml
   - prometheusrule.yaml
-  # The open-meteo sync worker is NOT here — it's a sidecar in deployment-open-meteo.yaml (controller strips podAffinity; RWO volume).
+  # The open-meteo sync worker is NOT here — it's a sidecar in deployment-open-meteo.yaml (shares that RWO volume).
   # Schedules are seeded once via `python -m temporal.schedules.seed` after rollout.
   - temporal-workers/configmap-temporal-config.yaml
   - temporal-workers/temporal-connection.yaml

--- a/my-apps/development/radar-ng/prometheusrule.yaml
+++ b/my-apps/development/radar-ng/prometheusrule.yaml
@@ -37,3 +37,50 @@ spec:
           annotations:
             summary: radar-ng API error rate is above 5 percent
             description: The five-minute API 5xx ratio has stayed above 5 percent for 10 minutes.
+    - name: radar-ng.worker
+      rules:
+        - alert: RadarNgWorkerOOMKilled
+          expr: kube_pod_container_status_last_terminated_reason{namespace="radar-ng", container="worker", reason="OOMKilled"} == 1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: radar-ng worker was OOMKilled
+            description: The Temporal worker container hit its memory limit; schedules skip while it restarts and heavy activities restart from scratch.
+        - alert: RadarNgWorkerMemoryHigh
+          expr: |
+            container_memory_working_set_bytes{namespace="radar-ng", container="worker"}
+              /
+            on (pod, container) kube_pod_container_resource_limits{namespace="radar-ng", container="worker", resource="memory"} > 0.85
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: radar-ng worker memory above 85 percent of its limit
+            description: Nowcast, HRRR and air-quality renders are overlapping; an OOM kill is likely without a slot or limit change.
+        - alert: RadarNgWorkerRestarting
+          expr: increase(kube_pod_container_status_restarts_total{namespace="radar-ng", container="worker"}[1h]) > 1
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: radar-ng worker restarted more than once in an hour
+            description: Repeated restarts drop in-flight renders and can leave Temporal schedules skipping.
+    - name: radar-ng.layers
+      rules:
+        - alert: RadarNgHrrrLayerMissing
+          expr: absent(radar_ng_tile_timestamps{layer="radar-hrrr"}) == 1
+          for: 3h
+          labels:
+            severity: warning
+          annotations:
+            summary: radar-ng has published no HRRR forecast radar for 3 hours
+            description: The ingest-hrrr schedule is running but never publishing a complete run; check hour_pending and incomplete-run log lines.
+        - alert: RadarNgNowcastLayerMissing
+          expr: absent(radar_ng_tile_timestamps{layer="nowcast"}) == 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: radar-ng nowcast layer has no published frames
+            description: Nowcast fails closed on radar publication gaps; look at /api/health nowcast.reason.

--- a/my-apps/development/radar-ng/temporal-workers/configmap-temporal-config.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/configmap-temporal-config.yaml
@@ -10,8 +10,10 @@ data:
   # Drop the missing colorblind palette (no backend/shared/palettes/colorblind.json
   # exists). The muted palette already advertises colorblind-safety.
   PALETTES: "classic,muted,vivid"
-  # Keep at 1 until render perf improves: a frame takes ~10 min vs the 2-min schedule cadence, so 3 backlogs the manifest.
+  # A frame renders in ~25-40 s; keep 1 so a run stays well inside the 2-min SKIP cadence (backlog >1 stretches the run, not freshness).
   BACKLOG_PER_CYCLE: "1"
+  # One process per palette (3 palettes); the 12-CPU limit has the headroom.
+  MRMS_RENDER_WORKERS: "3"
   MRMS_PREFIX: "CONUS/MergedBaseReflectivityQC_00.50"
   FORECAST_HOURS: "18"
   EXTENDED_FORECAST_HOURS: "48"

--- a/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
@@ -14,14 +14,8 @@ spec:
       name: cluster-temporal
     temporalNamespace: default
   rollout:
-    # Same progressive shape as news-reader-temporal-worker. Tune per
-    # workload — radar ingest is more time-sensitive than news.
-    strategy: Progressive
-    steps:
-      - rampPercentage: 10
-        pauseDuration: 2m
-      - rampPercentage: 50
-        pauseDuration: 5m
+    # Single replica pinned to the RWO node: Progressive would run old+new pods there for 7 min for no traffic-split benefit.
+    strategy: AllAtOnce
   sunset:
     scaledownDelay: 10m
     deleteDelay: 1h
@@ -58,7 +52,7 @@ spec:
             # No OTEL endpoint on purpose — set, the worker spams UNAVAILABLE gRPC retries; unset = no-op tracer.
             # CONFIG_REV is a no-op; bump it to roll pods on ConfigMap changes (pod annotations aren't in the controller's hash).
             - name: CONFIG_REV
-              value: "2026-05-10-backlog1"
+              value: "2026-09-02-render-workers-3"
             - name: TILE_DIR
               value: /data/tiles
             - name: STATE_DIR
@@ -80,10 +74,10 @@ spec:
             - { name: grids,  mountPath: /data/grids }
             - { name: state,  mountPath: /data/state }
           resources:
-            # CPU-bound (pysteps nowcast + MRMS reproject) — a tight CPU limit makes nowcast_run time out.
-            # 250m: Progressive rollout runs old+new side by side on tile-server's node (RWO affinity); 2×1-CPU requests can't schedule there.
-            requests: { cpu: "250m", memory: "3Gi" }
-            limits:   { cpu: "12", memory: "12Gi" }
+            # CPU-bound (pysteps nowcast + MRMS render) — a tight CPU limit makes nowcast_run time out.
+            # Requests track real steady use (~3 CPU / 5-8 Gi); OOMKilled at 12Gi when nowcast+HRRR+airquality overlapped.
+            requests: { cpu: "2", memory: "6Gi" }
+            limits:   { cpu: "12", memory: "16Gi" }
       volumes:
         - name: tiles
           persistentVolumeClaim: { claimName: tiles }

--- a/my-apps/development/temporal/postgres/deployment.yaml
+++ b/my-apps/development/temporal/postgres/deployment.yaml
@@ -77,10 +77,10 @@ spec:
             timeoutSeconds: 5
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 500m
+              memory: 512Mi
             limits:
-              memory: 1Gi
+              memory: 2Gi
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data

--- a/my-apps/development/temporal/values.yaml
+++ b/my-apps/development/temporal/values.yaml
@@ -12,6 +12,10 @@ server:
       memory: 512Mi
     limits:
       memory: 2Gi
+  metrics:
+    serviceMonitor:
+      enabled: true
+      interval: 30s
   config:
     logLevel: "info"
     persistence:

--- a/my-apps/development/temporal/vpa.yaml
+++ b/my-apps/development/temporal/vpa.yaml
@@ -10,7 +10,8 @@ spec:
     kind: Deployment
     name: temporal-postgres
   updatePolicy:
-    updateMode: InPlaceOrRecreate
+    # Recommend only: a Recreate of the single-replica DB takes every Temporal shard down; size it by hand from the recommendation.
+    updateMode: "Off"
     minReplicas: 1
   resourcePolicy:
     containerPolicies:


### PR DESCRIPTION
## Why

Overnight review of radar-ng found the app went dark for ~4 h (23:22Z–03:22Z) and three Temporal schedules (poll-alerts, tile-cleanup, open-meteo-sync-hrrr) slept for ~36 h. Root causes, all verified from live history/logs:

- **4 h radar gap** — both CoreDNS pods were down; the worker retried polls silently (no liveness probe) while its 2-min schedule sat behind a 90-min workflow timeout under `OverlapPolicy.SKIP`.
- **Sleeping schedules** — the Temporal server (`numHistoryShards: 1`) lost the scheduler workflow's timer; any signal wakes it. Not fixable from gitops; the worker gets a watchdog in the radar-ng repo PR.
- **Worker OOMKilled at 12Gi (2026-08-31)** — nowcast + HRRR + air-quality renders overlapped in one 4-slot process.
- **05:11Z control-plane outage** — a node reboot moved the single-replica Temporal Postgres; Longhorn needed 7 min to re-attach. The VPA's Recreate fallback can cause the same outage on its own.
- **HRRR forecast radar has not published in days** (manifest has no `radar-hrrr` layer) — code fix in the radar-ng PR; an alert is added here so it can't be silent again.

## What changes

**radar-ng app**
- Worker: `AllAtOnce` rollout (single replica pinned to the RWO node), requests 2 CPU / 6Gi (real steady use), memory limit 16Gi, `MRMS_RENDER_WORKERS=3`. Stale "frame takes ~10 min" comment corrected (25–40 s measured).
- tile-server: `TEMPORAL_ALERTS_TASK_QUEUE=radar-ng` so a future storm watch can't land on a queue with no poller.
- Alerts: worker OOMKilled / memory > 85 % / restart loop; HRRR layer absent 3 h; nowcast layer absent 30 min.
- Runbook: waking a schedule whose timer never fired.
- Two comments claiming the Worker Controller strips `podAffinity` corrected (the rendered Deployment keeps it).

**Temporal platform**
- `temporal-postgres` VPA → `updateMode: Off`; Postgres sized 500m/512Mi → 2Gi by hand.
- `server.metrics.serviceMonitor.enabled: true` — the server was never scraped. Temporal alert rules follow once metric names are confirmed.

## Rollout notes
- The WorkerDeployment change rolls the worker once (AllAtOnce). Schedules skip for ~1 min.
- `MRMS_RENDER_WORKERS` change needs the `CONFIG_REV` bump included here to roll pods.
- `RadarNgHrrrLayerMissing` will fire ~3 h after merge until the radar-ng HRRR fix ships. That is correct.
- Postgres resource change restarts the Temporal DB once (Recreate) → ~1–2 min control-plane blip. Merge when radar being 2–3 min late is acceptable.

## Not in this PR (design changes, see the plan in the radar-ng repo)
Isolated worker pools per role, tiles to object storage + multi-replica tile-server, dedicated Temporal namespace / sharded Temporal, CoreDNS 3 replicas + PDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyR6MAkCvKbbXgQVUUHFXh