### PR TITLE
chore(radar-ng): roll render-once API reader

### DIFF
--- a/my-apps/development/radar-ng/deployment-tile-server.yaml
+++ b/my-apps/development/radar-ng/deployment-tile-server.yaml
@@ -56,7 +56,7 @@ spec:
         - name: tile-server
           # v1.1.6/v1.1.7 crashloop: caddy binary carried a file capability
           # that exec-fails under drop-ALL. Fixed in v1.1.8 (radar-ng 144dcb9).
-          image: ghcr.io/mitchross/radar-ng-tile-server:v1.1.16
+          image: ghcr.io/mitchross/radar-ng-tile-server:v1.1.17
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## What

Roll only the Radar tile-server from v1.1.16 to v1.1.17.

This is the reader-first half of radar-ng #41. The image accepts the optional nowcast frame grid_key while retaining timestamp-only fallback. Worker images remain v1.1.29 and indexed rendering remains disabled.

Source: radar-ng merge a708555b105f67d8f0a38ef9e3c2c5a2db5ac765
Image: ghcr.io/mitchross/radar-ng-tile-server:v1.1.17
Digest: sha256:95db471e2b6766fb1ed66a9a12ee8f71e0b4f4632bb0e4477ab8a0befe70c4be

## Verification

- Exact release image built locally
- API suite: 21 passed
- kustomize build succeeds
- Rendered output has tile-server v1.1.17 and all six workers unchanged at v1.1.29
- git diff --check clean

## Acceptance

Argo Synced/Healthy, tile-server Ready on the exact digest, health and manifest remain current, old timestamp-only nowcast point reads still work.

## Rollback

Revert this PR through GitOps to v1.1.16. No writer has changed yet, so rollback does not require a manifest transition.