### PR TITLE
ai: add Qwen3.8 Flash-Next MTP llama.cpp sidecar

### DIFF
--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -8,7 +8,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  # Parked GGUF rollback backend; vLLM owns the sole RTX 3090.
+  # Parked experimental Flash-Next MTP sidecar; vLLM owns the sole RTX 3090.
+  # Scale vLLM down before setting this deployment to replicas: 1.
   replicas: 0
   strategy:
     type: Recreate
@@ -36,18 +37,57 @@ spec:
       securityContext:
         fsGroup: 10001
         fsGroupChangePolicy: OnRootMismatch
+      initContainers:
+        - name: install-unsloth-llama-cpp
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              apk add --no-cache curl
+              tag=b10715-mix-86bd2d3
+              asset=app-b10715-mix-86bd2d3-linux-x64-cuda12-portable.tar.gz
+              expected=0b5127dc1c50908fdae74e93369c4d943155f3beeddd4a2b15b0f4e8c05687dc
+              url="https://github.com/unslothai/llama.cpp/releases/download/$tag/$asset"
+              curl -fL --retry 5 -o /tmp/llama.tar.gz "$url"
+              echo "$expected  /tmp/llama.tar.gz" | sha256sum -c -
+              tar -xzf /tmp/llama.tar.gz -C /opt/unsloth
+              server="$(find /opt/unsloth -type f -name llama-server -perm -u+x | head -n 1)"
+              [ -n "$server" ] || { echo "llama-server not found in $asset"; exit 1; }
+              if [ "$server" != /opt/unsloth/llama-server ]; then
+                ln -sf "$server" /opt/unsloth/llama-server
+              fi
+              /opt/unsloth/llama-server --version
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+          volumeMounts:
+            - name: unsloth-bin
+              mountPath: /opt/unsloth
       containers:
         - name: llama-cpp-server
+          # Keep the official CUDA image as the runtime environment; the pinned
+          # Unsloth binary above supplies qwen4exp MTP + tensor borrowing.
           image: ghcr.io/ggml-org/llama.cpp:server-cuda-b10666@sha256:a2d04d1d1c2b2abe287fef9a22a3700a7fa20aec4c4ab56135e0099f38119848
           imagePullPolicy: IfNotPresent
-          command: ["/app/llama-server"]
+          command: ["/opt/unsloth/llama-server"]
           args:
             - --model
             - /models/qwen3.8-flash-next-gguf/unsloth-ud-iq4-xs/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf
             - --mmproj
             - /models/qwen3.8-flash-next-gguf/mmproj-BF16.gguf
+            - -md
+            - /models/qwen3.8-flash-next-gguf/mtp/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf
+            - --spec-type
+            - draft-mtp
+            - --spec-draft-n-max
+            - "3"
             - --alias
-            - Qwen3.8-Flash-Next Q4
+            - Qwen3.8-Flash-Next Q4 MTP
             - --ctx-size
             - "131072"
             - --batch-size
@@ -99,6 +139,8 @@ spec:
           env:
             - name: NVIDIA_DRIVER_CAPABILITIES
               value: compute,utility
+            - name: LD_LIBRARY_PATH
+              value: /opt/unsloth:/opt/unsloth/lib
           ports:
             - name: http
               containerPort: 8080
@@ -139,6 +181,9 @@ spec:
             - name: models
               mountPath: /models
               readOnly: true
+            - name: unsloth-bin
+              mountPath: /opt/unsloth
+              readOnly: true
             - name: dshm
               mountPath: /dev/shm
       volumes:
@@ -147,6 +192,8 @@ spec:
         - name: models
           persistentVolumeClaim:
             claimName: ai-model-cache
+        - name: unsloth-bin
+          emptyDir: {}
         - name: dshm
           emptyDir:
             medium: Memory

--- a/my-apps/ai/llama-cpp/kustomization.yaml
+++ b/my-apps/ai/llama-cpp/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - pvc.yaml
   - pvc-model-cache.yaml
   - download-model-job.yaml
+  - mtp-download-job.yaml
   - cache-sync-job.yaml
   - deployment.yaml
   - service.yaml

