### PR TITLE
docs(radar-ng): correct isolated queue cutover

### DIFF
--- a/my-apps/development/radar-ng/RUNBOOK.md
+++ b/my-apps/development/radar-ng/RUNBOOK.md
@@ -84,39 +84,46 @@ frame with every configured palette.
 
 The application image contains role-aware queues for `mrms`, `nowcast`,
 `hrrr`, `aux`, and `alerts`. Keep `USE_ISOLATED_TASK_QUEUES=0` on the legacy
-pool until an image containing those roles is running. Then:
+pool until the observe-only Schedule image is running on all six workers. Then:
 
-1. Seed the `radar-ng` Temporal namespace and deploy one WorkerDeployment per
-   role with `SKIP_SCHEDULE_SEED=1` except `aux`.
-2. Confirm each target version is current and polling its role queue.
-3. Set `USE_ISOLATED_TASK_QUEUES=1` and `SEED_SCHEDULES=1` only on `aux`.
-4. Confirm all schedules point to their role queues before scaling legacy.
-5. Leave legacy polling `radar-ng` until pinned executions drain; never delete
-   it merely because new schedule traffic moved.
+1. Deploy the exact same image digest to legacy and the five role pools. Leave
+   `SKIP_SCHEDULE_SEED=1` on every role pool.
+2. Confirm all six target versions are current, the five role queues have both
+   workflow and activity pollers, and the Open-Meteo queue has its activity
+   poller. Check node memory headroom while both pool sets coexist.
+3. Keep legacy as the sole seeder and Schedule observer. Do not transfer
+   seeding to `aux` during this cutover.
+4. Change only legacy's `USE_ISOLATED_TASK_QUEUES` from `0` to `1`. Its seeder
+   updates the schedules after the destination pollers are ready.
+5. Confirm every schedule's actual task queue, then observe one natural run per
+   role. A manual trigger is not proof that the Schedule timer is healthy.
+6. Leave legacy polling `radar-ng` until pinned and long-lived executions drain;
+   never delete it merely because new schedule traffic moved.
+
+Before workflow API routes are enabled, separately change tile-server's
+`TEMPORAL_ALERTS_TASK_QUEUE` to `radar-ng-alerts` and roll it. Those routes are
+disabled today, so keep that rollout out of the initial Schedule cutover.
 
 This ordering prevents a schedule update from routing work to a queue with no
-poller and keeps existing pinned workflows replayable.
+poller, keeps one declarative Schedule writer, and preserves replayability for
+existing pinned workflows. Roll back by first proving the legacy pollers are
+healthy, changing the legacy flag back to `0`, and letting the same seeder route
+schedules back. Keep the role pools until their executions drain.
 
 ## Schedule stops firing (timer never fires)
 
-Signature: `temporal schedule describe --schedule-id <id>` shows `NextRunTime`
-in the past, `RunningWorkflows []`, not paused, and `ActionCounts.MissedCatchupWindow`
-climbing. The schedule answers RPCs instantly, so the seed self-heal (which only
-recreates schedules whose RPCs hang) does nothing. The backing
-`temporal-sys-scheduler:<id>` workflow set a timer that the 1-shard history
-service never fired; it stays asleep until something signals it.
+Signature: `temporal schedule describe --schedule-id <id>` shows its next action
+in the past, no running action, and no natural fire. A manual trigger can make
+fresh application output while leaving the Schedule's durable timer stranded,
+so it is mitigation, not repair.
 
-Any signal wakes it — `describe` and `trigger` both do:
+The application observer deliberately does not trigger, update, delete,
+recreate, terminate, or purge anything. Treat its critical overdue event as a
+Temporal control-plane incident. Inventory the timer DLQ and affected workflow
+histories using the [Temporal timer DLQ runbook](../temporal/README.md#timer-dlq-alert-runbook).
+Coordinate every affected application owner before approving a DLQ prefix
+merge; prefix semantics may include another application's messages.
 
-```sh
-kubectl -n temporal exec deploy/temporal-admintools -- \
-  temporal schedule trigger \
-  --address temporal-frontend.temporal.svc.cluster.local:7233 \
-  --namespace default \
-  --schedule-id poll-alerts --overlap-policy Skip
-```
-
-Expect it to wedge again after the next run until the worker image carries the
-schedule watchdog (it re-triggers overdue schedules itself). Verify recovery by
-the state file the workflow writes, e.g. `alerts_active_snapshot.json` mtime on
-the `state` PVC moving.
+Recovery is complete only after the DLQ job succeeds, the queue is inventoried
+again, and affected schedules fire naturally for at least two cadences. Never
+purge the DLQ or use a manual trigger as the acceptance test.

--- a/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
@@ -1,6 +1,6 @@
 # One WorkerDeployment per Temporal task queue (plan Phase 1). Every pool polls only its own queue;
-# schedules still route to the legacy `radar-ng` queue until USE_ISOLATED_TASK_QUEUES=1 is set on the seeder (aux).
-# SKIP_SCHEDULE_SEED=1 everywhere here: the legacy worker seeds and runs the watchdog until the flip.
+# schedules still route to the legacy `radar-ng` queue until USE_ISOLATED_TASK_QUEUES=1 is set on legacy.
+# SKIP_SCHEDULE_SEED=1 stays set on every role pool during the initial cutover; legacy remains the sole seeder/observer.
 # All pools share the RWO tiles/grids/state volumes, so they must land on tile-server's node (podAffinity).
 # Controller injects TEMPORAL_ADDRESS/NAMESPACE/DEPLOYMENT_NAME/WORKER_BUILD_ID — do not set them via env.
 ---


### PR DESCRIPTION
## What changed
- keep legacy as the sole Schedule seeder/observer during initial role-queue cutover
- flip only the legacy queue-routing flag after the same observe-only image digest and pollers are verified on all six workers
- replace stale trigger-based timer recovery with the shared Temporal DLQ runbook
- document the separate alerts API queue rollout and safe rollback

## Safety
Documentation and comments only; rendered Kubernetes resources are unchanged.

Depends on #2178 for the linked timer-DLQ runbook.

## Validation
- git diff --check
- kustomize build my-apps/development/radar-ng