### PR TITLE
fix(radar-ng): deploy HRRR worker v1.1.27

### DIFF
--- a/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
@@ -47,7 +47,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.26
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
@@ -49,7 +49,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.26
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -134,7 +134,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.26
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -219,7 +219,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.26
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -304,7 +304,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.26
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -389,7 +389,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.26
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## What changed

- Deploy radar-ng temporal worker v1.1.27 to the legacy worker and all five isolated role pools.
- Keep the tile server unchanged.

## Provenance

- Built by successful release run 33673202433 from Radar PR #36 merge 1d5d0c5087196bea086e0df7e08e879bc0fc2b3b.
- GHCR digest: sha256:792adbd883cef6783c96bb651ebc337bacd6076d7f52c01930b7ddb59bbe52f3.
- v1.1.27 supersedes the live v1.1.26 rollout. v1.1.26 was built from workflow-only merge #38 and does not contain the HRRR source fix.

## Why all six refs

Schedules still route to the legacy radar-ng queue while isolated pools remain idle. The same image also owns every role registration, so keeping all six WorkerDeployments identical avoids mixed worker behavior before queue cutover.

## Validation

- git diff --check
- kustomize build my-apps/development/radar-ng
- scripts/validate-argocd-apps.sh
- scripts/validate-no-inline-scripts.sh
- kubectl apply --server-side --dry-run=server for all six rendered WorkerDeployments
- Rendered manifest contains exactly six v1.1.27 worker refs and no v1.1.26 refs
