### PR TITLE
chore(radar-ng): roll workers to v1.1.29

### DIFF
--- a/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
@@ -47,7 +47,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.29
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
@@ -49,7 +49,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.29
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -134,7 +134,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.29
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -219,7 +219,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.29
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -304,7 +304,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.29
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -389,7 +389,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: worker
-          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.27
+          image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.29
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- roll the legacy worker and all five isolated role pools from v1.1.27 to v1.1.29
- deploy the merged versioned replay gate and observe-only Schedule supervision
- keep every isolated pool at SKIP_SCHEDULE_SEED=1
- keep legacy USE_ISOLATED_TASK_QUEUES=0 so every Schedule still routes to radar-ng

Source release: radar-ng commit fa0e72ed43e51914d4092eea62508ca018cf1a93

Image: ghcr.io/mitchross/radar-ng-temporal-worker:v1.1.29

Published digest: sha256:561b3d3ddff6fd39a59db4ce876a706064498bd21bfa5d2045dbcb78f34ae17d

## Validation

- exact worker image passed its embedded replay and workflow-discovery gate
- radar-ng CI passed 95 tests and 435 subtests on the combined source
- kustomize build my-apps/development/radar-ng passed
- rendered output contains exactly six v1.1.29 worker references
- no task-queue, seeding, resource, PVC, or replica settings changed

## Rollout gate

After Argo sync, verify all six WorkerDeployments and pods report v1.1.29 and the same image digest, all legacy and role workflow/activity pollers exist, Radar schedules remain on radar-ng, no new timer-DLQ entry appears, and natural Radar runs remain fresh. Queue cutover is a separate later PR after soak.

Rollback is a Git revert to v1.1.27 on all six references.
