### PR TITLE
fix(ai): drop unsupported tensor-read-lazy from Unsloth build

### DIFF
--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -104,10 +104,10 @@ spec:
             - "45"
             - --fit
             - "off"
+            # b10715 supports mmap load mode but predates --tensor-read-lazy.
+            # The model still reads from the node-local NVMe-backed PVC.
             - --load-mode
             - mmap
-            - --tensor-read-lazy
-            - "on"
             - --flash-attn
             - on
             - --cache-type-k


### PR DESCRIPTION
The Flash-Next pod now reaches the Unsloth b10715 llama-server, but that prebuilt rejects `--tensor-read-lazy` as an unknown argument.

This removes only `--tensor-read-lazy on` and keeps `--load-mode mmap`, so the model continues serving from the node-local NVMe-backed PVC with mmap. No changes to model, MTP, vision, context, Open WebUI routing, replica cutover, or CPU-MoE settings.

Unsloth's current MTP README documents the b10715-compatible route without `--tensor-read-lazy`; newer upstream work is heading through ggml-org/llama.cpp PR #28243, but this PR intentionally keeps tonight's test on the pinned prebuilt rather than introducing another runtime change.