### PR TITLE
test(ai): cut over RTX 3090 to Flash-Next with Open WebUI

### DIFF
--- a/my-apps/ai/llama-cpp/kustomization.yaml
+++ b/my-apps/ai/llama-cpp/kustomization.yaml
@@ -15,6 +15,11 @@ resources:
   - httproute.yaml
   - servicemonitor.yaml
 
+# Flash-Next test cutover: claim the sole RTX 3090 after vLLM is parked.
+replicas:
+  - name: llama-cpp-server
+    count: 1
+
 configMapGenerator:
   - name: llama-cpp-scripts
     files:

--- a/my-apps/ai/open-webui/open-webui-configmap.env
+++ b/my-apps/ai/open-webui/open-webui-configmap.env
@@ -1,18 +1,17 @@
 ENABLE_OPENAI_API=True
-# Open WebUI uses the single-card vLLM Qwen3.8-27B backend.
-OPENAI_API_BASE_URL=http://vllm-service.vllm.svc.cluster.local:8080/v1
-OPENAI_API_BASE_URLS=http://vllm-service.vllm.svc.cluster.local:8080/v1
+# Flash-Next test cutover: Open WebUI talks directly to the llama.cpp sidecar.
+OPENAI_API_BASE_URL=http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1
+OPENAI_API_BASE_URLS=http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1
 OPENAI_API_KEY=sk-required
 OPENAI_API_KEYS=sk-required
 ENABLE_OLLAMA_API=false
-DEFAULT_MODELS=qwen3.8-27b
-VISION_MODELS=qwen3.8-27b
-CONTEXT_WINDOW=65536
+DEFAULT_MODELS=Qwen3.8-Flash-Next Q4 MTP
+VISION_MODELS=Qwen3.8-Flash-Next Q4 MTP
+CONTEXT_WINDOW=131072
 # Qwen 3.8 publishes different sampling per mode. The server defaults to
-# non-thinking output,
-# whose published profile is temp 0.7 / top_p 0.80. Open WebUI sends these
-# explicitly on every request and OVERRIDES the server, so they must match the
-# mode the server actually runs in; thinking values (1.0 / 0.95) are wrong here.
+# low-reasoning output for this Flash-Next trial; keep the published
+# non-thinking/low-reasoning sampling profile here so Open WebUI does not
+# silently override the backend with unrelated values.
 TEMPERATURE=0.7
 TOP_P=0.80
 MIN_P=0.0
@@ -53,8 +52,8 @@ RAG_SYSTEM_CONTEXT=True
 ENABLE_TOOLS=True
 OPENAPI_API_ENDPOINTS=mcpo-time:http://mcpo.open-webui.svc.cluster.local:8000:mcp-demo-key;mcpo-multi:http://mcpo-multi.open-webui.svc.cluster.local:8001:mcp-multi-key;mcpo-kiwix:http://mcpo-kiwix.open-webui.svc.cluster.local:8002:mcp-kiwix-key
 # Title/tag generation uses the same advertised model.
-TASK_MODEL=qwen3.8-27b
-TASK_MODEL_EXTERNAL=qwen3.8-27b
+TASK_MODEL=Qwen3.8-Flash-Next Q4 MTP
+TASK_MODEL_EXTERNAL=Qwen3.8-Flash-Next Q4 MTP
 DEFAULT_SYSTEM_PROMPT="You have access to an offline encyclopedia (Kiwix) via the 'fetch' tool.\nThe Kiwix server is located at: http://kiwix.kiwix.svc.cluster.local:8080\n\nTo search for information:\n1. Use the 'fetch' tool to search: \"http://kiwix.kiwix.svc.cluster.local:8080/search?pattern=YOUR_SEARCH_QUERY\"\n2. The result will be an HTML page containing search results. Read the links from this page.\n3. To read an article, use 'fetch' again on the article URL found in the search results (e.g., \"http://kiwix.kiwix.svc.cluster.local:8080/content/wikipedia_en_all_maxi_2025-08/Article_Name\").\n\nWhen asked about general knowledge or historical facts, ALWAYS check the offline encyclopedia first using these steps.\nCITE your sources by referencing the article title.\n"
 ENABLE_IMAGE_GENERATION=True
 IMAGE_GENERATION_ENGINE=comfyui

--- a/my-apps/ai/vllm/kustomization.yaml
+++ b/my-apps/ai/vllm/kustomization.yaml
@@ -15,6 +15,11 @@ resources:
   - httproute.yaml
   - servicemonitor.yaml
 
+# Flash-Next test cutover: release the sole RTX 3090 for llama.cpp.
+replicas:
+  - name: vllm-server
+    count: 0
+
 configMapGenerator:
   - name: vllm-scripts
     files:


### PR DESCRIPTION
## What

Performs the controlled Flash-Next test cutover now that the model, vision projector, and shared Q8 MTP head are verified and hydrated on the GPU worker's local NVMe.

- parks `vllm-server` at 0 via Kustomize replica override
- starts `llama-cpp-server` at 1 via Kustomize replica override
- repoints Open WebUI directly at `llama-cpp-service`
- advertises `Qwen3.8-Flash-Next Q4 MTP` as both the default and vision model
- raises Open WebUI's context window to 131072 for the trial
- keeps the existing tools, RAG, web search, image generation, and UI behavior intact

## Test target

- 1x RTX 3090 24 GB
- Threadripper 2950X Talos worker
- Qwen3.8-Flash-Next UD-IQ4_XS
- BF16 vision projector
- Q8_0 KV
- CPU MoE offload 45 layers
- Unsloth llama.cpp b10715-mix-86bd2d3
- shared Q8_0 MTP draft head
- `draft-mtp`, `n-max=3`
- 131072 context
- local-NVMe mmap/lazy model path

## Validation

Use Open WebUI for first-hand testing, not only synthetic benchmarks:

1. normal chat quality and latency
2. image understanding / multimodal requests
3. reasoning behavior and overthinking
4. MCP/tool calls
5. multi-turn correctness
6. 32K / 64K / 128K context behavior
7. VRAM/RAM headroom and stability over repeated conversations

Reverting this PR restores the production vLLM/Open WebUI routing shape.