### PR TITLE
fix(ai): create llama.cpp scripts before download hooks

### DIFF
--- a/my-apps/ai/llama-cpp/kustomization.yaml
+++ b/my-apps/ai/llama-cpp/kustomization.yaml
@@ -20,3 +20,6 @@ configMapGenerator:
     files:
       - scripts/download-models.sh
       - scripts/sync-model-cache.sh
+    options:
+      annotations:
+        argocd.argoproj.io/sync-wave: "-2"


### PR DESCRIPTION
Fixes the Argo sync ordering regression introduced by the Flash-Next MTP sidecar PR.

The generated `llama-cpp-scripts-*` ConfigMap gets a new Kustomize hash whenever either script changes. The wave -1 download hooks were therefore trying to mount the new hashed ConfigMap before Argo had applied it at the default wave, leaving the Jobs Pending with `configmap ... not found`.

This annotates the generated ConfigMap with sync wave `-2`, so it is created before both wave -1 download Jobs. No model/runtime settings change.