### PR TITLE
fix(radar-ng): deploy unified Open-Meteo v1.1.9

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -154,6 +154,17 @@
       allowedVersions: '<1.5.3 || >=1.5.4',
       automerge: false,
     },
+    {
+      description: 'Radar Open-Meteo serve and sync share one image and must be reviewed and updated atomically.',
+      matchPackageNames: [
+        'ghcr.io/mitchross/radar-ng-open-meteo-worker',
+      ],
+      matchFileNames: [
+        'my-apps/development/radar-ng/deployment-open-meteo.yaml',
+      ],
+      groupName: 'radar open-meteo image',
+      automerge: false,
+    },
     // -------------------------------------------------------------------
     // PostHog image rules
     // -------------------------------------------------------------------

--- a/my-apps/development/radar-ng/deployment-open-meteo.yaml
+++ b/my-apps/development/radar-ng/deployment-open-meteo.yaml
@@ -1,5 +1,4 @@
-# Self-hosted Open-Meteo API. Backed by model data synced into the PVC by
-# the open-meteo-sync-gfs and open-meteo-sync-hrrr CronJobs.
+# Self-hosted Open-Meteo API backed by model data synced into the PVC by its Temporal worker sidecar.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,6 +7,7 @@ metadata:
   labels:
     app: open-meteo
 spec:
+  progressDeadlineSeconds: 900
   replicas: 1
   strategy:
     type: Recreate
@@ -19,6 +19,7 @@ spec:
       labels:
         app: open-meteo
     spec:
+      terminationGracePeriodSeconds: 40
       # Keep UID 999 (the image's "openmeteo" user) so PVC writes match the files the sync worker writes.
       securityContext:
         runAsNonRoot: true
@@ -30,8 +31,11 @@ spec:
           type: RuntimeDefault
       containers:
         - name: open-meteo
-          # Pin tag@digest of a verified build: 1.5.3 shipped without libparquet-glib.so.2400 and a bare tag re-pulls broken rebuilds.
-          image: ghcr.io/open-meteo/open-meteo:1.5.6@sha256:4e30cdc550702e7ebe3a27d61a6640e94a5d70798e58392361dab06e6210df35
+          # Both containers use one verified artifact so the sync format matches the served binary.
+          image: ghcr.io/mitchross/radar-ng-open-meteo-worker:v1.1.9@sha256:0387cac5a2c691a67680e7d696b687fb91f135b3b6c7a733e7c3d0c1bab422f9
+          imagePullPolicy: IfNotPresent
+          workingDir: /app
+          command: ["/app/openmeteo-api"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -40,6 +44,24 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          startupProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 120
+          readinessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 20
+            timeoutSeconds: 2
+            failureThreshold: 3
           volumeMounts:
             - name: openmeteo-data
               mountPath: /app/data
@@ -53,9 +75,8 @@ spec:
         # Sidecar, not a standalone WorkerDeployment: it must share this RWO volume with the serve container (same pod).
         # Runs non-versioned (no TEMPORAL_DEPLOYMENT_NAME/BUILD_ID env).
         - name: sync-worker
-          # Base image must match the serve container's (1.5.3 base lacks libparquet-glib.so.2400 -> HRRR sync rc=127).
-          image: ghcr.io/mitchross/radar-ng-open-meteo-worker:v1.1.8
-          imagePullPolicy: Always
+          image: ghcr.io/mitchross/radar-ng-open-meteo-worker:v1.1.9@sha256:0387cac5a2c691a67680e7d696b687fb91f135b3b6c7a733e7c3d0c1bab422f9
+          imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## Summary

- pin both Open-Meteo containers to ghcr.io/mitchross/radar-ng-open-meteo-worker:v1.1.9@sha256:0387cac5a2c691a67680e7d696b687fb91f135b3b6c7a733e7c3d0c1bab422f9
- run the serve binary explicitly from /app and add TCP startup, readiness, and liveness probes
- preserve the single Recreate pod and shared RWO PVC, with a 40 second termination grace period
- keep the sync worker probe-free because it does not expose an honest health endpoint
- require reviewed, grouped Renovate updates for the shared image

Artifact source revision: b65075ada2bf6c05777f3c117272fa39ce12ece2

## Validation

- kustomize build my-apps/development/radar-ng --enable-helm
- kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -k my-apps/development/radar-ng
- bash scripts/validate-argocd-apps.sh
- bash scripts/validate-no-inline-scripts.sh
- Renovate strict config validator
- git diff --check

## Rollout gate

Wait for Argo CD to report Synced and Healthy, then require one 2/2 Ready Open-Meteo pod with both image IDs on this digest, a successful forecast request, and a successful natural Open-Meteo Temporal sync before calling the rollout complete.

## Rollback

Revert this commit to restore the previous serve 1.5.6 and sync-worker 1.1.8 pair. The PVC and its data are unchanged by either direction.