### PR TITLE
feat(storage): add wired two-replica Longhorn tier

### DIFF
--- a/docs/domains/storage/storage-tiers.md
+++ b/docs/domains/storage/storage-tiers.md
@@ -1,12 +1,13 @@
 # Storage tiers
 
-The cluster has four storage tiers, **classified by what the hardware is** — not by
+The cluster has five storage tiers, **classified by what the hardware is** — not by
 which app uses them. Pick a class by the volume's access pattern.
 
 | Class | Backing hardware | Character | Use for |
 |-------|------------------|-----------|---------|
 | `longhorn` (**default**) | Threadripper EDILOCA NVMe plus the Dell Talos system SSD | local RWO; Threadripper tier is **read-strong**, Dell is a small Wi-Fi-site failure domain | app state, caches, read-heavy volumes, big sequential-write DBs (ClickHouse, Prometheus TSDB, Loki) |
 | `longhorn-flash` | Proxmox 2× enterprise SATA SSD, PLP, mdadm RAID1, **thick** LVM | fast local flash, **write-strong** (PLP), RWO | anything fsync-heavy: Postgres/MySQL commits, WAL, Kafka, Redis AOF, message queues |
+| `longhorn-wired-ha` | two distinct nodes/zones carrying the Longhorn `wired-storage` node tag | local V1 RWO, two synchronous replicas, survives one eligible node/disk loss | availability-critical small databases/state, paired with kopiur for disaster recovery |
 | `truenas-nfs` | TrueNAS HDD (BigTank) | network bulk, **RWX** | shared volumes, rebuildable tile/grid caches |
 | `*-smb` / static NFS | TrueNAS HDD / ai-pool SSD | network SMB/NFS shares | media libraries, model weights, hand-browsable data |
 
@@ -19,7 +20,13 @@ distinct classes, and you choose per volume:
 - **read-heavy or big-sequential-write → `longhorn` (default).** The NVMe reads far
   faster, and sequential write on this host's X399 chipset SATA is only ~65–92 MB/s.
 - **shared (RWX) → NFS/SMB.** Neither local block tier can be RWX safely.
+- **availability-critical small state → `longhorn-wired-ha`.** It trades one extra synchronous
+  local-network write for a second live copy; kopiur remains the recoverable off-cluster copy.
 - **when in doubt → `longhorn` default.**
+
+`longhorn-wired-ha` is opt-in and fails closed until at least two healthy,
+distinct-zone Longhorn nodes have the `wired-storage` node tag. Adding the class
+does not migrate existing PVCs; use a new or restore-before-bind PVC for adoption.
 
 ## The rule that matters most in practice: get small-block RANDOM IO off the HDD
 
@@ -144,10 +151,13 @@ This is also what modern Kubernetes-on-metal actually does — OpenShift Data Fo
 and vSAN all pool **local** NVMe and replicate in software, rather than front a SAN. Kubernetes
 already handles replication at the app layer; shared-array semantics are redundant.
 
-## The real single point of failure (unchanged until replica policy changes)
+## The real single point of failure for existing volumes
 
-The Dell provides a second schedulable Longhorn disk, but the `longhorn`
-StorageClass and existing volumes still request one replica. Capacity on two
-nodes is not redundancy: selected volumes must move to two replicas before
-they survive losing either Proxmox host. That trade-off is explicit because
-the second synchronous replica crosses the Wi-Fi media bridge.
+The `longhorn` StorageClass and existing volumes still request one replica.
+Capacity on several nodes is not redundancy: selected volumes must move to two
+replicas before they survive losing a storage node. The one-copy default remains
+deliberate for ordinary and rebuildable state; high availability is opt-in.
+
+The opt-in `longhorn-wired-ha` class is the migration target for small critical
+state once the wired-node tags are deployed and verified. It never changes an
+existing volume in place.

