### PR TITLE
fix(ai): gate llama.cpp startup on hydrated model cache

### DIFF
--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -36,6 +36,29 @@ spec:
       securityContext:
         fsGroup: 10001
         fsGroupChangePolicy: OnRootMismatch
+      initContainers:
+        # An existing Deployment can roll while Argo Sync hooks are still
+        # downloading/hydrating a new model. Gate the real server on an atomic,
+        # revisioned ready stamp written only after local-NVMe hydration ends.
+        - name: wait-for-model-cache
+          image: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          command:
+            - /bin/sh
+            - -ec
+            - /opt/repo-scripts/wait-for-model-cache.sh
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 64Mi
+          volumeMounts:
+            - name: repo-scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
+            - name: models
+              mountPath: /models
+              readOnly: true
       containers:
         - name: llama-cpp-server
           # b10751 fixed the Qwen3.8-27B MTP KV-init regression seen in b10745;
@@ -165,6 +188,10 @@ spec:
             - name: dshm
               mountPath: /dev/shm
       volumes:
+        - name: repo-scripts
+          configMap:
+            name: llama-cpp-scripts
+            defaultMode: 0555
         # Node-local NVMe cache, not NFS: the download hook persists the verified
         # artifacts on NFS and cache-sync hydrates this PVC before the server.
         - name: models

--- a/my-apps/ai/llama-cpp/kustomization.yaml
+++ b/my-apps/ai/llama-cpp/kustomization.yaml
@@ -24,6 +24,7 @@ configMapGenerator:
     files:
       - scripts/download-models.sh
       - scripts/sync-model-cache.sh
+      - scripts/wait-for-model-cache.sh
     options:
       annotations:
         argocd.argoproj.io/sync-wave: "-2"

--- a/my-apps/ai/llama-cpp/scripts/sync-model-cache.sh
+++ b/my-apps/ai/llama-cpp/scripts/sync-model-cache.sh
@@ -3,7 +3,14 @@ set -eu
 
 SRC=/src/qwen3.8-27b-gguf
 DST=/dst/qwen3.8-27b-gguf
+READY=/dst/.qwen38-27b-cache-ready
+CACHE_REV='qwen3.8-27b-q4kxl|3f227079003add2511437e5b1e94812e363385225bf6a9b47b0054a72bc8b01e|83ee4f4f205fa514161778c41df1ea14144faa0f713510893b63c2395f5c2d53|50d9ce5a6da381bbcfb31061cf73df94a90e6faf8efeddee379a9cb8f1501c6e'
+
 mkdir -p "$DST/mtp"
+
+# Clear readiness before touching the cache. If this Job fails or is killed,
+# a new serving pod must wait rather than start against partial/stale files.
+rm -f "$READY" "$READY.tmp"
 
 sync_one() {
   rel="$1"
@@ -30,6 +37,12 @@ sync_one Qwen3.8-27B-UD-Q4_K_XL.gguf
 sync_one mmproj-BF16.gguf
 sync_one mtp/mtp-Qwen3.8-27B-Q4_0.gguf
 
+# Atomic readiness publication. The serving initContainer requires this exact
+# revision plus all three non-empty files before llama-server may start.
+printf '%s\n' "$CACHE_REV" > "$READY.tmp"
+mv "$READY.tmp" "$READY"
+
+echo "model cache ready: $CACHE_REV"
 echo "=== RESULT ==="
 du -sb "$DST" | awk '{printf "Qwen3.8-27B cache: %s bytes (%.2f GiB)\n", $1, $1/1073741824}'
 df -h /dst

--- a/my-apps/ai/llama-cpp/scripts/wait-for-model-cache.sh
+++ b/my-apps/ai/llama-cpp/scripts/wait-for-model-cache.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+BASE=/models/qwen3.8-27b-gguf
+READY=/models/.qwen38-27b-cache-ready
+CACHE_REV='qwen3.8-27b-q4kxl|3f227079003add2511437e5b1e94812e363385225bf6a9b47b0054a72bc8b01e|83ee4f4f205fa514161778c41df1ea14144faa0f713510893b63c2395f5c2d53|50d9ce5a6da381bbcfb31061cf73df94a90e6faf8efeddee379a9cb8f1501c6e'
+
+MODEL="$BASE/Qwen3.8-27B-UD-Q4_K_XL.gguf"
+MMPROJ="$BASE/mmproj-BF16.gguf"
+MTP="$BASE/mtp/mtp-Qwen3.8-27B-Q4_0.gguf"
+
+# Argo sync hooks stage NFS -> local NVMe, but an already-existing Deployment
+# can be rolled before those hooks finish. Never let llama-server enter a
+# crash-loop against a half-hydrated cache.
+i=0
+while :; do
+  stamp="$(cat "$READY" 2>/dev/null || true)"
+  if [ "$stamp" = "$CACHE_REV" ] && [ -s "$MODEL" ] && [ -s "$MMPROJ" ] && [ -s "$MTP" ]; then
+    echo "model cache ready: $CACHE_REV"
+    exit 0
+  fi
+
+  i=$((i + 1))
+  if [ $((i % 6)) -eq 1 ]; then
+    echo "waiting for Qwen3.8-27B local-NVMe cache hydration (stamp=${stamp:-missing})"
+    ls -lh "$BASE" "$BASE/mtp" 2>/dev/null || true
+  fi
+  sleep 5
+done


### PR DESCRIPTION
Fixes the startup race observed immediately after the Qwen3.8-27B llama.cpp production cutover.

Observed failure:

`llama-server` rolled while `llama-cpp-download-qwen38-27b` was still running and exited repeatedly with `failed to open GGUF file ... No such file or directory` because the new 27B artifacts had not yet reached the GPU worker's local NVMe cache.

Argo sync waves sequence new resources/hooks, but an already-existing Deployment can still roll while Sync hooks are in progress. This change makes server startup independent of that race:

- cache-sync clears readiness before hydration starts
- after all three artifacts are copied successfully, cache-sync atomically writes a revisioned ready stamp on the local NVMe PVC
- a new `wait-for-model-cache` initContainer blocks the serving container until the exact revision stamp and all three non-empty artifacts exist
- the revision encodes the pinned SHA256s for target, BF16 projector, and MTP draft, so a future model/artifact change cannot accidentally consume a stale ready marker
- the wait script lives in the existing wave -2 generated scripts ConfigMap

No model, quant, runtime, MTP, context, vision, routing, consumer wiring, or replica settings change. This is startup sequencing only.