### PR TITLE
fix(ai): don't execute Unsloth glibc binary in Alpine init

### DIFF
--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -57,7 +57,11 @@ spec:
               if [ "$server" != /opt/unsloth/llama-server ]; then
                 ln -sf "$server" /opt/unsloth/llama-server
               fi
-              /opt/unsloth/llama-server --version
+              # Do not execute the downloaded binary in Alpine: Unsloth's
+              # portable x64 CUDA build is glibc-linked while Alpine is musl.
+              # The main llama.cpp CUDA image provides the glibc/CUDA runtime.
+              test -x /opt/unsloth/llama-server
+              echo "installed Unsloth llama.cpp $tag"
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
The Flash-Next pod is failing in the `install-unsloth-llama-cpp` init container with exit code 127. The Unsloth portable x64 CUDA binary is glibc-linked, while the Alpine init image uses musl, so executing `llama-server --version` there fails even though the extracted binary exists.

This keeps the SHA-pinned download/extract flow, verifies the binary exists and is executable, but defers actually launching it to the main llama.cpp CUDA container where the glibc/CUDA runtime is available.

No model, MTP, Open WebUI, context, or replica settings change.