### PR TITLE
Give Radar its own Temporal server without moving any jobs yet

### DIFF
--- a/my-apps/development/radar-temporal/README.md
+++ b/my-apps/development/radar-temporal/README.md
@@ -1,0 +1,137 @@
+# radar-temporal — dedicated Temporal control plane for Radar NG
+
+**Purpose:** a second, Radar-only Temporal server so Radar workflows stop
+sharing the one-shard `temporal` control plane with every other app.
+**Status:** current desired state; the cluster is deployed *empty* — no
+Radar workers, schedules, or `TemporalConnection` point at it yet. The
+cutover is a separate change in `my-apps/development/radar-ng/`.
+
+| Fact | Value |
+|---|---|
+| Kubernetes namespace | `radar-temporal` (ArgoCD app `my-apps-radar-temporal`, wave 6) |
+| Logical Temporal namespace | `radar-ng`, 7-day retention, seeded by `scripts/seed-namespaces.sh` |
+| History shards | **32**, immutable after first boot |
+| Server services | frontend, history, matching, worker — **3 replicas each**, one per wired zone |
+| UI / admintools | 1 replica each, `radar-temporal.vanillax.me` on the internal gateway |
+| Database | plain Postgres 17, 30Gi PVC on `longhorn-wired-ha` (2 Longhorn replicas), kopiur hourly at :36 |
+
+## Scope
+
+This directory owns the Temporal **server** and its Postgres. It deliberately
+does not:
+
+- touch `my-apps/development/radar-ng/` (workers, schedules, the shared
+  `TemporalConnection`);
+- back up anything on the shared `temporal` namespace;
+- claim cluster-level HA — Talos still has one control-plane/etcd node.
+
+## How placement works
+
+All three placement rules are Helm values in `values.yaml`; nothing is
+patched after render.
+
+| Rule | Where | Effect |
+|---|---|---|
+| `server.affinity` nodeAffinity `node.vanillax.dev/link In [wired]` | all four server services (Postgres repeats it in `postgres/deployment.yaml`) | only hp-sff, hp-elite, dell are eligible |
+| per-service `topologySpreadConstraints` on `topology.kubernetes.io/zone`, `maxSkew: 1`, `DoNotSchedule` | frontend/history/matching/worker | exactly one replica per wired node |
+| `server.deploymentStrategy` `maxSurge: 0`, `maxUnavailable: 1` | all four server services | a rollout reuses the freed zone instead of needing a 4th slot |
+| per-service `podDisruptionBudget: {maxUnavailable: 1}` | frontend/history/matching/worker | drains move one pod at a time |
+
+Consequence to know: if a wired node is down, its replica stays `Pending`
+until the node returns (the spread refuses to double up a zone). Two of three
+replicas keep serving. That is intended.
+
+## Prerequisites (before merging)
+
+1. **Longhorn node tags.** `longhorn-wired-ha` requires the Longhorn node tag
+   `wired-storage` on at least two wired nodes (PR #2191). Until then the PVC
+   stays `Pending` and the whole app waits at wave -2 — it fails closed.
+   Verify:
+   ```sh
+   kubectl -n longhorn-system get nodes.longhorn.io -o custom-columns='NAME:.metadata.name,TAGS:.spec.tags'
+   ```
+   Expected: `[wired-storage]` on the hp-sff, hp-elite, and dell nodes.
+2. **1Password property.** Add `radar_temporal_db_password` to the
+   `postgres-secrets` item in the `homelab-prod` vault (new random password —
+   do **not** copy `temporal_db_password`). Until it exists the ExternalSecret
+   reports `SecretSyncedError` and Postgres never starts. Verify after sync:
+   ```sh
+   kubectl -n radar-temporal get externalsecret radar-temporal-db-secret
+   ```
+   Expected: `STATUS SecretSynced`, `READY True`.
+3. Node labels already present (read-only check):
+   ```sh
+   kubectl get nodes -L node.vanillax.dev/link,topology.kubernetes.io/zone
+   ```
+   Expected: three nodes with `LINK wired` and three distinct zones.
+
+## Verification (after merge)
+
+```sh
+# 1. ArgoCD app healthy, all pods on wired nodes, one per zone
+kubectl get application -n argocd my-apps-radar-temporal
+kubectl -n radar-temporal get deploy
+kubectl -n radar-temporal get pods -o wide
+```
+Expected: frontend/history/matching/worker `3/3`, postgres/web/admintools
+`1/1`; each 3-replica service has pods on three different nodes.
+
+```sh
+# 2. PDBs and PVC
+kubectl -n radar-temporal get pdb
+kubectl -n radar-temporal get pvc radar-temporal-postgres-data
+kubectl -n longhorn-system get volumes.longhorn.io -o custom-columns='NAME:.metadata.name,PVC:.status.kubernetesStatus.pvcName,ROBUST:.status.robustness' | grep radar-temporal
+```
+Expected: four PDBs with `MAX UNAVAILABLE 1`; PVC `Bound` on
+`longhorn-wired-ha`; the Longhorn volume `healthy` with two replicas on two
+different nodes (check in the Longhorn UI or `kubectl -n longhorn-system get replicas.longhorn.io`).
+
+```sh
+# 3. Temporal itself: 32 shards, namespace radar-ng exists
+kubectl -n radar-temporal exec deploy/radar-temporal-admintools -- \
+  temporal --address radar-temporal-frontend:7233 operator cluster describe
+kubectl -n radar-temporal exec deploy/radar-temporal-admintools -- \
+  temporal --address radar-temporal-frontend:7233 operator namespace describe -n radar-ng
+```
+Expected: `HistoryShardCount 32`; namespace `radar-ng` with
+`WorkflowExecutionRetentionTtl 168h0m0s`.
+
+```sh
+# 4. Backups and alerts wired up
+kubectl -n radar-temporal get secret kopiur-rustfs
+kubectl -n radar-temporal get snapshotpolicy,snapshotschedule,restore,snapshot
+kubectl -n radar-temporal get servicemonitor,prometheusrule
+```
+Expected: the secret exists; after the first :36 a `Snapshot` reaches
+`Succeeded` with non-zero files.
+
+Web UI: <https://radar-temporal.vanillax.me> (internal gateway, LAN only).
+
+## Timer DLQ
+
+Same rule as the shared server: a non-zero timer DLQ is an incident.
+Inventory with `tdbg dlq list --print-json` in `radar-temporal-admintools`,
+merge only an explicitly approved contiguous prefix, never purge. The full
+procedure is in `../temporal/README.md` § "Timer DLQ alert runbook"; swap the
+namespace and deployment names.
+
+## Rollback
+
+Revert the merge commit. ArgoCD prunes the namespace and everything in it.
+Two things to know before doing that:
+
+- `longhorn-wired-ha` is `reclaimPolicy: Delete` — pruning the PVC deletes the
+  Longhorn volume. The kopiur repository keeps the snapshots (the component
+  sets `onPolicyDelete: Retain`), so a re-deploy restores from the latest one
+  via `dataSourceRef`.
+- Nothing else depends on this namespace until the Radar cutover, so a revert
+  has no effect on the shared `temporal` control plane or on `radar-ng`.
+
+## Source of truth
+
+- `values.yaml` — image pin, shards, replicas, placement, PDBs.
+- `postgres/` + `kopiur/radar-temporal-postgres-data.yaml` — database and backup.
+- `prometheusrule.yaml` — alerts (DLQ, availability, persistence, shards).
+- Reference app this mirrors: `../temporal/README.md`.
+- Storage class contract: `infrastructure/storage/longhorn/storageclass-wired-ha.yaml`.
+- Backup architecture: `docs/domains/storage/kopiur-backup-architecture.md`.

--- a/my-apps/development/radar-temporal/externalsecret.yaml
+++ b/my-apps/development/radar-temporal/externalsecret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: radar-temporal-db-secret
+  namespace: radar-temporal
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: radar-temporal-db-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: postgres-secrets
+        # Own credential — never the shared temporal_db_password. Missing property = SecretSyncedError, app stays Pending (fail closed).
+        property: radar_temporal_db_password

--- a/my-apps/development/radar-temporal/httproute.yaml
+++ b/my-apps/development/radar-temporal/httproute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: radar-temporal-web
+  namespace: radar-temporal
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-internal-technitium
+      namespace: gateway
+  hostnames:
+    - "radar-temporal.vanillax.me"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: radar-temporal-web
+          port: 8080
+          weight: 1

--- a/my-apps/development/radar-temporal/kopiur/radar-temporal-postgres-data.yaml
+++ b/my-apps/development/radar-temporal/kopiur/radar-temporal-postgres-data.yaml
@@ -1,0 +1,77 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+# Per-PVC stub (uniform fields from ../../common/kopiur-backup); the before-hook CHECKPOINTs Postgres so the capture is flushed.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: radar-temporal-postgres-data
+  namespace: radar-temporal
+  annotations:
+    # Wave -3: the Restore populator must exist before the wave -2 PVC tries to bind (waves block).
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  sources:
+    - pvc:
+        name: radar-temporal-postgres-data
+  identity:
+    username: radar-temporal-postgres-data
+    hostname: radar-temporal
+  hooks:
+    beforeSnapshot:
+      - workloadExec:
+          podSelector:
+            matchLabels:
+              app: radar-temporal-postgres
+          container: postgres
+          command: ["/bin/sh", "-c", "exec psql -v ON_ERROR_STOP=1 -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\" -c \"CHECKPOINT\""]
+          timeout: 2m
+  retention:
+    keepHourly: 24
+    keepDaily: 7
+    keepWeekly: 4
+  mover:
+    securityContext:
+      runAsUser: 999 # postgres uid:gid in the official image
+      runAsGroup: 999
+      runAsNonRoot: true
+    podSecurityContext:
+      fsGroup: 999
+      supplementalGroups:
+        - 999
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: radar-temporal-postgres-data-hourly
+  namespace: radar-temporal
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  policyRef:
+    name: radar-temporal-postgres-data
+  schedule:
+    # :36 hourly — unused by every other schedule (incl. the 03:MM daily tier) and 30 min from shared temporal's :06.
+    cron: "36 * * * *"
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: radar-temporal-postgres-data-restore
+  namespace: radar-temporal
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  source:
+    fromPolicy:
+      name: radar-temporal-postgres-data
+      offset: 0
+  mover:
+    securityContext:
+      runAsUser: 999
+      runAsGroup: 999
+      runAsNonRoot: true
+    podSecurityContext:
+      fsGroup: 999
+      supplementalGroups:
+        - 999

--- a/my-apps/development/radar-temporal/kustomization.yaml
+++ b/my-apps/development/radar-temporal/kustomization.yaml
@@ -1,0 +1,78 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: radar-temporal
+resources:
+  - vpa.yaml
+  - namespace.yaml
+  - httproute.yaml
+  - externalsecret.yaml
+  - namespace-init-job.yaml
+  - prometheusrule.yaml
+  - postgres/deployment.yaml
+  - postgres/service.yaml
+  - postgres/pvc.yaml
+  - postgres/servicemonitor.yaml
+  - kopiur/radar-temporal-postgres-data.yaml
+
+# Uniform kopiur backup fields (repository, copyMethod, populator) for the per-PVC stub in kopiur/.
+components:
+  - ../../common/kopiur-backup
+
+# Kustomize turns scripts/seed-namespaces.sh into a ConfigMap at render time.
+configMapGenerator:
+  - name: radar-temporal-seed-scripts
+    files:
+      - scripts/seed-namespaces.sh
+    options:
+      # Stable name — the Job mounts it by name; BeforeHookCreation already restarts the Job.
+      disableNameSuffixHash: true
+  # Mounted at /docker-entrypoint-initdb.d — creates temporal_visibility on the FIRST boot of an empty volume only.
+  - name: radar-temporal-postgres-init
+    files:
+      - postgres/init-visibility.sql
+    options:
+      disableNameSuffixHash: true
+      annotations:
+        # Postgres (wave -2) mounts this — must exist before that wave.
+        argocd.argoproj.io/sync-wave: "-3"
+
+helmCharts:
+  - name: temporal
+    repo: https://go.temporal.io/helm-charts
+    version: 1.6.0
+    releaseName: radar-temporal
+    namespace: radar-temporal
+    includeCRDs: true
+    valuesFile: values.yaml
+
+patches:
+  # Scoped to Helm-rendered Jobs only — unscoped, it turns our seed Job's PostSync hook into Sync.
+  # Schema job must run in an earlier wave than the server Deployments or an image bump rolls pods before migrations finish.
+  - target:
+      kind: Job
+      labelSelector: helm.sh/chart
+    patch: |
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1hook
+        value: Sync
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "-1"
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1hook-delete-policy
+        value: BeforeHookCreation
+  # gRPC long-polls (60s+) read as permanently slow to Coroot's latency SLI (10s histogram cap) — latency SLO off, availability stays.
+  - target:
+      kind: Deployment
+      name: radar-temporal-frontend
+    patch: |
+      - op: add
+        path: /metadata/annotations/coroot.com~1slo-latency-objective
+        value: "0%"
+  - target:
+      kind: Deployment
+      name: radar-temporal-matching
+    patch: |
+      - op: add
+        path: /metadata/annotations/coroot.com~1slo-latency-objective
+        value: "0%"

--- a/my-apps/development/radar-temporal/namespace-init-job.yaml
+++ b/my-apps/development/radar-temporal/namespace-init-job.yaml
@@ -1,0 +1,38 @@
+# Seeds the `radar-ng` Temporal namespace so a rebuild/PGDATA restore doesn't leave only `temporal-system`.
+# PostSync: the frontend must be reachable when scripts/seed-namespaces.sh (ConfigMap via configMapGenerator) probes it.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: radar-temporal-namespace-seed
+  namespace: radar-temporal
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+    app.kubernetes.io/name: radar-temporal-namespace-seed
+    app.kubernetes.io/part-of: radar-temporal
+spec:
+  backoffLimit: 20
+  ttlSecondsAfterFinished: 3600   # keep 1h so `kubectl logs` still works post-success
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: radar-temporal-namespace-seed
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: seed
+          image: temporalio/admin-tools:1.31.2
+          command: ["/bin/sh", "/scripts/seed-namespaces.sh"]
+          volumeMounts:
+            - name: seed-script
+              mountPath: /scripts
+              readOnly: true
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits:   { memory: 512Mi }
+      volumes:
+        - name: seed-script
+          configMap:
+            name: radar-temporal-seed-scripts
+            defaultMode: 0555   # readable + executable

--- a/my-apps/development/radar-temporal/namespace.yaml
+++ b/my-apps/development/radar-temporal/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: radar-temporal
+  annotations:
+    # Before the wave -2 postgres stack: the kopiur label drives the cred fanout the PVC populator needs to bind.
+    argocd.argoproj.io/sync-wave: "-3"
+  labels:
+    # kopiur-managed: ClusterExternalSecret cred fanout + ClusterRepository tenancy for radar-temporal-postgres-data.
+    kopiur.home-operations.com/repo: cluster-kopia

--- a/my-apps/development/radar-temporal/postgres/deployment.yaml
+++ b/my-apps/development/radar-temporal/postgres/deployment.yaml
@@ -1,0 +1,139 @@
+# Plain Postgres + kopiur (gitea pattern). The chart's schema hooks (wave -1) create both schemas on first boot.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radar-temporal-postgres
+  namespace: radar-temporal
+  labels:
+    app: radar-temporal-postgres
+  annotations:
+    # Schema Jobs are wave -1 Sync hooks and waves block: Postgres must be healthy at wave -2 or the hook waits forever.
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  strategy:
+    type: Recreate # RWO PVC — RollingUpdate deadlocks on Multi-Attach
+  replicas: 1
+  selector:
+    matchLabels:
+      app: radar-temporal-postgres
+  template:
+    metadata:
+      labels:
+        app: radar-temporal-postgres
+    spec:
+      # Same wired-only rule as the Temporal services; the volume's replicas live on these nodes too (dataLocality best-effort).
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.vanillax.dev/link
+                    operator: In
+                    values: ["wired"]
+      # SIGINT = Postgres fast shutdown; 60s covers a busy checkpoint before SIGKILL.
+      terminationGracePeriodSeconds: 60
+      securityContext:
+        fsGroup: 999 # postgres uid:gid in the official image
+      containers:
+        - name: postgres
+          # Pin MAJOR.MINOR; majors need a manual dump/restore (gated in renovate.json5).
+          # Held at 17 until Temporal declares PG18 support — a wedged schema hook deadlocks the whole app sync.
+          image: postgres:17.11
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            # Only used on first boot of an EMPTY volume; a restored volume skips init and its data wins.
+            - name: POSTGRES_DB
+              value: "temporal"
+            - name: POSTGRES_USER
+              value: "temporal"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: radar-temporal-db-secret
+                  key: password
+            - name: POSTGRES_INITDB_ARGS
+              value: "--data-checksums"
+            # Subdirectory keeps initdb happy on a fresh PVC (top-level mount contains lost+found).
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          # Suppresses liveness restarts while a restored DB replays WAL.
+          startupProbe:
+            exec:
+              command: ["pg_isready", "-U", "temporal", "-d", "temporal"]
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "temporal", "-d", "temporal"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "temporal", "-d", "temporal"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+              readOnly: true
+        # Metrics sidecar — same pattern as gitea-postgres.
+        - name: postgres-exporter
+          image: quay.io/prometheuscommunity/postgres-exporter:v0.20.1
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: DATA_SOURCE_URI
+              value: "localhost:5432/temporal?sslmode=disable"
+            - name: DATA_SOURCE_USER
+              value: "temporal"
+            - name: DATA_SOURCE_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: radar-temporal-db-secret
+                  key: password
+          ports:
+            - containerPort: 9187
+              name: metrics
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: radar-temporal-postgres-data
+        - name: initdb
+          configMap:
+            name: radar-temporal-postgres-init

--- a/my-apps/development/radar-temporal/postgres/init-visibility.sql
+++ b/my-apps/development/radar-temporal/postgres/init-visibility.sql
@@ -1,0 +1,5 @@
+-- Runs ONLY on first boot of an empty volume (docker-entrypoint-initdb.d);
+-- a kopiur-restored volume skips initdb entirely and keeps its databases.
+-- Temporal needs a second database for the visibility store and the chart
+-- runs with createDatabase: false — the schema Jobs only create tables.
+CREATE DATABASE temporal_visibility OWNER temporal;

--- a/my-apps/development/radar-temporal/postgres/pvc.yaml
+++ b/my-apps/development/radar-temporal/postgres/pvc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: radar-temporal-postgres-data
+  namespace: radar-temporal
+  annotations:
+    # immutable dataSourceRef on a Bound PVC — mask the SSA dry-run diff;
+    # the AppSet ignoreDifferences handles the live compare.
+    argocd.argoproj.io/compare-options: ServerSideDiff=false
+    argocd.argoproj.io/sync-options: ServerSideApply=false
+    argocd.argoproj.io/sync-wave: "-2" # before the wave -1 schema hook
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi
+  # Two Longhorn replicas on `wired-storage`-tagged nodes only; stays Pending (fails closed) until those node tags exist.
+  storageClassName: longhorn-wired-ha
+  dataSourceRef:
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: radar-temporal-postgres-data-restore

--- a/my-apps/development/radar-temporal/postgres/service.yaml
+++ b/my-apps/development/radar-temporal/postgres/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: radar-temporal-postgres
+  namespace: radar-temporal
+  labels:
+    app: radar-temporal-postgres
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2" # before the wave -1 schema hook
+spec:
+  selector:
+    app: radar-temporal-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+    - name: metrics
+      port: 9187
+      targetPort: 9187

--- a/my-apps/development/radar-temporal/postgres/servicemonitor.yaml
+++ b/my-apps/development/radar-temporal/postgres/servicemonitor.yaml
@@ -1,0 +1,18 @@
+# Scrapes the postgres-exporter sidecar. Prometheus uses empty
+# serviceMonitor*Selectors, so no release label is needed.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: radar-temporal-postgres
+  namespace: radar-temporal
+  labels:
+    app: radar-temporal-postgres
+spec:
+  selector:
+    matchLabels:
+      app: radar-temporal-postgres
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/my-apps/development/radar-temporal/prometheusrule.yaml
+++ b/my-apps/development/radar-temporal/prometheusrule.yaml
@@ -1,0 +1,161 @@
+# Every metric name below was checked against the live shared Temporal server's series before use.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: radar-temporal-alerts
+  namespace: radar-temporal
+  labels:
+    app.kubernetes.io/name: radar-temporal
+    app.kubernetes.io/component: monitoring
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: radar-temporal.dlq
+      rules:
+        - alert: RadarTemporalTimerDLQNotEmpty
+          expr: max(dlq_message_count{namespace="radar-temporal", service_name="history", task_category="timer"}) > 0
+          for: 2m
+          labels:
+            severity: critical
+            component: radar-temporal
+            category: workflow-platform
+          annotations:
+            summary: Radar Temporal timer DLQ contains durable tasks
+            description: |
+              The Radar control plane has {{ $value }} timer task(s) in its
+              dead-letter queue. Scheduled workflows can remain running while
+              their next durable timer never fires. Runbook: README.md
+              "Timer DLQ" — inventory with `tdbg dlq list` in
+              radar-temporal-admintools, correlate every message, merge only an
+              approved contiguous prefix; never purge.
+        - alert: RadarTemporalTimerDLQMetricMissing
+          expr: absent(dlq_message_count{namespace="radar-temporal", service_name="history", task_category="timer"}) == 1
+          for: 15m
+          labels:
+            severity: warning
+            component: radar-temporal
+            category: workflow-platform
+          annotations:
+            summary: Radar Temporal timer-DLQ visibility is missing
+            description: |
+              Prometheus has not received the timer DLQ gauge from any
+              radar-temporal history pod for 15 minutes. Runbook: check the
+              history pods, the headless Service, the ServiceMonitor, and the
+              Prometheus target before trusting the DLQ alerts above.
+    - name: radar-temporal.availability
+      rules:
+        - alert: RadarTemporalServiceDown
+          expr: up{namespace="radar-temporal", job=~"radar-temporal-(frontend|history|matching|worker)-headless"} == 0
+          for: 5m
+          labels:
+            severity: warning
+            component: radar-temporal
+            category: workflow-platform
+          annotations:
+            summary: Radar Temporal {{ $labels.job }} pod {{ $labels.pod }} is not scrapeable
+            description: |
+              One replica of a Radar Temporal service has been down for 5
+              minutes. Two replicas keep serving, but the zone spread is now
+              broken. Runbook: `kubectl -n radar-temporal describe pod
+              {{ $labels.pod }}` — a Pending pod usually means its wired node
+              is gone (DoNotSchedule spread holds the slot until it returns).
+        - alert: RadarTemporalServiceReplicasDegraded
+          expr: count by (job) (up{namespace="radar-temporal", job=~"radar-temporal-(frontend|history|matching|worker)-headless"} == 1) < 3
+          for: 15m
+          labels:
+            severity: warning
+            component: radar-temporal
+            category: workflow-platform
+          annotations:
+            summary: Radar Temporal {{ $labels.job }} has fewer than 3 healthy replicas
+            description: |
+              {{ $labels.job }} has been below its 3-replica target for 15
+              minutes, so a single further failure removes half the remaining
+              capacity. Runbook: `kubectl -n radar-temporal get pods -o wide`
+              and check node readiness for the wired nodes (hp-sff, hp-elite,
+              dell).
+        - alert: RadarTemporalPostgresDown
+          expr: up{namespace="radar-temporal", job="radar-temporal-postgres"} == 0
+          for: 5m
+          labels:
+            severity: critical
+            component: radar-temporal
+            category: workflow-platform
+          annotations:
+            summary: Radar Temporal Postgres exporter is down
+            description: |
+              The single Postgres instance behind the Radar control plane is
+              not scrapeable; every Temporal shard depends on it. Runbook:
+              `kubectl -n radar-temporal get pod,pvc -l app=radar-temporal-postgres`
+              — a Pending PVC on longhorn-wired-ha means the wired-storage
+              Longhorn node tags are missing; a Faulted volume is a stop
+              condition (do not force-detach, restore via kopiur).
+    - name: radar-temporal.persistence
+      rules:
+        - alert: RadarTemporalPersistenceErrorRateHigh
+          expr: |
+            sum by (service_name) (rate(persistence_errors{namespace="radar-temporal"}[5m]))
+              /
+            sum by (service_name) (rate(persistence_requests{namespace="radar-temporal"}[5m]))
+              > 0.05
+          for: 10m
+          labels:
+            severity: critical
+            component: radar-temporal
+            category: workflow-platform
+          annotations:
+            summary: Radar Temporal {{ $labels.service_name }} persistence error ratio above 5%
+            description: |
+              More than 5% of {{ $labels.service_name }} database calls have
+              failed for 10 minutes. Runbook: break down by error type with
+              `sum by (error_type) (rate(persistence_error_with_type{namespace="radar-temporal", service_name="{{ $labels.service_name }}"}[5m]))`,
+              then check Postgres logs and connection counts
+              (`persistence_sql_open_conn`).
+        - alert: RadarTemporalResourceExhausted
+          expr: sum by (service_name) (rate(service_errors_resource_exhausted{namespace="radar-temporal"}[5m])) > 0
+          for: 10m
+          labels:
+            severity: warning
+            component: radar-temporal
+            category: workflow-platform
+          annotations:
+            summary: Radar Temporal {{ $labels.service_name }} is returning ResourceExhausted
+            description: |
+              {{ $labels.service_name }} has been rejecting requests with
+              ResourceExhausted (rate limit or persistence QPS cap) for 10
+              minutes. Runbook: compare with worker poller counts and
+              `persistence_requests`; raise the dynamic-config RPS limits only
+              after confirming Postgres has headroom.
+    - name: radar-temporal.shards
+      rules:
+        - alert: RadarTemporalShardsNotFullyOwned
+          expr: sum(numshards_gauge{namespace="radar-temporal", service_name="history"}) != 32
+          for: 15m
+          labels:
+            severity: critical
+            component: radar-temporal
+            category: workflow-platform
+          annotations:
+            summary: Radar Temporal history hosts own {{ $value }} of 32 shards
+            description: |
+              The history pods together should own exactly the 32 configured
+              shards. Fewer means workflows on unowned shards make no progress;
+              more means split ownership. Runbook: `kubectl -n radar-temporal
+              logs deploy/radar-temporal-history | grep -i shard`, check
+              membership (`membership_changed_count`) and that all 3 history
+              pods are Ready.
+        - alert: RadarTemporalShardChurnHigh
+          expr: sum(increase(shard_closed_count{namespace="radar-temporal", service_name="history"}[30m])) > 64
+          for: 10m
+          labels:
+            severity: warning
+            component: radar-temporal
+            category: workflow-platform
+          annotations:
+            summary: Radar Temporal shards are being closed and reacquired repeatedly
+            description: |
+              More than two full shard sets (64 closes) in 30 minutes. A
+              rolling restart closes each pod's shards once; sustained churn
+              means membership flapping or shard ownership lost errors.
+              Runbook: check history pod restarts, node network on the wired
+              nodes, and `persistence_error_with_type{error_type="persistence_ShardOwnershipLostError"}`.

--- a/my-apps/development/radar-temporal/scripts/seed-namespaces.sh
+++ b/my-apps/development/radar-temporal/scripts/seed-namespaces.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Seeds the Radar Temporal control plane's user namespace. Run as a
+# PostSync Job after the frontend Deployment is ready. Idempotent — safe
+# to re-run on every deploy; an existing namespace is skipped.
+set -eu
+
+FRONTEND="${FRONTEND:-radar-temporal-frontend:7233}"
+SEED_RETRIES="${SEED_RETRIES:-20}"
+SEED_SLEEP_SECONDS="${SEED_SLEEP_SECONDS:-10}"
+SEED_RPC_TIMEOUT_SECONDS="${SEED_RPC_TIMEOUT_SECONDS:-30}"
+
+temporal_rpc() {
+  timeout "$SEED_RPC_TIMEOUT_SECONDS" temporal --address "$FRONTEND" "$@"
+}
+
+# Wait for the frontend to accept RPCs. On a fresh database this can take
+# a minute (SQL schema bootstrap finishes before serving). 20 × 10s = 200s.
+echo "[seed] waiting for frontend at $FRONTEND..."
+frontend_ready=0
+for i in $(seq 1 "$SEED_RETRIES"); do
+  if temporal_rpc operator namespace list >/dev/null 2>&1; then
+    echo "[seed] frontend reachable"
+    frontend_ready=1
+    break
+  fi
+  echo "[seed] not ready yet (attempt $i/$SEED_RETRIES), sleeping ${SEED_SLEEP_SECONDS}s..."
+  sleep "$SEED_SLEEP_SECONDS"
+done
+
+if [ "$frontend_ready" != 1 ]; then
+  echo "[seed] frontend did not become reachable after $SEED_RETRIES attempts" >&2
+  exit 1
+fi
+
+# Only `radar-ng` lives on this control plane — no `default`, so nothing
+# lands here by accident. Named here (not an env var) so a repo grep finds it.
+NS="radar-ng"
+echo "[seed] ensuring namespace: $NS"
+if temporal_rpc operator namespace describe -n "$NS" >/dev/null 2>&1; then
+  echo "[seed]   already exists"
+else
+  temporal_rpc operator namespace create \
+    --retention 168h \
+    --description "Radar NG application namespace (GitOps-seeded)" \
+    -n "$NS"
+  echo "[seed]   created"
+fi
+
+echo "[seed] final namespace list:"
+temporal_rpc operator namespace list | grep "NamespaceInfo.Name"
+echo "[seed] done."

--- a/my-apps/development/radar-temporal/values.yaml
+++ b/my-apps/development/radar-temporal/values.yaml
@@ -1,0 +1,174 @@
+server:
+  enabled: true
+  # Chart default tag lags Temporal server patches by weeks; bump here. A chart bump only wins if its default exceeds this.
+  image:
+    repository: temporalio/server
+    tag: 1.31.2
+    pullPolicy: IfNotPresent
+  # Applies to frontend/history/matching/worker; web and admintools stay single-replica.
+  replicaCount: 3
+  # Three wired nodes = three zone slots. maxSurge 0 so a rollout never needs a 4th slot the spread below would refuse.
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  # Wired nodes only (hp-sff, hp-elite, dell). The GPU node has no link label; hp-micro is wifi.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.vanillax.dev/link
+                operator: In
+                values: ["wired"]
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+  metrics:
+    serviceMonitor:
+      enabled: true
+      interval: 30s
+  config:
+    logLevel: "info"
+    persistence:
+      defaultStore: default
+      visibilityStore: visibility
+      # Immutable after first boot — changing it means a new database and a data migration.
+      numHistoryShards: 32
+      datastores:
+        default:
+          sql:
+            createDatabase: false
+            manageSchema: true
+            pluginName: postgres12
+            driverName: postgres12
+            databaseName: temporal
+            connectAddr: "radar-temporal-postgres.radar-temporal.svc.cluster.local:5432"
+            # Temporal 1.28+ refuses to boot without this and the chart doesn't set it (ConnectProtocol: zero value crashloop).
+            connectProtocol: "tcp"
+            user: temporal
+            existingSecret: radar-temporal-db-secret
+            secretKey: password
+        visibility:
+          sql:
+            createDatabase: false
+            manageSchema: true
+            pluginName: postgres12
+            driverName: postgres12
+            databaseName: temporal_visibility
+            connectAddr: "radar-temporal-postgres.radar-temporal.svc.cluster.local:5432"
+            connectProtocol: "tcp"
+            user: temporal
+            existingSecret: radar-temporal-db-secret
+            secretKey: password
+  # Per-service only in this chart (no server-wide default): one replica per zone, hard; voluntary disruption one pod at a time.
+  frontend:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        memory: 2Gi
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: temporal
+            app.kubernetes.io/instance: radar-temporal
+            app.kubernetes.io/component: frontend
+    podDisruptionBudget:
+      maxUnavailable: 1
+  history:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        memory: 2Gi
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: temporal
+            app.kubernetes.io/instance: radar-temporal
+            app.kubernetes.io/component: history
+    podDisruptionBudget:
+      maxUnavailable: 1
+  matching:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        memory: 2Gi
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: temporal
+            app.kubernetes.io/instance: radar-temporal
+            app.kubernetes.io/component: matching
+    podDisruptionBudget:
+      maxUnavailable: 1
+  worker:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        memory: 2Gi
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: temporal
+            app.kubernetes.io/instance: radar-temporal
+            app.kubernetes.io/component: worker
+    podDisruptionBudget:
+      maxUnavailable: 1
+
+# Keep OFF on 1.30+ images: shims render a wave-0 ConfigMap the wave -1 schema hook can never mount → sync deadlock.
+shims:
+  dockerize: false
+  elasticsearchTool: false
+
+schema:
+  useHelmHooks: false
+  backoffLimit: 20
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
+admintools:
+  enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+
+web:
+  enabled: true
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi

--- a/my-apps/development/radar-temporal/vpa.yaml
+++ b/my-apps/development/radar-temporal/vpa.yaml
@@ -1,0 +1,158 @@
+# VPA policy is owned with this application so Argo prunes it with the target.
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: radar-temporal-postgres
+  namespace: radar-temporal
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: radar-temporal-postgres
+  updatePolicy:
+    # Recommend only: a Recreate of the single-replica DB takes every shard down; size it by hand from the recommendation.
+    updateMode: "Off"
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      # Fixed-size metrics sidecar — not VPA-managed.
+      - containerName: postgres-exporter
+        mode: "Off"
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "2"
+          memory: 2Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: radar-temporal-admintools
+  namespace: radar-temporal
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: radar-temporal-admintools
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "1"
+          memory: 2Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: radar-temporal-worker
+  namespace: radar-temporal
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: radar-temporal-worker
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "2"
+          memory: 4Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: radar-temporal-frontend
+  namespace: radar-temporal
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: radar-temporal-frontend
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "2"
+          memory: 2Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: radar-temporal-history
+  namespace: radar-temporal
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: radar-temporal-history
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "2"
+          memory: 4Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: radar-temporal-matching
+  namespace: radar-temporal
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: radar-temporal-matching
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "2"
+          memory: 2Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: radar-temporal-web
+  namespace: radar-temporal
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: radar-temporal-web
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "1"
+          memory: 1Gi


### PR DESCRIPTION
## What is this for?

Give Radar a separate Temporal installation instead of having it share the existing one. Temporal runs and tracks Radar's background jobs.

**This PR starts the new installation empty. It does not move Radar's workers, schedules, or connections over.** Switching Radar to it is a separate change.

## What will run?

The new app is `my-apps/development/radar-temporal`, in the `radar-temporal` Kubernetes namespace.

It runs three copies of each of Temporal's four services: 12 service pods, spread across the wired HP SFF, HP Elite, and Dell hosts. It also adds a Postgres database with 30 GiB of storage, two Longhorn storage copies, and hourly kopiur backups.

It uses 32 history shards, compared with one on the shared server. That setting divides Temporal's stored workflow history and must be chosen before first boot; it cannot be changed afterward.

It includes alerts for failed jobs awaiting attention, unavailable services, database trouble, storage errors, and problems assigning those history shards. This adds running services and resource usage even before Radar is moved over.

## What needs doing before merging?

Keep this as a draft until the following are confirmed:

- #2191 is merged and the required `wired-storage` node labels are actually applied. Without them, the database volume stays pending and the new app cannot start.
- Add a new `radar_temporal_db_password` field to the `postgres-secrets` item in 1Password. Use a fresh password, not the shared server's password.
- Test a disposable `longhorn-wired-ha` volume: confirm its two copies land on separate eligible nodes and can rebuild after a failure.

Also resolve any merge conflicts and review current CI before proceeding.

## Tests and rollback

The original implementation notes report that Kustomize generated the expected configuration, Kubernetes schema validation passed for 45 resources, and all 102 repository directories built successfully. The topology, VPA, and backup checks also passed at that time. An inline-script check was reported as already failing on the base branch in unrelated llama.cpp files. These are historical results, not a substitute for current CI or the live storage test above.

Deployment checks are in the app's README. Reverting the PR can remove the new installation and its volume; do not treat that as harmless once it contains useful data. Its storage class deletes the volume when the claim is removed, while kopiur is configured to retain backup history. Confirm a usable backup before removing any state you need.

<details>
<summary>Exact settings for reviewers</summary>

Temporal chart 1.6.0; server 1.31.2; Postgres 17.11. The Temporal namespace is `radar-ng`, with seven-day retention, created after the app syncs.

Each Temporal service uses wired-node affinity, strict zone spread, no extra pod during updates (`maxSurge: 0`), and at most one unavailable pod. Each has a disruption budget allowing one unavailable pod.

Database backups run hourly at minute 36, offset from the shared Temporal backup at minute 6. The implementation follows the existing Temporal app's schema-job and backup patterns.

Generated with [Claude Code](https://claude.com/claude-code).

https://claude.ai/code/session_01Y1L7LjtxSVaLdDpyuhpq3D

</details>