### PR TITLE
fix(radar-ng): stop WorkerDeployment default-field self-heal loop

### DIFF
--- a/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     app: radar-ng-worker
     radar-ng.vanillax.dev/worker: "true"
 spec:
+  minReadySeconds: 0
+  progressDeadlineSeconds: 600
   replicas: 1
   workerOptions:
     connectionRef:
@@ -51,7 +53,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }
           ports:
-            - { containerPort: 9464, name: metrics }
+            - { containerPort: 9464, name: metrics, protocol: TCP }
           env:
             # No OTEL endpoint on purpose — set, the worker spams UNAVAILABLE gRPC retries; unset = no-op tracer.
             # CONFIG_REV is a no-op; bump it to roll pods on ConfigMap changes (pod annotations aren't in the controller's hash).

--- a/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
@@ -13,6 +13,8 @@ metadata:
     app: radar-ng-worker-mrms
     radar-ng.vanillax.dev/worker: "true"
 spec:
+  minReadySeconds: 0
+  progressDeadlineSeconds: 600
   replicas: 1
   workerOptions:
     connectionRef:
@@ -53,7 +55,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }
           ports:
-            - { containerPort: 9464, name: metrics }
+            - { containerPort: 9464, name: metrics, protocol: TCP }
           env:
             - { name: WORKER_ROLE, value: mrms }
             - { name: SKIP_SCHEDULE_SEED, value: "1" }
@@ -96,6 +98,8 @@ metadata:
     app: radar-ng-worker-nowcast
     radar-ng.vanillax.dev/worker: "true"
 spec:
+  minReadySeconds: 0
+  progressDeadlineSeconds: 600
   replicas: 1
   workerOptions:
     connectionRef:
@@ -136,7 +140,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }
           ports:
-            - { containerPort: 9464, name: metrics }
+            - { containerPort: 9464, name: metrics, protocol: TCP }
           env:
             - { name: WORKER_ROLE, value: nowcast }
             - { name: SKIP_SCHEDULE_SEED, value: "1" }
@@ -179,6 +183,8 @@ metadata:
     app: radar-ng-worker-hrrr
     radar-ng.vanillax.dev/worker: "true"
 spec:
+  minReadySeconds: 0
+  progressDeadlineSeconds: 600
   replicas: 1
   workerOptions:
     connectionRef:
@@ -219,7 +225,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }
           ports:
-            - { containerPort: 9464, name: metrics }
+            - { containerPort: 9464, name: metrics, protocol: TCP }
           env:
             - { name: WORKER_ROLE, value: hrrr }
             - { name: SKIP_SCHEDULE_SEED, value: "1" }
@@ -262,6 +268,8 @@ metadata:
     app: radar-ng-worker-aux
     radar-ng.vanillax.dev/worker: "true"
 spec:
+  minReadySeconds: 0
+  progressDeadlineSeconds: 600
   replicas: 1
   workerOptions:
     connectionRef:
@@ -302,7 +310,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }
           ports:
-            - { containerPort: 9464, name: metrics }
+            - { containerPort: 9464, name: metrics, protocol: TCP }
           env:
             - { name: WORKER_ROLE, value: aux }
             - { name: SKIP_SCHEDULE_SEED, value: "1" }
@@ -345,6 +353,8 @@ metadata:
     app: radar-ng-worker-alerts
     radar-ng.vanillax.dev/worker: "true"
 spec:
+  minReadySeconds: 0
+  progressDeadlineSeconds: 600
   replicas: 1
   workerOptions:
     connectionRef:
@@ -385,7 +395,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities: { drop: [ALL] }
           ports:
-            - { containerPort: 9464, name: metrics }
+            - { containerPort: 9464, name: metrics, protocol: TCP }
           env:
             - { name: WORKER_ROLE, value: alerts }
             - { name: SKIP_SCHEDULE_SEED, value: "1" }


### PR DESCRIPTION
## What changed

Declare the three defaults added by the WorkerDeployment admission API on all six Radar worker resources:

- `minReadySeconds: 0`
- `progressDeadlineSeconds: 600`
- container port `protocol: TCP`

## Why

Argo CD saw those defaulted live fields as drift and server-side-applied all six WorkerDeployments roughly every five minutes. This makes Git match the API representation; no pod or workload behavior change is intended.

## Validation

- `git diff --check`
- `kustomize build my-apps/development/radar-ng`
- `scripts/validate-argocd-apps.sh`
- `scripts/validate-no-inline-scripts.sh`
- server-side dry-run accepted all six WorkerDeployments