--- a/infrastructure/storage/CLAUDE.md
+++ b/infrastructure/storage/CLAUDE.md
@@ -5,6 +5,7 @@
 | Class | Use Case |
 |-------|----------|
 | `longhorn` | Distributed block storage — **cluster default**, served by the **V1 data engine** (chart default). The Threadripper GPU worker has three Longhorn disks: `/var/lib/longhorn`, `/var/mnt/longhorn-nvme1`, and flash-tagged `/var/mnt/longhorn-ssd-flash`. The Dell CPU worker adds a dedicated 400 GiB virtual disk on its Samsung 500 GB SSD at `/var/mnt/longhorn-dell-ssd` (tag `dell-ssd`); its Talos boot disk stays unschedulable. The Threadripper general worker is compute-only. Dell capacity is a separate failure domain (zone `dell`), not HA by itself. **V2/SPDK was tried and retired 2026-06-12** — it failed under full-DR restore load (open Longhorn 1.12 bugs #13315/#13314); forensics in git history; short version in `docs/disaster-recovery.md`. Do not re-enable V2 without a fixed release + a passed DR drill. |
+| `longhorn-wired-ha` | Opt-in two-replica V1 RWO storage across distinct trusted wired nodes/zones. Use only after at least two Longhorn nodes carry the `wired-storage` node tag; provisioning deliberately fails before that prerequisite. Availability-critical small databases/state, always paired with kopiur. Existing PVCs do not migrate when their StorageClass changes. |
 | `truenas-nfs` | Official TrueNAS CSI dynamic NFS (canary-gated, non-default) |
 | `nfs-comfyui-10g` | NFS 10G for ComfyUI models |
 | `nfs-llama-cpp-10g` | NFS 10G for LLM models |

--- a/infrastructure/storage/longhorn/kustomization.yaml
+++ b/infrastructure/storage/longhorn/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
   - node-failure-settings.yaml
   # Fast local flash tier — enterprise-SSD Longhorn disk (tag `flash`).
   - storageclass-flash.yaml
+  # Two-copy critical-state tier; provisioning fails closed until wired Longhorn node tags exist.
+  - storageclass-wired-ha.yaml
   # Disposable kopiur snapshot clones. WFFC lets the mover pick the node before the clone is provisioned (avoids V1 clone attach race).
   - storageclass-kopiur-staging.yaml
   # Chart-created `longhorn` StorageClass is V1-engine; do NOT route it to dataEngine:v2 (retired, see values.yaml).

--- a/infrastructure/storage/longhorn/storageclass-wired-ha.yaml
+++ b/infrastructure/storage/longhorn/storageclass-wired-ha.yaml
@@ -1,0 +1,25 @@
+# Two-copy RWO tier for availability-critical state on trusted wired storage nodes.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-wired-ha
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+    argocd.argoproj.io/sync-options: Replace=true
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "2"
+  staleReplicaTimeout: "30"
+  fsType: "ext4"
+  dataEngine: "v1"
+  nodeSelector: "wired-storage"
+  dataLocality: "best-effort"
+  replicaAutoBalance: "best-effort"
+  replicaSoftAntiAffinity: "disabled"
+  replicaZoneSoftAntiAffinity: "disabled"
+  replicaDiskSoftAntiAffinity: "disabled"
+  disableRevisionCounter: "true"
+  unmapMarkSnapChainRemoved: "ignored"


### PR DESCRIPTION
## Outcome

Add an opt-in `longhorn-wired-ha` StorageClass for small, availability-critical RWO state.

The class uses the Longhorn V1 engine, two replicas, hard node/zone/disk separation, the `wired-storage` Longhorn node tag, and best-effort locality/auto-balance. It is not the default, and no PVC selects it in this PR.

## Why

The 2026-09-02 Temporal outage proved that capacity on several nodes is not availability when a database volume still has one replica. Temporal Postgres lost service when the one node holding its one replica became unreachable.

Kopiur remains the off-cluster disaster-recovery copy. This class adds a second live copy so one eligible storage node can fail without forcing a restore.

## Safety

- No live PVC is changed or migrated.
- Provisioning fails closed until at least two distinct-zone Longhorn nodes carry the `wired-storage` node tag.
- The cluster default `longhorn` class remains one replica.
- V1 remains explicit; this does not revive the retired V2 engine.
- StorageClass parameters are create-time only; adoption requires a new or restore-before-bind PVC.

## Validation

- `kustomize build --enable-helm infrastructure/storage/longhorn` passed and rendered the expected class.
- Kubernetes server-side dry-run accepted the manifest.
- `scripts/validate-argocd-apps.sh` passed.
- `scripts/validate-no-inline-scripts.sh` passed.
- `git diff --check` passed.

## Follow-up gate

Before any PVC uses this class, commit and deploy the intended Omni node definitions, add the Longhorn `wired-storage` node tag to verified wired storage nodes, and prove a disposable two-replica canary becomes healthy and rebuilds after losing one replica. Temporal migration must use a distinct restored PVC; never edit the existing PVC StorageClass in place.
