### PR TITLE
feat(omni): tag wired workers for longhorn-wired-ha

### DIFF
--- a/docs/domains/storage/storage-tiers.md
+++ b/docs/domains/storage/storage-tiers.md
@@ -28,6 +28,17 @@ distinct classes, and you choose per volume:
 distinct-zone Longhorn nodes have the `wired-storage` node tag. Adding the class
 does not migrate existing PVCs; use a new or restore-before-bind PVC for adoption.
 
+The tag comes from the Omni cluster template: the `hp-sff`, `hp-elite`, and `dell`
+worker blocks set the `node.longhorn.io/default-node-tags` node annotation, which
+Longhorn copies onto a node whose tag list is still empty. The Wi-Fi `hp-micro`
+node and the GPU node (radar's hot `flash` disk) are left untagged on purpose.
+Longhorn never re-syncs tags from the annotation afterwards, so to change a tagged
+node later edit `spec.tags` on its `nodes.longhorn.io` object as well. Verify with:
+
+```sh
+kubectl -n longhorn-system get nodes.longhorn.io -o custom-columns='NAME:.metadata.name,TAGS:.spec.tags'
+```
+
 ## The rule that matters most in practice: get small-block RANDOM IO off the HDD
 
 The biggest real-world storage win here is **not** flash-vs-NVMe (that difference is marginal, and

--- a/omni/cluster-template/cluster-template-prod-v2.yaml
+++ b/omni/cluster-template/cluster-template-prod-v2.yaml
@@ -235,6 +235,8 @@ patches:
       nodeLabels:
         node.longhorn.io/create-default-disk: "config"
       nodeAnnotations:
+        # Node tag (not a disk tag) selecting longhorn-wired-ha replicas; applies only while the Longhorn node has no tags.
+        node.longhorn.io/default-node-tags: '["wired-storage"]'
         node.longhorn.io/default-disks-config: >-
           [{"name":"talos-ephemeral","path":"/var/lib/longhorn","allowScheduling":false,"diskType":"filesystem","storageReserved":17179869184,"tags":[]},{"name":"hp-sff-ssd","path":"/var/mnt/longhorn-hp-sff-ssd","allowScheduling":true,"diskType":"filesystem","storageReserved":0,"tags":["hp-sff-ssd"]}]
       kubelet:
@@ -293,6 +295,8 @@ patches:
         node.longhorn.io/create-default-disk: "config"
       # The Intel SSD is healthy but already reports 74% lifetime wear.
       nodeAnnotations:
+        # Node tag (not a disk tag) selecting longhorn-wired-ha replicas; applies only while the Longhorn node has no tags.
+        node.longhorn.io/default-node-tags: '["wired-storage"]'
         node.longhorn.io/default-disks-config: >-
           [{"name":"talos-ephemeral","path":"/var/lib/longhorn","allowScheduling":false,"diskType":"filesystem","storageReserved":17179869184,"tags":[]},{"name":"hp-elite-nvme","path":"/var/mnt/longhorn-hp-elite-nvme","allowScheduling":true,"diskType":"filesystem","storageReserved":0,"tags":["hp-elite-nvme"]}]
       kubelet:
@@ -354,6 +358,8 @@ patches:
       nodeLabels:
         node.longhorn.io/create-default-disk: "config"
       nodeAnnotations:
+        # Node tag (not a disk tag) selecting longhorn-wired-ha replicas; applies only while the Longhorn node has no tags.
+        node.longhorn.io/default-node-tags: '["wired-storage"]'
         node.longhorn.io/default-disks-config: >-
           [{"name":"talos-ephemeral","path":"/var/lib/longhorn","allowScheduling":false,"diskType":"filesystem","storageReserved":17179869184,"tags":[]},{"name":"dell-ssd","path":"/var/mnt/longhorn-dell-ssd","allowScheduling":true,"diskType":"filesystem","storageReserved":0,"tags":["dell-ssd"]}]
       kubelet:


### PR DESCRIPTION
## What

Adds the Longhorn **node** tag `wired-storage` (via the `node.longhorn.io/default-node-tags` annotation) to the `hp-sff`, `hp-elite`, and `dell` worker blocks in the Omni cluster template, plus a short doc paragraph in `docs/domains/storage/storage-tiers.md`.

This is step 2 of the storage sequence in the radar-ng handoff: it makes the dormant `longhorn-wired-ha` class (#2181) provisionable. Disk tags (`hp-sff-ssd`, `hp-elite-nvme`, `dell-ssd`) are untouched.

## Why these three nodes

- All three are `node.vanillax.dev/link: wired` with a dedicated Longhorn disk and their own `topology.kubernetes.io/zone`.
- `hp-micro` is the Wi-Fi shed node: excluded.
- The GPU node holds radar's hot `flash` disk and is the single-node rollout bottleneck: excluded on purpose.
- Three eligible nodes gives two replicas plus one spare for rebuild.

## How it takes effect

Longhorn copies the annotation onto a node **only while that node's tag list is empty**. All five live Longhorn nodes have `tags: []` today (checked 2026-09-02 23:20Z), so this applies on the next Longhorn node sync after the machine config lands. No reboot.

Apply (from repo root, after merge):

```sh
cd omni/cluster-template && omnictl cluster template sync -f cluster-template-prod-v2.yaml
kubectl -n longhorn-system get nodes.longhorn.io -o custom-columns='NAME:.metadata.name,TAGS:.spec.tags'
```

Expected: `[wired-storage]` on the hp-sff, hp-elite and dell Longhorn nodes; `[]` elsewhere.

## Validation

- `omnictl cluster template validate` passes (with the gitignored docker-hub-auth patch present locally).
- `mkdocs build --strict` passes.

## Next (not in this PR)

Provision a disposable PVC on `longhorn-wired-ha`, prove replicas land on two different nodes and rebuild after a controlled failure, then restore Temporal Postgres into a restore-before-bind PVC on this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1L7LjtxSVaLdDpyuhpq3D
