### PR TITLE
radar-ng: Phase 1 worker pools + liveness + SDK metrics (images v1.1.25 / v1.1.15)

### DIFF
--- a/my-apps/development/radar-ng/deployment-tile-server.yaml
+++ b/my-apps/development/radar-ng/deployment-tile-server.yaml
@@ -56,7 +56,7 @@ spec:
         - name: tile-server
           # v1.1.6/v1.1.7 crashloop: caddy binary carried a file capability
           # that exec-fails under drop-ALL. Fixed in v1.1.8 (radar-ng 144dcb9).
-          image: ghcr.io/mitchross/radar-ng-tile-server:v1.1.14
+          image: ghcr.io/mitchross/radar-ng-tile-server:v1.1.15
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/my-apps/development/radar-ng/kustomization.yaml
+++ b/my-apps/development/radar-ng/kustomization.yaml
@@ -20,6 +20,8 @@ resources:
   - temporal-workers/configmap-temporal-config.yaml
   - temporal-workers/temporal-connection.yaml
   - temporal-workers/temporal-worker-deployment.yaml
+  - temporal-workers/worker-pools.yaml
+  - temporal-workers/podmonitor.yaml
 
 namespace: radar-ng
 

--- a/my-apps/development/radar-ng/temporal-workers/podmonitor.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/podmonitor.yaml
@@ -1,0 +1,17 @@
+# Temporal SDK metrics (schedule-to-start latency, slot usage, poll failures) from every worker pool.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: radar-ng-workers
+  namespace: radar-ng
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      radar-ng.vanillax.dev/worker: "true"
+  namespaceSelector:
+    matchNames: [radar-ng]
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 30s

--- a/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: radar-ng
   labels:
     app: radar-ng-worker
+    radar-ng.vanillax.dev/worker: "true"
 spec:
   replicas: 1
   workerOptions:
@@ -23,6 +24,7 @@ spec:
     metadata:
       labels:
         app: radar-ng-worker
+        radar-ng.vanillax.dev/worker: "true"
     spec:
       # Shares RWO tiles/grids/state with tile-server — must land on the same node or Longhorn Multi-Attach fails.
       affinity:
@@ -43,11 +45,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.24
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.25
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }
+          ports:
+            - { containerPort: 9464, name: metrics }
           env:
             # No OTEL endpoint on purpose — set, the worker spams UNAVAILABLE gRPC retries; unset = no-op tracer.
             # CONFIG_REV is a no-op; bump it to roll pods on ConfigMap changes (pod annotations aren't in the controller's hash).
@@ -69,6 +73,13 @@ spec:
               value: "0"
           envFrom:
             - configMapRef: { name: radar-ng-temporal-config }