--- a/my-apps/ai/llama-cpp/mtp-download-job.yaml
+++ b/my-apps/ai/llama-cpp/mtp-download-job.yaml
@@ -1,0 +1,68 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: llama-cpp-download-qwen38-flash-next-mtp
+  namespace: llama-cpp
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 4
+  activeDeadlineSeconds: 3600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.vanillax.dev/class
+                    operator: In
+                    values:
+                      - dell-worker
+      containers:
+        - name: download
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              apk add --no-cache curl
+              base=/models/qwen3.8-flash-next-gguf/mtp
+              file=mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf
+              rev=5d16c055a7c5cb276e721ee154f9c22420dde2a1
+              expected=5ff54097406a905cf3a724c709124ceb0e3e10235ee862298969e91c96fa96e6
+              mkdir -p "$base"
+              if [ -f "$base/$file" ] && [ "$(cat "$base/$file.sha256" 2>/dev/null)" = "$expected" ]; then
+                echo "verified (stamp): $file"
+                exit 0
+              fi
+              curl -fL --retry 5 -C - \
+                -o "$base/$file.part" \
+                "https://huggingface.co/unsloth/Qwen3.8-Flash-Next-GGUF/resolve/$rev/MTP/$file"
+              actual="$(sha256sum "$base/$file.part" | cut -d' ' -f1)"
+              [ "$actual" = "$expected" ] || {
+                echo "SHA MISMATCH: $file: $actual"
+                rm -f "$base/$file.part"
+                exit 1
+              }
+              mv "$base/$file.part" "$base/$file"
+              printf '%s' "$expected" > "$base/$file.sha256"
+              echo "downloaded and verified: $file"
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+          volumeMounts:
+            - name: models
+              mountPath: /models
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: llama-cpp-models-pvc

--- a/my-apps/ai/llama-cpp/scripts/sync-model-cache.sh
+++ b/my-apps/ai/llama-cpp/scripts/sync-model-cache.sh
@@ -4,7 +4,8 @@ DST=/dst/qwen3.8-flash-next-gguf
 mkdir -p \
   "$DST/unsloth-ud-iq4-xs" \
   "$DST/unsloth-ud-q4-k-xl" \
-  "$DST/atomic-ad-4.27-q4-k-m-m64"
+  "$DST/atomic-ad-4.27-q4-k-m-m64" \
+  "$DST/mtp"
 
 sync_one() {
   rel="$1"; s="$SRC/$rel"; d="$DST/$rel"
@@ -27,6 +28,7 @@ for i in 1 2 3 4; do
   sync_one "unsloth-ud-q4-k-xl/Qwen3.8-Flash-Next-UD-Q4_K_XL-0000$i-of-00004.gguf"
 done
 sync_one "mmproj-BF16.gguf"
+sync_one "mtp/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf"
 
 i=1
 while [ "$i" -le 33 ]; do
@@ -39,4 +41,3 @@ sync_one "mmproj-F16.gguf"
 echo "=== RESULT ==="
 du -sb "$DST" | awk '{printf "cache: %s bytes (%.2f GiB)\n", $1, $1/1073741824}'
 df -h /dst
-


### PR DESCRIPTION
## What

Adds an opt-in Qwen3.8-Flash-Next MTP test path for the existing parked llama.cpp deployment while leaving the production Qwen3.8-27B/vLLM backend untouched.

- keeps `replicas: 0` so this cannot contend with the production RTX 3090 until explicitly scaled
- uses Unsloth llama.cpp `b10715-mix-86bd2d3` CUDA 12 portable release, SHA256 pinned and verified at pod startup
- downloads and SHA-verifies Unsloth's recommended `mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf`
- hydrates the MTP head through the existing NFS -> node-local NVMe cache flow
- enables `draft-mtp` with `--spec-draft-n-max 3`
- retains the existing IQ4_XS target, 128K context, Q8 KV, CPU MoE offload, mmap/lazy reads, and BF16 vision projector

## Why

A new reproducible single-RTX-3090 Flash-Next result shows MTP materially improving decode throughput at useful context depths. Unsloth now publishes the qwen4exp MTP build and shared Q8 draft head, but this support is not in mainline llama.cpp yet. This PR isolates that experiment from production rather than replacing the current vLLM backend.

## Validation plan

Before any production consideration:

1. scale the Qwen3.8-27B vLLM deployment down so the sole RTX 3090 is free
2. scale this deployment to 1
3. verify model + MTP load and VRAM/RAM headroom
4. compare MTP off vs `n-max=2` vs `n-max=3`
5. test 32K / 64K / 128K conversation depth
6. test vision through `mmproj-BF16.gguf`
7. test multi-turn reasoning and tool-call correctness, not just llama-bench
8. revert to vLLM immediately on state corruption, tool-call regression, or unstable memory behavior

## Non-goals

- no change to production vLLM
- no merge/cutover
- no claim that Flash-Next on vLLM is ready for a 24 GB RTX 3090
- no custom image publication; the upstream Unsloth release artifact is fetched and hash-verified at startup
