### PR TITLE
fix(radar-ng): pin radar workloads to the node holding their flash disk

### DIFF
--- a/infrastructure/controllers/gpu-priority-classes/priority-classes.yaml
+++ b/infrastructure/controllers/gpu-priority-classes/priority-classes.yaml
@@ -25,3 +25,14 @@ metadata:
 value: 50
 globalDefault: false
 preemptionPolicy: PreemptLowerPriority
+---
+# Production data pipelines: outrank general homelab apps, still yield to primary AI workloads.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: app-critical
+  annotations:
+    description: "Production data pipelines (radar-ng ingestion + tile origin)"
+value: 500
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority

--- a/my-apps/development/radar-ng/deployment-tile-server.yaml
+++ b/my-apps/development/radar-ng/deployment-tile-server.yaml
@@ -25,7 +25,16 @@ spec:
         config-rev: "2026-09-02-alerts-queue"
     spec:
       # Prefer the node holding the worker that shares these RWO volumes (preferred, so tile-server can bootstrap first).
+      priorityClassName: app-critical
       affinity:
+        # longhorn-flash (tiles/grids/state) sets diskSelector "flash"; only this node carries that disk.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpu-worker
+                    operator: In
+                    values: ["true"]
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/temporal-worker-deployment.yaml
@@ -29,7 +29,16 @@ spec:
         radar-ng.vanillax.dev/worker: "true"
     spec:
       # Shares RWO tiles/grids/state with tile-server — must land on the same node or Longhorn Multi-Attach fails.
+      priorityClassName: app-critical
       affinity:
+        # longhorn-flash (tiles/grids/state) sets diskSelector "flash"; only this node carries that disk.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpu-worker
+                    operator: In
+                    values: ["true"]
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:

--- a/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
+++ b/my-apps/development/radar-ng/temporal-workers/worker-pools.yaml
@@ -31,7 +31,16 @@ spec:
         app: radar-ng-worker-mrms
         radar-ng.vanillax.dev/worker: "true"
     spec:
+      priorityClassName: app-critical
       affinity:
+        # longhorn-flash (tiles/grids/state) sets diskSelector "flash"; only this node carries that disk.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpu-worker
+                    operator: In
+                    values: ["true"]
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -116,7 +125,16 @@ spec:
         app: radar-ng-worker-nowcast
         radar-ng.vanillax.dev/worker: "true"
     spec:
+      priorityClassName: app-critical
       affinity:
+        # longhorn-flash (tiles/grids/state) sets diskSelector "flash"; only this node carries that disk.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpu-worker
+                    operator: In
+                    values: ["true"]
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -201,7 +219,16 @@ spec:
         app: radar-ng-worker-hrrr
         radar-ng.vanillax.dev/worker: "true"
     spec:
+      priorityClassName: app-critical
       affinity:
+        # longhorn-flash (tiles/grids/state) sets diskSelector "flash"; only this node carries that disk.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpu-worker
+                    operator: In
+                    values: ["true"]
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -286,7 +313,16 @@ spec:
         app: radar-ng-worker-aux
         radar-ng.vanillax.dev/worker: "true"
     spec:
+      priorityClassName: app-critical
       affinity:
+        # longhorn-flash (tiles/grids/state) sets diskSelector "flash"; only this node carries that disk.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpu-worker
+                    operator: In
+                    values: ["true"]
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -371,7 +407,16 @@ spec:
         app: radar-ng-worker-alerts
         radar-ng.vanillax.dev/worker: "true"
     spec:
+      priorityClassName: app-critical
       affinity:
+        # longhorn-flash (tiles/grids/state) sets diskSelector "flash"; only this node carries that disk.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpu-worker
+                    operator: In
+                    values: ["true"]
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:


### PR DESCRIPTION
## The outage

Three of radar's six worker pools (`legacy`, `mrms`, `nowcast`) have been `Pending` for over two hours. `/api/health` reports `degraded`, MRMS 7912s stale.

## Root cause

Radar's `tiles`, `grids`, `state`, and `pmtiles` PVCs use `longhorn-flash`. That class sets `diskSelector: flash`, and exactly one disk in the cluster carries that tag:

```
flash disk on: talos-prod-cluster-v2-gpu-workers-7ct4kq  ssd-flash  /var/mnt/longhorn-ssd-flash
```

Longhorn's `dataLocality: best-effort` does **not** influence the kube-scheduler — that is still an [open Longhorn improvement request](https://github.com/longhorn/longhorn/issues/5448). So nothing ever kept radar's pods on the node holding their own storage; they simply happened to land there.

At 02:20 the AI cutover filled the GPU node, `tile-server` was rescheduled onto `hp-elite`, and all six worker pools followed it there through their existing required `podAffinity`. `hp-elite` has 22.97Gi allocatable and already carries ~13Gi of pinned infrastructure. Radar's full stack is ~20Gi, so the three largest pools could not fit and stayed Pending. The pods that *did* fit are serving every tile read over iSCSI from the GPU node.

A PriorityClass alone could not have fixed this: preempting every general app on `hp-elite` frees only ~7Gi of the ~13Gi needed.

## The change

**1. Required `nodeAffinity` on `gpu-worker`** for the seven flash-bound workloads (tile-server + six worker pools). This makes an already-real storage constraint explicit instead of accidental. `open-meteo` is deliberately excluded — its PVC is on the default `longhorn` class with its replica on hp-elite's NVMe, so it stays put.

**2. New `app-critical` PriorityClass (500)**, applied to the same workloads. Every radar pod ran at priority 0, tied with redlib and convertx, which is why the scheduler logged `no preemption victims found`. Placement in the existing tier ladder:

| Class | Value | Who |
|---|---|---|
| `gpu-workload-high` | 1000 | llama-cpp, vLLM — AI still wins the GPU box |
| **`app-critical`** | **500** | **radar ingestion + tile origin** |
| `gpu-workload-background` | 100 | batch AI |
| `gpu-workload-preemptible` | 50 | ComfyUI, SwarmUI |
| *(default)* | 0 | general homelab apps |

This matches the stated intent that the GPU box prioritises AI: radar yields to llama-cpp and vLLM, but is no longer a pushover for general apps.

## Capacity after the move

GPU node is 29.95 CPU / 97.7Gi allocatable, currently 32% CPU and 41% memory. Radar's full stack is ~9 CPU / ~20Gi, leaving roughly 11 CPU and 36Gi free for AI to grow.

## Validation

- Full-repo aggregate render: 101 directories, `fail=0`.
- `validate-argocd-apps.sh`: PASSED. `validate-no-inline-scripts.sh`: clean.
- `validate-vpa-policies.py`: 0 errors (4 pre-existing warnings unrelated to radar). `validate-kopiur-coverage.py`: OK.
- Render confirms all 7 workloads carry both `priorityClassName` and the `nodeAffinity`.

## After merge

```sh
kubectl -n radar-ng get pods -o wide          # all radar pods on the gpu-worker node
kubectl get workerdeployments -n radar-ng     # six pools current=target, Ready
curl -s https://radar-ng-api.vanillax.me/api/health | jq '.status, .mrms_age_s'
```

Expected: `status: ok` and MRMS age back under 600s once ingestion catches up.

## Known follow-up

`gpu-worker` is a GPU label doing duty as a storage constraint. The honest long-term fix is either a storage-purpose node label as part of the node-pool work, or moving radar's tiles off `longhorn-flash` entirely (Phase 3 RustFS), which would free radar from the GPU box and let that node be AI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1L7LjtxSVaLdDpyuhpq3D