+          # The worker touches this file only while Temporal check_health succeeds; a 4-h poll blackout once left a Ready pod doing nothing.
+          livenessProbe:
+            exec:
+              command: [sh, -c, "test $(find /tmp/temporal-healthy -mmin -3)"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
           volumeMounts:
             - { name: tiles,  mountPath: /data/tiles }
             - { name: grids,  mountPath: /data/grids }

--- a/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
@@ -1,0 +1,417 @@
+# One WorkerDeployment per Temporal task queue (plan Phase 1). Every pool polls only its own queue;
+# schedules still route to the legacy `radar-ng` queue until USE_ISOLATED_TASK_QUEUES=1 is set on the seeder (aux).
+# SKIP_SCHEDULE_SEED=1 everywhere here: the legacy worker seeds and runs the watchdog until the flip.
+# All pools share the RWO tiles/grids/state volumes, so they must land on tile-server's node (podAffinity).
+# Controller injects TEMPORAL_ADDRESS/NAMESPACE/DEPLOYMENT_NAME/WORKER_BUILD_ID — do not set them via env.
+---
+apiVersion: temporal.io/v1alpha1
+kind: WorkerDeployment
+metadata:
+  name: radar-ng-worker-mrms
+  namespace: radar-ng
+  labels:
+    app: radar-ng-worker-mrms
+    radar-ng.vanillax.dev/worker: "true"
+spec:
+  replicas: 1
+  workerOptions:
+    connectionRef:
+      name: cluster-temporal
+    temporalNamespace: default
+  rollout:
+    strategy: AllAtOnce
+  sunset:
+    scaledownDelay: 10m
+    deleteDelay: 1h
+  template:
+    metadata:
+      labels:
+        app: radar-ng-worker-mrms
+        radar-ng.vanillax.dev/worker: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: tile-server
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        # fsGroup REQUIRED: fresh Longhorn block volumes mount root:root; uid 1000 cannot write without it.
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: worker
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.25
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: [ALL] }
+          ports:
+            - { containerPort: 9464, name: metrics }
+          env:
+            - { name: WORKER_ROLE, value: mrms }
+            - { name: SKIP_SCHEDULE_SEED, value: "1" }
+            # MRMS_RENDER_WORKERS=3 spawns one process per palette; slots cover 2 frames x 2 layers plus list/mark.
+            - { name: TEMPORAL_MAX_CONCURRENT_ACTIVITIES, value: "6" }
+            - { name: TILE_DIR, value: /data/tiles }
+            - { name: GRID_DIR, value: /data/grids }
+            - { name: STATE_DIR, value: /data/state }
+            - { name: PUSH_DISABLED, value: "1" }
+          envFrom:
+            - configMapRef: { name: radar-ng-temporal-config }
+          # The worker touches this file only while Temporal check_health succeeds; a 4-h poll blackout once left a Ready pod doing nothing.
+          livenessProbe:
+            exec:
+              command: [sh, -c, "test $(find /tmp/temporal-healthy -mmin -3)"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+          volumeMounts:
+            - { name: tiles, mountPath: /data/tiles }
+            - { name: grids, mountPath: /data/grids }
+            - { name: state, mountPath: /data/state }
+          resources:
+            requests: { cpu: "2", memory: "3Gi" }
+            limits:   { cpu: "6", memory: "6Gi" }
+      volumes:
+        - name: tiles
+          persistentVolumeClaim: { claimName: tiles }
+        - name: grids
+          persistentVolumeClaim: { claimName: grids }
+        - name: state
+          persistentVolumeClaim: { claimName: state }
+---
+apiVersion: temporal.io/v1alpha1
+kind: WorkerDeployment
+metadata:
+  name: radar-ng-worker-nowcast
+  namespace: radar-ng
+  labels:
+    app: radar-ng-worker-nowcast
+    radar-ng.vanillax.dev/worker: "true"
+spec:
+  replicas: 1
+  workerOptions:
+    connectionRef:
+      name: cluster-temporal
+    temporalNamespace: default
+  rollout:
+    strategy: AllAtOnce
+  sunset:
+    scaledownDelay: 10m
+    deleteDelay: 1h
+  template:
+    metadata:
+      labels:
+        app: radar-ng-worker-nowcast
+        radar-ng.vanillax.dev/worker: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: tile-server
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        # fsGroup REQUIRED: fresh Longhorn block volumes mount root:root; uid 1000 cannot write without it.
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: worker
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.25
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: [ALL] }
+          ports:
+            - { containerPort: 9464, name: metrics }
+          env:
+            - { name: WORKER_ROLE, value: nowcast }
+            - { name: SKIP_SCHEDULE_SEED, value: "1" }
+            # One pysteps run at a time; a second would double the ~3 GiB peak and starve the first.
+            - { name: TEMPORAL_MAX_CONCURRENT_ACTIVITIES, value: "1" }
+            - { name: TILE_DIR, value: /data/tiles }
+            - { name: GRID_DIR, value: /data/grids }
+            - { name: STATE_DIR, value: /data/state }
+            - { name: PUSH_DISABLED, value: "1" }
+          envFrom:
+            - configMapRef: { name: radar-ng-temporal-config }
+          # The worker touches this file only while Temporal check_health succeeds; a 4-h poll blackout once left a Ready pod doing nothing.
+          livenessProbe:
+            exec:
+              command: [sh, -c, "test $(find /tmp/temporal-healthy -mmin -3)"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+          volumeMounts:
+            - { name: tiles, mountPath: /data/tiles }
+            - { name: grids, mountPath: /data/grids }
+            - { name: state, mountPath: /data/state }
+          resources:
+            requests: { cpu: "3", memory: "4Gi" }
+            limits:   { cpu: "8", memory: "8Gi" }
+      volumes:
+        - name: tiles
+          persistentVolumeClaim: { claimName: tiles }
+        - name: grids
+          persistentVolumeClaim: { claimName: grids }
+        - name: state
+          persistentVolumeClaim: { claimName: state }
+---
+apiVersion: temporal.io/v1alpha1
+kind: WorkerDeployment
+metadata:
+  name: radar-ng-worker-hrrr
+  namespace: radar-ng
+  labels:
+    app: radar-ng-worker-hrrr
+    radar-ng.vanillax.dev/worker: "true"
+spec:
+  replicas: 1
+  workerOptions:
+    connectionRef:
+      name: cluster-temporal
+    temporalNamespace: default
+  rollout:
+    strategy: AllAtOnce
+  sunset:
+    scaledownDelay: 10m
+    deleteDelay: 1h
+  template:
+    metadata:
+      labels:
+        app: radar-ng-worker-hrrr
+        radar-ng.vanillax.dev/worker: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: tile-server
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        # fsGroup REQUIRED: fresh Longhorn block volumes mount root:root; uid 1000 cannot write without it.
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: worker
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.25
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: [ALL] }
+          ports:
+            - { containerPort: 9464, name: metrics }
+          env:
+            - { name: WORKER_ROLE, value: hrrr }
+            - { name: SKIP_SCHEDULE_SEED, value: "1" }
+            # Fan-out is 4 hours at a time (FORECAST_CONCURRENCY), so 4 slots is the whole budget.
+            - { name: TEMPORAL_MAX_CONCURRENT_ACTIVITIES, value: "4" }
+            - { name: TILE_DIR, value: /data/tiles }
+            - { name: GRID_DIR, value: /data/grids }
+            - { name: STATE_DIR, value: /data/state }
+            - { name: PUSH_DISABLED, value: "1" }
+          envFrom:
+            - configMapRef: { name: radar-ng-temporal-config }
+          # The worker touches this file only while Temporal check_health succeeds; a 4-h poll blackout once left a Ready pod doing nothing.
+          livenessProbe:
+            exec:
+              command: [sh, -c, "test $(find /tmp/temporal-healthy -mmin -3)"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+          volumeMounts:
+            - { name: tiles, mountPath: /data/tiles }
+            - { name: grids, mountPath: /data/grids }
+            - { name: state, mountPath: /data/state }
+          resources:
+            requests: { cpu: "1", memory: "2Gi" }
+            limits:   { cpu: "4", memory: "6Gi" }
+      volumes:
+        - name: tiles
+          persistentVolumeClaim: { claimName: tiles }
+        - name: grids
+          persistentVolumeClaim: { claimName: grids }
+        - name: state
+          persistentVolumeClaim: { claimName: state }
+---
+apiVersion: temporal.io/v1alpha1
+kind: WorkerDeployment
+metadata:
+  name: radar-ng-worker-aux
+  namespace: radar-ng
+  labels:
+    app: radar-ng-worker-aux
+    radar-ng.vanillax.dev/worker: "true"
+spec:
+  replicas: 1
+  workerOptions:
+    connectionRef:
+      name: cluster-temporal
+    temporalNamespace: default
+  rollout:
+    strategy: AllAtOnce
+  sunset:
+    scaledownDelay: 10m
+    deleteDelay: 1h
+  template:
+    metadata:
+      labels:
+        app: radar-ng-worker-aux
+        radar-ng.vanillax.dev/worker: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: tile-server
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        # fsGroup REQUIRED: fresh Longhorn block volumes mount root:root; uid 1000 cannot write without it.
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: worker
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.25
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: [ALL] }
+          ports:
+            - { containerPort: 9464, name: metrics }
+          env:
+            - { name: WORKER_ROLE, value: aux }
+            - { name: SKIP_SCHEDULE_SEED, value: "1" }
+            # Lightning holds one slot ~50 min/h; air quality chunks, tropical and cleanup share the rest.
+            - { name: TEMPORAL_MAX_CONCURRENT_ACTIVITIES, value: "4" }
+            - { name: TILE_DIR, value: /data/tiles }
+            - { name: GRID_DIR, value: /data/grids }
+            - { name: STATE_DIR, value: /data/state }
+            - { name: PUSH_DISABLED, value: "1" }
+          envFrom:
+            - configMapRef: { name: radar-ng-temporal-config }
+          # The worker touches this file only while Temporal check_health succeeds; a 4-h poll blackout once left a Ready pod doing nothing.
+          livenessProbe:
+            exec:
+              command: [sh, -c, "test $(find /tmp/temporal-healthy -mmin -3)"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+          volumeMounts:
+            - { name: tiles, mountPath: /data/tiles }
+            - { name: grids, mountPath: /data/grids }
+            - { name: state, mountPath: /data/state }
+          resources:
+            requests: { cpu: "500m", memory: "1.5Gi" }
+            limits:   { cpu: "2", memory: "4Gi" }
+      volumes:
+        - name: tiles
+          persistentVolumeClaim: { claimName: tiles }
+        - name: grids
+          persistentVolumeClaim: { claimName: grids }
+        - name: state
+          persistentVolumeClaim: { claimName: state }
+---
+apiVersion: temporal.io/v1alpha1
+kind: WorkerDeployment
+metadata:
+  name: radar-ng-worker-alerts
+  namespace: radar-ng
+  labels:
+    app: radar-ng-worker-alerts
+    radar-ng.vanillax.dev/worker: "true"
+spec:
+  replicas: 1
+  workerOptions:
+    connectionRef:
+      name: cluster-temporal
+    temporalNamespace: default
+  rollout:
+    strategy: AllAtOnce
+  sunset:
+    scaledownDelay: 10m
+    deleteDelay: 1h
+  template:
+    metadata:
+      labels:
+        app: radar-ng-worker-alerts
+        radar-ng.vanillax.dev/worker: "true"
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: tile-server
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        # fsGroup REQUIRED: fresh Longhorn block volumes mount root:root; uid 1000 cannot write without it.
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: worker
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.25
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: [ALL] }
+          ports:
+            - { containerPort: 9464, name: metrics }
+          env:
+            - { name: WORKER_ROLE, value: alerts }
+            - { name: SKIP_SCHEDULE_SEED, value: "1" }
+            # Small HTTP/JSON activities only; storm watches read grids, never write tiles.
+            - { name: TEMPORAL_MAX_CONCURRENT_ACTIVITIES, value: "8" }
+            - { name: TILE_DIR, value: /data/tiles }
+            - { name: GRID_DIR, value: /data/grids }
+            - { name: STATE_DIR, value: /data/state }
+            - { name: PUSH_DISABLED, value: "1" }
+          envFrom:
+            - configMapRef: { name: radar-ng-temporal-config }
+          # The worker touches this file only while Temporal check_health succeeds; a 4-h poll blackout once left a Ready pod doing nothing.
+          livenessProbe:
+            exec:
+              command: [sh, -c, "test $(find /tmp/temporal-healthy -mmin -3)"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+          volumeMounts:
+            - { name: state, mountPath: /data/state }
+            - { name: grids, mountPath: /data/grids, readOnly: true }
+          resources:
+            requests: { cpu: "250m", memory: "512Mi" }
+            limits:   { cpu: "1", memory: "1Gi" }
+      volumes:
+        - name: state
+          persistentVolumeClaim: { claimName: state }
+        - name: grids
+          persistentVolumeClaim: { claimName: grids }


### PR DESCRIPTION
## What

Phase 1, step 2 of `docs/reliability-and-scale-plan.md` (radar-ng repo).

- **Image bumps**: worker `v1.1.25`, tile-server `v1.1.15` — built from radar-ng #33 (schedule timeouts, watchdog, health file, HRRR fix, backend hardening).
- **Liveness probe** on every worker: `test $(find /tmp/temporal-healthy -mmin -3)`. The new image touches that file only while Temporal `check_health` succeeds. During the 4-h DNS outage the worker sat Ready doing nothing; this restarts it instead.
- **Five WorkerDeployments** (`radar-ng-worker-{mrms,nowcast,hrrr,aux,alerts}`), one per task queue, each with its own `TEMPORAL_MAX_CONCURRENT_ACTIVITIES` and memory budget (plan §5 Phase 1 table). All `AllAtOnce`, `SKIP_SCHEDULE_SEED=1`, pinned to tile-server's node by the RWO volumes.
- **PodMonitor** scraping the SDK Prometheus port (9464) on every worker pool: schedule-to-start latency, slot usage, poll failures.

## What this does NOT do yet

Schedules still route to the legacy `radar-ng` queue. The pools poll their own queues and stay idle (they hold ~7 CPU / 12 Gi of requests on the GPU node meanwhile). The flip is the next PR, once each queue shows a poller:

```sh
kubectl -n temporal exec deploy/temporal-admintools -- temporal task-queue describe \
  --address temporal-frontend.temporal.svc.cluster.local:7233 --namespace default \
  --task-queue radar-ng-mrms --select-all-active
```

Cutover order (plan Phase 1): set `SKIP_SCHEDULE_SEED=1` on legacy **before** `USE_ISOLATED_TASK_QUEUES=1` + `SEED_SCHEDULES=1` on `aux`; then tile-server `TEMPORAL_ALERTS_TASK_QUEUE=radar-ng-alerts`; then scale legacy to 0 when nothing is Running on `radar-ng`.

## Rollout

Legacy worker rolls once (image + probe). Schedules skip ~1 min. Watch `kubectl -n radar-ng get pods` for the five new pools reaching Running and the probe not flapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyR6MAkCvKbbXgQVUUHFXh