### PR TITLE
ai: finish llama.cpp production cutover cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,12 @@ This is a production-grade GitOps Kubernetes cluster running on **Talos OS** wit
 
 **Tech Stack**: Talos OS + ArgoCD + Cilium (Gateway API) + Longhorn + 1Password + GPU support
 
-**AI/LLM Backend**: Two OpenAI-compatible local backends, both NOT ollama:
+**AI/LLM Backend**: one active OpenAI-compatible local backend plus a parked rollback, both NOT ollama:
 
-- **vLLM** (`http://vllm-service.vllm.svc.cluster.local:8080/v1`, served model `qwen3.8-27b`) is active with the AutoRound W4A16 dense 27B, native vision, fp8 KV at 64K, and 2-token MTP on one RTX 3090.
-- **llama.cpp** is the parked GGUF rollback backend at `replicas: 0` (Unsloth Flash-Next UD-IQ4_XS).
+- **llama.cpp** (`http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`, served model `qwen3.8-27b`) is active with Qwen3.8-27B UD-Q4_K_XL, q8_0 target/draft KV, 65K context, MTP-2, native vision, and one RTX 3090.
+- **vLLM** is the parked Qwen3.8-27B W4A16 rollback backend at `replicas: 0`; its model/cache artifacts remain intact.
 
-GPU topology: the GPU workloads use **mutually exclusive whole-card** allocations (`type: Recreate`, time-slicing disabled — never oversubscribe the card). They scale-swap by committed replica counts. Current state is vLLM `1`, llama-cpp `0`, and ComfyUI/SwarmUI `0`; the chassis has one RTX 3090. App→backend wiring is tabulated in `docs/domains/ai-gpu/model-catalog.md`; the swap procedure + card truth table live in `docs/domains/ai-gpu/gpu-scale-swap.md`.
+GPU topology: the GPU workloads use **mutually exclusive whole-card** allocations (`type: Recreate`, time-slicing disabled — never oversubscribe the card). They scale-swap by committed replica counts. Current state is llama.cpp `1`, vLLM `0`, and ComfyUI/SwarmUI `0`; the chassis has one RTX 3090. App→backend wiring is tabulated in `docs/domains/ai-gpu/model-catalog.md`; the swap procedure + card truth table live in `docs/domains/ai-gpu/gpu-scale-swap.md`.
 
 ## Core Architecture Pattern: GitOps Self-Management
 
@@ -122,7 +122,7 @@ Do **not** write changelog/jira-style comments: no per-version release-note summ
 - Use NFS CSI driver (`csi: driver: nfs.csi.k8s.io`) for static NFS PVs — **legacy `nfs:` silently ignores mountOptions**
 - Add new infrastructure component paths to `infrastructure/controllers/argocd/apps/appsets/infrastructure-appset.yaml` explicitly (not glob-discovered)
 - List ALL YAML files in each directory's `kustomization.yaml` under `resources:` — **unlisted files are never deployed**
-- Use **vLLM** (`qwen3.8-27b`, the default for app inference) or the parked llama.cpp rollback backend — **never ollama**
+- Use **llama.cpp** (`qwen3.8-27b`, the active default for app inference) or the parked vLLM rollback backend — **never ollama**
 - Use sync waves when adding infrastructure components
 - Add ArgoCD hook annotations to all Kubernetes Jobs — `argocd.argoproj.io/hook: Sync` + `argocd.argoproj.io/hook-delete-policy: BeforeHookCreation`. K8s Jobs are immutable after creation; without these, image tag bumps from Renovate cause "field is immutable" sync failures. For standalone Jobs, add annotations directly. For Helm-rendered Jobs, use Kustomize patches targeting `kind: Job`
 - Check `helm show values <chart> | grep -A20 certManager` when adding any Helm chart with webhooks — if a `certManager.enabled` option exists, **set it to `true`**. Helm hook Jobs for webhook certs break under ArgoCD (SA deleted before Job runs = stuck forever = API server death)
@@ -173,7 +173,7 @@ Detailed instructions load automatically when working in these directories:
 | `infrastructure/database/` | Database AppSet scope (Redis + shared support); plain-Postgres pointer |
 | `infrastructure/networking/` | Gateway API routing patterns, HTTPRoute templates |
 | `my-apps/` | App templates (minimal, web, secrets, storage), Helm+Kustomize patterns |
-| `my-apps/ai/` | GPU workload patterns, vLLM backend |
+| `my-apps/ai/` | GPU workload patterns, active llama.cpp backend, parked vLLM rollback |
 | `my-apps/development/posthog/` | Self-hosted PostHog: file map, invariants, upgrade/DR rules, porting guide |
 | `monitoring/` | Monitoring pitfalls (S3 creds, ServiceMonitor selectors) |
 

--- a/docs/domains/ai-gpu/gpu-scale-swap.md
+++ b/docs/domains/ai-gpu/gpu-scale-swap.md
@@ -8,94 +8,77 @@ manifests all point here.
 
 GPU workloads are **mutually-exclusive whole-card**: time-slicing is disabled,
 every GPU pod requests whole `nvidia.com/gpu` cards, and each Deployment uses
-`strategy: Recreate`. **Never two pods on the cards at once.** You don't
-"deploy" a GPU app — you **swap** which one holds the cards by flipping
-committed `replicas:` values.
+`strategy: Recreate`. **Never two pods on the card at once.** You don't
+"deploy" a GPU app — you **swap** which one holds the card by flipping
+committed replica counts.
 
 Two things make this safe by construction:
 
 1. **The scheduler enforces exclusivity.** A newly scaled-up pod sits
-   `Pending` until the outgoing pod actually releases its card(s).
-   `0/2 nodes available ... Insufficient nvidia.com/gpu` during a swap is
-   **normal**, not a broken scheduler — it clears when the old pod finishes
-   terminating.
-2. **ArgoCD selfHeal reverts manual scaling.** `kubectl scale` is undone
-   within minutes. The committed value in git is the only real switch.
+   `Pending` until the outgoing pod actually releases its card.
+   `Insufficient nvidia.com/gpu` during a swap is normal.
+2. **ArgoCD selfHeal reverts manual scaling.** `kubectl scale` is undone.
+   The committed value in git is the only real switch.
 
 ## Card truth table
 
 | App | Cards | `replicas` in git (current) | File |
-|---|---|---|---|
-| **vLLM** (Qwen 3.8 27B W4A16, active) | **1** | `1` | `my-apps/ai/vllm/deployment.yaml` |
-| **llama-cpp** (Qwen 3.8 Flash-Next UD-IQ4_XS, rollback) | 1 | `0` | `my-apps/ai/llama-cpp/deployment.yaml` |
-| **NInfer-3090** (Qwen 3.8 .ninfer, parked candidate) | 1 | `0` | `my-apps/ai/ninfer/deployment.yaml` |
-| **ComfyUI** (image gen — see note below) | 1 | `0` | `my-apps/ai/comfyui/deployment.yaml` |
-| **SwarmUI** (image gen — see note below) | 1 | `0` | `my-apps/ai/swarmui/deployment.yaml` |
-| llmfit (batch benchmark **Jobs**, not always-on) | 1 or 2 | n/a | `my-apps/ai/llmfit/` |
+|---|---:|---:|---|
+| **llama.cpp** (Qwen3.8-27B UD-Q4_K_XL, active) | **1** | `1` | `my-apps/ai/llama-cpp/deployment.yaml` |
+| **vLLM** (Qwen3.8-27B W4A16, rollback) | 1 | `0` | `my-apps/ai/vllm/deployment.yaml` |
+| **NInfer-3090** (Qwen3.8 .ninfer, parked candidate) | 1 | `0` | `my-apps/ai/ninfer/deployment.yaml` |
+| **ComfyUI** | 1 | `0` | `my-apps/ai/comfyui/deployment.yaml` |
+| **SwarmUI** | 1 | `0` | `my-apps/ai/swarmui/deployment.yaml` |
+| llmfit (batch benchmark Jobs) | 1 | n/a | `my-apps/ai/llmfit/` |
 
-> **Single-card reality (2026-08-21, permanent):** the chassis holds one RTX
-> 3090. A valid state has exactly one `replicas: 1` GPU Deployment.
-
-There are no valid two-workload combinations. The dual-GPU llmfit Job cannot
-run on this chassis.
-
-> **Image gen: ComfyUI vs SwarmUI — decision pending.** ComfyUI's manifest is
-> marked *retired, replaced by SwarmUI* (SwarmUI self-starts its own ComfyUI),
-> but the docs' vision→image wiring still describes ComfyUI and no final call
-> has been made. Both sit at `replicas: 0`; neither is canonical yet. If you
-> need image gen today, pick one, bring it up per the procedure below, and
-> scale it back to 0 when done.
+The chassis permanently has one RTX 3090. A valid steady state has exactly one
+GPU Deployment at `replicas: 1`.
 
 ## The procedure
 
-1. **Pick the target state** from the truth table (exactly one active row).
-2. **Edit the `replicas:` values in ONE commit** — outgoing app(s) to `0`,
-   incoming app(s) to `1`, in their `deployment.yaml` files. One commit means
-   ArgoCD applies both sides together and the scheduler sequences the rest.
-3. **Push.** The my-apps AppSet (wave 6) syncs automatically; no manual sync
-   needed.
-4. **Wait out the handover.** The incoming pod stays `Pending` while the
-   outgoing pod terminates (model unload can take ~a minute). Do **not**
-   "fix" the Pending state — see rule 1 above.
-5. **Verify:**
+1. Pick the target state from the truth table.
+2. Edit outgoing and incoming committed replica counts in **one PR/commit**.
+3. Push/merge and let ArgoCD self-heal to the new state.
+4. Wait for the outgoing pod to release the GPU; do not "fix" the incoming
+   pod while it is Pending.
+5. Verify:
 
 ```bash
-# Old pod gone, new pod Running
-kubectl -n llama-cpp get pods; kubectl -n vllm get pods
-kubectl -n comfyui get pods; kubectl -n swarmui get pods
+kubectl -n llama-cpp get pods
+kubectl -n vllm get pods
+kubectl -n comfyui get pods
+kubectl -n swarmui get pods
 
-# Who actually holds the cards (run inside the power-limit admin DaemonSet,
-# which sees all GPUs without consuming an allocation)
+# Card owner / live cap.
 kubectl -n gpu-operator exec ds/nvidia-powerlimit -- nvidia-smi
 
-# Endpoint answers (from any in-cluster pod)
-curl -s http://vllm-service.vllm.svc.cluster.local:8080/v1/models
+# Active production endpoint.
+curl -s http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1/models
 ```
+
+The LAN compatibility hostname `https://vllm.vanillax.me/v1` currently routes
+to llama.cpp too; the canonical in-cluster endpoint is `llama-cpp-service`.
 
 ## Side effects to expect
 
-- **Scaling vLLM to 0** → every Qwen consumer loses inference, including
-  Open WebUI, Perplexica, and Deal Scout. Treat it as an app-degraded window.
-- **ComfyUI's vision→image workflow needs the chat backend too** — it calls the
-  active multimodal endpoint for vision. Bringing up ComfyUI alone leaves
-  its vision/caption nodes failing against a dead Service. With one card, that
-  combined workflow cannot run concurrently.
-- **llmfit Jobs** need the active server parked first; only single-GPU Jobs fit.
+- Scaling llama.cpp to 0 removes the active chat/vision backend for Open WebUI,
+  Perplexica, SurfSense, LiteLLM, Hindsight, Presenton, HolmesGPT, Project Nomad,
+  and any Pi.dev sessions using the cluster endpoint.
+- ComfyUI's vision-to-image helper depends on the active chat backend. With one
+  card, ComfyUI and the chat backend cannot both own the GPU simultaneously.
+- llmfit Jobs require the active server parked first.
 
 ## Don'ts
 
-- Don't `kubectl scale` (selfHeal reverts it — commit the value).
-- Don't set `NVIDIA_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` in pod env — they
-  bypass the device plugin's accounting (sole exception: the infrastructure
-  `nvidia-powerlimit` admin DaemonSet).
-- Don't switch a GPU Deployment to `RollingUpdate` — Recreate is what
-  guarantees the old pod releases the card (and avoids RWO Multi-Attach).
-- Don't delete the 200 W power cap to "fix" slowness — tune
-  `POWER_LIMIT_WATTS` in
-  `infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml`
-  instead. The cap is set by the house circuit, not by the efficiency knee;
-  raising it needs an electrical decision, not just a performance one.
+- Don't `kubectl scale`; selfHeal reverts it.
+- Don't set `NVIDIA_VISIBLE_DEVICES`/`CUDA_VISIBLE_DEVICES` in GPU workload pods.
+  The infrastructure `nvidia-powerlimit` DaemonSet is the intentional exception.
+- Don't switch a GPU Deployment to `RollingUpdate`; `Recreate` releases the
+  whole card cleanly and avoids RWO Multi-Attach.
+- Don't raise the **220 W** production power cap just to chase throughput.
+  `POWER_LIMIT_WATTS` lives in
+  `infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml`;
+  changing it is an electrical/circuit decision.
 
-Related: [model catalog](model-catalog.md) (who points at what) ·
+Related: [model catalog](model-catalog.md) ·
 [3090 LLM optimization](3090-llm-optimization.md) · `my-apps/ai/CLAUDE.md`
-(GPU workload pattern).

--- a/docs/domains/ai-gpu/model-catalog.md
+++ b/docs/domains/ai-gpu/model-catalog.md
@@ -78,9 +78,10 @@ HolmesGPT, Hindsight, Project Nomad, and the ComfyUI vision bridge.
 
 Pi.dev uses the same `qwen3.8-27b` API id through
 `https://llama.vanillax.me/v1`. The workstation configuration lives in
-[`pi-agent-local-dev.md`](pi-agent-local-dev.md). Pi sends top-level
-`reasoning_effort`; medium is the normal coding default and xhigh is reserved
-for difficult reasoning.
+[`pi-agent-local-dev.md`](pi-agent-local-dev.md). Because Qwen3.8 separates
+`enable_thinking` from its valid effort values (`low`, `medium`, `xhigh`), Pi
+uses explicit `chat_template_kwargs` so `off` really disables thinking and
+`medium` is the normal coding default.
 
 ## Rollback
 

--- a/docs/domains/ai-gpu/model-catalog.md
+++ b/docs/domains/ai-gpu/model-catalog.md
@@ -30,23 +30,31 @@ llama.cpp serves the canonical `qwen3.8-27b` id:
 | Concurrency | one sequence slot |
 | Placement | target + draft fully on RTX 3090 |
 | Speculation | MTP Q4_0, `n-max=2` |
-| Backend default | low reasoning; temp 0.7, top-p 0.8, top-k 20, presence-penalty 1.5 |
+| Backend default | low reasoning; temp 0.7, top-p 0.8, top-k 20, min-p 0, presence-penalty 1.5 |
+| Power cap | 220 W |
 
 `b10751` fixed a Qwen3.8-27B MTP KV-initialization regression present in
-`b10745`; production uses `b10752`. The 65K window is deliberately conservative
-for the first production cutover: stability, tools, vision, Pi and multi-turn
-correctness matter more than advertising the largest context that can boot.
+`b10745`; production uses `b10752`. The 65K window is deliberately conservative:
+stability, tools, vision, Pi.dev and multi-turn correctness matter more than
+advertising the largest context that can boot.
 
-The 200 W power cap remains mandatory.
+### Measured production baseline — 2026-09-03
+
+Normal Open WebUI responses measured about **42-43 generated tok/s**. While
+generating, the single RTX 3090 reported approximately **22,740 MiB / 24,576
+MiB VRAM**, **87% GPU utilization**, and **216 W / 220 W**. These are
+real-machine observations on the Threadripper 2950X host, not synthetic maxima.
 
 ## Storage and staging
 
 The TrueNAS llama.cpp share is the canonical archive. A wave -1 hook downloads
 and SHA-verifies the Q4_K_XL target, BF16 projector and Q4_0 MTP artifact; a
-wave 0 hook hydrates those files into the GPU worker's 450 GB local NVMe cache.
-The serving pod mounts only the local cache.
+wave 0 hook hydrates those files into the GPU worker's local NVMe cache. The
+serving pod mounts only the local cache.
 
-The old vLLM model and compile caches remain intact for rollback.
+A revisioned ready stamp plus a serving initContainer gates startup until the
+exact local-NVMe artifact set is present. The old vLLM model and compile caches
+remain intact for rollback.
 
 ## App wiring
 
@@ -54,11 +62,25 @@ Canonical Git-managed direct-client configuration:
 
 - endpoint: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`
 - model: `qwen3.8-27b`
+- LAN endpoint: `https://llama.vanillax.me/v1`
 
-Both `https://vllm.vanillax.me/v1` and `https://llama.vanillax.me/v1` route to
-llama.cpp. The old in-cluster `vllm-service.vllm.svc.cluster.local:8080` name is
-retained as an `ExternalName` alias for persistent clients whose configuration
-is stored outside Git, such as already-imported n8n workflows.
+`https://vllm.vanillax.me/v1` remains a compatibility LAN hostname and also
+routes to llama.cpp. The old in-cluster
+`vllm-service.vllm.svc.cluster.local:8080` name remains an `ExternalName` alias
+for persistent clients whose configuration lives outside Git, such as already
+imported n8n workflows.
+
+Git-managed consumers should use `llama-cpp-service` directly. Current direct
+consumers include Open WebUI, Perplexica/Vane, LiteLLM, Presenton, SurfSense,
+HolmesGPT, Hindsight, Project Nomad, and the ComfyUI vision bridge.
+
+## Pi.dev
+
+Pi.dev uses the same `qwen3.8-27b` API id through
+`https://llama.vanillax.me/v1`. The workstation configuration lives in
+[`pi-agent-local-dev.md`](pi-agent-local-dev.md). Pi sends top-level
+`reasoning_effort`; medium is the normal coding default and xhigh is reserved
+for difficult reasoning.
 
 ## Rollback
 

--- a/docs/domains/ai-gpu/pi-agent-local-dev.md
+++ b/docs/domains/ai-gpu/pi-agent-local-dev.md
@@ -8,34 +8,22 @@
 > This document is for **Pi.dev / Pi coding agent**, not Raspberry Pi.
 
 Pi is a workstation client. Nothing in `~/.pi/agent/` deploys to Kubernetes.
-The cluster owns the model/runtime; Pi only needs an OpenAI-compatible provider
-entry and the model metadata that lets it expose the right reasoning levels,
-context window, image input, and token accounting.
+The cluster owns model/runtime tuning; Pi only needs the provider/model metadata
+that describes the OpenAI-compatible API and Qwen3.8's reasoning controls.
 
-## 1. Update Pi itself
+## 1. Update Pi
 
 ```bash
-# Pi CLI only
 pi update --self
-
-# Or Pi + installed packages/extensions
 pi update --all
-```
-
-Useful checks:
-
-```bash
 pi --version
-pi list
 ```
 
-Pi's current package manager also supports `pi update --models` for refreshed
-remote catalogs, but the homelab model below is defined locally in
-`models.json`, so that command is not required for this backend.
+The configuration below targets Pi 0.84.x or newer.
 
 ## 2. `~/.pi/agent/models.json`
 
-Use a dedicated custom provider for the homelab llama.cpp endpoint:
+Use a dedicated custom provider for the active llama.cpp endpoint:
 
 ```json
 {
@@ -46,10 +34,17 @@ Use a dedicated custom provider for the homelab llama.cpp endpoint:
       "apiKey": "local-no-key-required",
       "compat": {
         "supportsDeveloperRole": false,
-        "supportsReasoningEffort": true,
+        "supportsReasoningEffort": false,
         "supportsUsageInStreaming": true,
         "maxTokensField": "max_tokens",
-        "thinkingFormat": "reasoning_effort"
+        "thinkingFormat": "chat-template",
+        "chatTemplateKwargs": {
+          "enable_thinking": { "$var": "thinking.enabled" },
+          "reasoning_effort": {
+            "$var": "thinking.effort",
+            "omitWhenOff": true
+          }
+        }
       },
       "models": [
         {
@@ -57,7 +52,7 @@ Use a dedicated custom provider for the homelab llama.cpp endpoint:
           "name": "Qwen3.8 27B (llama.cpp, 1x3090, 65K)",
           "reasoning": true,
           "thinkingLevelMap": {
-            "off": "none",
+            "off": "off",
             "minimal": null,
             "low": "low",
             "medium": "medium",
@@ -81,114 +76,151 @@ Use a dedicated custom provider for the homelab llama.cpp endpoint:
 }
 ```
 
-Why these compatibility settings:
+### Why the explicit chat-template mapping matters
 
-- `openai-completions` matches llama.cpp's `/v1/chat/completions` API.
-- `supportsDeveloperRole: false` keeps Pi on a single normal `system` message;
-  Qwen3.8's template is stricter than OpenAI's role model and this avoids
-  duplicate/developer-system edge cases.
-- llama.cpp now accepts top-level OpenAI-style `reasoning_effort`, so the old
-  vLLM-era `chat_template_kwargs` workaround is intentionally gone.
-- Qwen3.8 accepts `low`, `medium`, and `xhigh`; `none` disables thinking.
-  Unsupported Pi levels are explicitly `null`, so Pi hides/clamps them instead
-  of inventing values the model template does not understand.
+Qwen3.8's upstream template accepts only `low`, `medium`, and `xhigh` when
+thinking is enabled, and defaults to `xhigh` if effort is omitted. Turning
+thinking off is a separate `enable_thinking=false` control.
+
+Pi's generic OpenAI `reasoning_effort` mode omits the effort field when Pi is
+set to `off`. That is not enough here because llama.cpp has its own server-side
+reasoning default. The explicit mapping above makes every request unambiguous:
+
+| Pi level | `chat_template_kwargs` sent to llama.cpp |
+|---|---|
+| `off` | `enable_thinking: false` |
+| `low` | `enable_thinking: true`, `reasoning_effort: low` |
+| `medium` | `enable_thinking: true`, `reasoning_effort: medium` |
+| `xhigh` | `enable_thinking: true`, `reasoning_effort: xhigh` |
+
+`omitWhenOff` prevents Pi from sending the string `off` as a Qwen reasoning
+effort. Unsupported Pi levels are `null`, so the UI skips them rather than
+inventing values the model template rejects.
+
+Other compatibility choices:
+
+- `supportsDeveloperRole: false` keeps the agent context in an ordinary system
+  message for the local OpenAI-compatible server.
+- `supportsReasoningEffort: false` prevents a duplicate top-level
+  `reasoning_effort`; the value belongs in `chat_template_kwargs` above.
 - `input: ["text", "image"]` enables Pi screenshot/image input.
-- sampling is deliberately not set in Pi. The production server owns the
-  validated Qwen sampling defaults: temp 0.7, top-p 0.8, top-k 20, min-p 0,
-  presence penalty 1.5, repeat penalty 1.0.
+- Sampling is not set in Pi. The validated production server owns temp/top-p/
+  top-k/min-p/presence/repeat defaults.
 
-`models.json` reloads whenever `/model` is opened, so a Pi restart is usually
-not needed after editing it.
+`models.json` reloads whenever `/model` is opened.
 
-## 3. `~/.pi/agent/settings.json`
+## 3. Fix your existing `~/.pi/agent/settings.json`
 
-Make the homelab model the default and use **medium** reasoning for normal coding:
+Your previous config used provider `vanillax-vllm` and the now-obsolete
+`modelThinkingLevels` key. Keep your installed packages exactly as they are;
+change only the model selection fields.
+
+The important result should be:
 
 ```json
 {
   "defaultProvider": "vanillax-llama",
   "defaultModel": "qwen3.8-27b",
   "defaultThinkingLevel": "medium",
-  "modelThinkingLevels": {
-    "vanillax-llama/qwen3.8-27b": "medium"
-  }
+  "enabledModels": [
+    "vanillax-llama/qwen3.8-27b",
+    "vanillax-litellm/kimi-k3"
+  ]
 }
 ```
 
-You can save the same settings interactively:
+Do **not** copy that small object over your whole file — your `packages`, theme,
+and other settings should remain. To update the existing JSON safely with `jq`:
 
-1. `/model` → choose `vanillax-llama/qwen3.8-27b` → **Ctrl+S**.
-2. `/thinking` → choose `medium` → **Ctrl+S**.
+```bash
+cp ~/.pi/agent/settings.json ~/.pi/agent/settings.json.bak
 
-Recommended levels:
+jq '
+  .defaultProvider = "vanillax-llama"
+  | .defaultModel = "qwen3.8-27b"
+  | .defaultThinkingLevel = "medium"
+  | del(.modelThinkingLevels)
+  | .enabledModels = ((.enabledModels // [])
+      | map(if . == "vanillax-vllm/qwen3.8-27b"
+            then "vanillax-llama/qwen3.8-27b"
+            else . end)
+      | if index("vanillax-llama/qwen3.8-27b") then .
+        else ["vanillax-llama/qwen3.8-27b"] + . end)
+' ~/.pi/agent/settings.json > ~/.pi/agent/settings.json.new \
+  && mv ~/.pi/agent/settings.json.new ~/.pi/agent/settings.json
+```
 
-| Pi level | Qwen request | Use |
-|---|---|---|
-| `off` | `reasoning_effort: none` | trivial edits, formatting, lookups |
-| `low` | `reasoning_effort: low` | short code changes |
-| `medium` | `reasoning_effort: medium` | default coding/debugging/agent work |
-| `xhigh` | `reasoning_effort: xhigh` | hard reasoning only |
+Then verify:
 
-Do not use `xhigh` as the everyday default. It consumes much more generation
-budget and is exactly the overthinking behavior this setup is trying to avoid.
+```bash
+jq '{defaultProvider,defaultModel,defaultThinkingLevel,enabledModels,packages}' \
+  ~/.pi/agent/settings.json
+```
+
+Pi 0.84.x uses `defaultThinkingLevel`; unknown legacy keys are ignored, so
+removing `modelThinkingLevels` avoids a config value that looks active but is not.
 
 ## 4. Start and verify
 
-Normal launch:
+Normal launch after the settings change:
 
 ```bash
 pi
 ```
 
-Explicit launch while testing the migration:
+Explicit launch while validating:
 
 ```bash
 pi --provider vanillax-llama --model qwen3.8-27b --thinking medium
 ```
 
-Or select the provider-qualified model in one argument:
+Or:
 
 ```bash
 pi --model vanillax-llama/qwen3.8-27b --thinking medium
 ```
 
-List what Pi sees:
+Check discovery:
 
 ```bash
 pi --list-models qwen3.8-27b
 ```
 
-Inside a Pi `bash` tool invocation, Pi exposes the selected model and effective
-reasoning level:
+Inside Pi, `/model` should show `vanillax-llama/qwen3.8-27b`, and the statusline
+should show `medium`. Use Shift+Tab (or your configured thinking control) to
+cycle only the supported levels.
 
-```bash
-printf '%s/%s\n' "$PI_PROVIDER" "$PI_MODEL"
-printf 'reasoning=%s\n' "$PI_REASONING_LEVEL"
-```
-
-Expected:
-
-```text
-vanillax-llama/qwen3.8-27b
-reasoning=medium
-```
-
-First tool test from the repository root:
+First tool test from a repository root:
 
 ```text
 Read package.json and summarize the scripts. Do not guess; use the read tool.
 ```
 
-You should see a real tool call. Then test an edit in a disposable branch and
-make Pi run the relevant tests/typecheck rather than merely describing them.
+You should see a real `read` tool call. Then test a small edit in a disposable
+branch and require Pi to run the relevant tests/typecheck.
 
-## 5. Vision / screenshot test
+## 5. Verify reasoning control directly
+
+The easiest sanity check is behavioral:
+
+```bash
+pi --model vanillax-llama/qwen3.8-27b --thinking off \
+  "Reply with exactly: OFF_OK"
+
+pi --model vanillax-llama/qwen3.8-27b --thinking medium \
+  "What is 37*43? Give the answer and a one-line check."
+```
+
+If Pi says `off` but the backend still emits a reasoning block, inspect the
+request/backend logs before changing model flags. Do not work around it by
+making xhigh or low the server-wide default.
+
+## 6. Vision / screenshot test
 
 The production backend has the BF16 multimodal projector enabled. Attach a
-screenshot/image in Pi and ask a concrete question about it. Keep the image
-small enough that image tokens do not unnecessarily eat the 65K coding window.
+screenshot/image in Pi and ask a concrete question about it.
 
-If text works but images fail, check the backend first:
+If text works but images fail:
 
 ```bash
 kubectl -n llama-cpp logs deploy/llama-cpp-server --tail=200
@@ -197,43 +229,40 @@ kubectl -n llama-cpp exec deploy/llama-cpp-server -- nvidia-smi
 
 Do not point Pi at ComfyUI for vision; `qwen3.8-27b` itself is multimodal.
 
-## 6. Context discipline
+## 7. Context discipline
 
-The server has one 65,536-token slot. Pi may have unlimited local token
-**volume**, but a single request does not have unlimited context.
+The server has one 65,536-token slot. Local token **volume** is free, but a
+single request still has a finite context window.
 
 For coding agents:
 
 - prefer targeted `read`, `grep`, `find`, and `ls` over dumping whole trees;
 - `/compact` before the session becomes mostly historical tool output;
 - use `/new` between unrelated tasks;
-- avoid sending giant generated files, lockfiles, logs, or build artifacts;
-- one active llama.cpp sequence slot means parallel subagents contend for the
-  same GPU request slot rather than increasing throughput.
+- avoid giant generated files, lockfiles, logs, or build artifacts;
+- parallel subagents contend for the same single llama.cpp sequence slot.
 
 The current backend is optimized for strong single-user interactive latency,
 not high-concurrency serving.
 
-## 7. Recommended Pi tools/packages
+## 8. Your installed Pi packages
 
-Pi's built-ins (`read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`) are enough
-for most repository work. Add packages only where they solve a real workflow:
+Your existing package list can stay. Packages/extensions add prompt/tool
+surface area, so keep only things you actually use, but there is no backend
+migration requirement to remove them.
+
+Useful maintenance:
 
 ```bash
-# MCP bridge, if you actually need MCP servers from Pi
-pi install npm:pi-mcp-adapter
-
-# Then inspect/update packages normally
 pi list
 pi update --all
 ```
 
-Keep package count modest on the local model: every extension/tool definition
-adds prompt tokens. For Kubernetes/Talos work, native CLIs (`kubectl`,
-`talosctl`, `argocd`, `gh`, `jq`) through Pi's shell tool are usually more
-context-efficient than loading a giant MCP catalog.
+For Kubernetes/Talos work, native CLIs through Pi's bash tool (`kubectl`,
+`talosctl`, `argocd`, `gh`, `jq`) are usually more context-efficient than
+loading a huge MCP catalog.
 
-## 8. Global `~/.pi/agent/AGENTS.md` starter
+## 9. Optional global `~/.pi/agent/AGENTS.md`
 
 ```markdown
 # Environment
@@ -254,19 +283,18 @@ context-efficient than loading a giant MCP catalog.
 ```
 
 Pi discovers project context files, so this repo's existing instruction files
-remain useful; do not duplicate the whole repository policy into the global
-file.
+remain useful; do not duplicate the whole repository policy globally.
 
-## 9. Backend source of truth
+## 10. Backend source of truth
 
-Pi should not carry backend-specific tuning beyond capability metadata. The
-cluster owns runtime tuning in:
+Pi should not carry backend tuning beyond capability metadata. Runtime tuning
+lives in:
 
 - `my-apps/ai/llama-cpp/deployment.yaml`
 - `my-apps/ai/llama-cpp/README.md`
 - `docs/domains/ai-gpu/model-catalog.md`
 
-Current production shape:
+Current measured production shape:
 
 ```text
 Qwen3.8-27B UD-Q4_K_XL
@@ -281,6 +309,5 @@ BF16 vision projector
 220 W cap
 ```
 
-If the model ID stays `qwen3.8-27b`, Pi does not need a config change for an
-engine patch or quant replacement unless the capabilities/context/reasoning
-contract changes.
+If the model ID remains `qwen3.8-27b`, Pi does not need a config change for a
+runtime patch or quant replacement unless capabilities/context/reasoning change.

--- a/docs/domains/ai-gpu/pi-agent-local-dev.md
+++ b/docs/domains/ai-gpu/pi-agent-local-dev.md
@@ -8,7 +8,7 @@
 > This document is for **Pi.dev / Pi coding agent**, not Raspberry Pi.
 
 Pi is a workstation client. Nothing in `~/.pi/agent/` deploys to Kubernetes.
-The cluster owns model/runtime tuning; Pi only needs the provider/model metadata
+The cluster owns model/runtime tuning; Pi only needs provider/model metadata
 that describes the OpenAI-compatible API and Qwen3.8's reasoning controls.
 
 ## 1. Update Pi
@@ -19,7 +19,8 @@ pi update --all
 pi --version
 ```
 
-The configuration below targets Pi 0.84.x or newer.
+`pi update --self` updates Pi itself; `pi update --all` updates Pi and installed
+packages/extensions. The configuration below targets Pi 0.84.x or newer.
 
 ## 2. `~/.pi/agent/models.json`
 
@@ -43,7 +44,8 @@ Use a dedicated custom provider for the active llama.cpp endpoint:
           "reasoning_effort": {
             "$var": "thinking.effort",
             "omitWhenOff": true
-          }
+          },
+          "preserve_thinking": true
         }
       },
       "models": [
@@ -82,16 +84,17 @@ Qwen3.8's upstream template accepts only `low`, `medium`, and `xhigh` when
 thinking is enabled, and defaults to `xhigh` if effort is omitted. Turning
 thinking off is a separate `enable_thinking=false` control.
 
-Pi's generic OpenAI `reasoning_effort` mode omits the effort field when Pi is
-set to `off`. That is not enough here because llama.cpp has its own server-side
-reasoning default. The explicit mapping above makes every request unambiguous:
+Pi has a built-in `qwen-chat-template` mode for the on/off toggle, but the
+current implementation does not also place Pi's selected effort inside the
+Qwen chat-template kwargs. `chat-template` lets this provider send both pieces
+explicitly:
 
 | Pi level | `chat_template_kwargs` sent to llama.cpp |
 |---|---|
-| `off` | `enable_thinking: false` |
-| `low` | `enable_thinking: true`, `reasoning_effort: low` |
-| `medium` | `enable_thinking: true`, `reasoning_effort: medium` |
-| `xhigh` | `enable_thinking: true`, `reasoning_effort: xhigh` |
+| `off` | `enable_thinking: false`, `preserve_thinking: true` |
+| `low` | `enable_thinking: true`, `reasoning_effort: low`, `preserve_thinking: true` |
+| `medium` | `enable_thinking: true`, `reasoning_effort: medium`, `preserve_thinking: true` |
+| `xhigh` | `enable_thinking: true`, `reasoning_effort: xhigh`, `preserve_thinking: true` |
 
 `omitWhenOff` prevents Pi from sending the string `off` as a Qwen reasoning
 effort. Unsupported Pi levels are `null`, so the UI skips them rather than
@@ -102,7 +105,7 @@ Other compatibility choices:
 - `supportsDeveloperRole: false` keeps the agent context in an ordinary system
   message for the local OpenAI-compatible server.
 - `supportsReasoningEffort: false` prevents a duplicate top-level
-  `reasoning_effort`; the value belongs in `chat_template_kwargs` above.
+  `reasoning_effort`; effort is deliberately carried in `chat_template_kwargs`.
 - `input: ["text", "image"]` enables Pi screenshot/image input.
 - Sampling is not set in Pi. The validated production server owns temp/top-p/
   top-k/min-p/presence/repeat defaults.
@@ -111,17 +114,20 @@ Other compatibility choices:
 
 ## 3. Fix your existing `~/.pi/agent/settings.json`
 
-Your previous config used provider `vanillax-vllm` and the now-obsolete
-`modelThinkingLevels` key. Keep your installed packages exactly as they are;
-change only the model selection fields.
+Your current file already has the right packages and uses model-specific
+`medium` reasoning. Keep those. Rename the old provider and make the current
+backend the default.
 
-The important result should be:
+The relevant result should be:
 
 ```json
 {
   "defaultProvider": "vanillax-llama",
   "defaultModel": "qwen3.8-27b",
   "defaultThinkingLevel": "medium",
+  "modelThinkingLevels": {
+    "vanillax-llama/qwen3.8-27b": "medium"
+  },
   "enabledModels": [
     "vanillax-llama/qwen3.8-27b",
     "vanillax-litellm/kimi-k3"
@@ -129,8 +135,9 @@ The important result should be:
 }
 ```
 
-Do **not** copy that small object over your whole file — your `packages`, theme,
-and other settings should remain. To update the existing JSON safely with `jq`:
+Do **not** overwrite your whole file with that small example; preserve your
+`packages`, theme, changelog state, and other settings. Update the existing JSON
+safely with `jq`:
 
 ```bash
 cp ~/.pi/agent/settings.json ~/.pi/agent/settings.json.bak
@@ -139,13 +146,17 @@ jq '
   .defaultProvider = "vanillax-llama"
   | .defaultModel = "qwen3.8-27b"
   | .defaultThinkingLevel = "medium"
-  | del(.modelThinkingLevels)
+  | .modelThinkingLevels = ((.modelThinkingLevels // {})
+      | with_entries(
+          if .key == "vanillax-vllm/qwen3.8-27b"
+          then .key = "vanillax-llama/qwen3.8-27b"
+          else . end))
+  | .modelThinkingLevels["vanillax-llama/qwen3.8-27b"] = "medium"
   | .enabledModels = ((.enabledModels // [])
       | map(if . == "vanillax-vllm/qwen3.8-27b"
             then "vanillax-llama/qwen3.8-27b"
             else . end)
-      | if index("vanillax-llama/qwen3.8-27b") then .
-        else ["vanillax-llama/qwen3.8-27b"] + . end)
+      | unique)
 ' ~/.pi/agent/settings.json > ~/.pi/agent/settings.json.new \
   && mv ~/.pi/agent/settings.json.new ~/.pi/agent/settings.json
 ```
@@ -153,12 +164,13 @@ jq '
 Then verify:
 
 ```bash
-jq '{defaultProvider,defaultModel,defaultThinkingLevel,enabledModels,packages}' \
+jq '{defaultProvider,defaultModel,defaultThinkingLevel,modelThinkingLevels,enabledModels,packages}' \
   ~/.pi/agent/settings.json
 ```
 
-Pi 0.84.x uses `defaultThinkingLevel`; unknown legacy keys are ignored, so
-removing `modelThinkingLevels` avoids a config value that looks active but is not.
+Current Pi supports both `defaultThinkingLevel` and per-model
+`modelThinkingLevels`; keeping the per-model value means this Qwen model starts
+at medium even if another provider later uses a different global default.
 
 ## 4. Start and verify
 
@@ -187,8 +199,8 @@ pi --list-models qwen3.8-27b
 ```
 
 Inside Pi, `/model` should show `vanillax-llama/qwen3.8-27b`, and the statusline
-should show `medium`. Use Shift+Tab (or your configured thinking control) to
-cycle only the supported levels.
+should show `medium`. `/model` + Ctrl+S and `/thinking` + Ctrl+S are also valid
+ways to persist the startup selections.
 
 First tool test from a repository root:
 
@@ -201,8 +213,6 @@ branch and require Pi to run the relevant tests/typecheck.
 
 ## 5. Verify reasoning control directly
 
-The easiest sanity check is behavioral:
-
 ```bash
 pi --model vanillax-llama/qwen3.8-27b --thinking off \
   "Reply with exactly: OFF_OK"
@@ -212,10 +222,33 @@ pi --model vanillax-llama/qwen3.8-27b --thinking medium \
 ```
 
 If Pi says `off` but the backend still emits a reasoning block, inspect the
-request/backend logs before changing model flags. Do not work around it by
-making xhigh or low the server-wide default.
+request/backend logs before changing model flags.
 
-## 6. Vision / screenshot test
+## 6. Current date/time in Pi
+
+Pi's model is not a clock. Do not trust Qwen to infer today's date from model
+training, file timestamps, or session text.
+
+For any current-date/time question, tell Pi to use its built-in bash tool:
+
+```text
+Before answering anything date/time-sensitive, run `date` (and `date -u` when
+UTC matters). Never infer the current date from model knowledge.
+```
+
+Put that rule in `~/.pi/agent/AGENTS.md` if you want it globally. It adds almost
+no context and avoids injecting a timestamp into every prompt. Your shell has
+the workstation's actual timezone, so `date` is the source of truth for Pi.
+
+Quick test:
+
+```text
+What is today's date? Verify with the shell before answering.
+```
+
+You should see a bash call to `date` rather than a guessed date.
+
+## 7. Vision / screenshot test
 
 The production backend has the BF16 multimodal projector enabled. Attach a
 screenshot/image in Pi and ask a concrete question about it.
@@ -229,7 +262,7 @@ kubectl -n llama-cpp exec deploy/llama-cpp-server -- nvidia-smi
 
 Do not point Pi at ComfyUI for vision; `qwen3.8-27b` itself is multimodal.
 
-## 7. Context discipline
+## 8. Context discipline
 
 The server has one 65,536-token slot. Local token **volume** is free, but a
 single request still has a finite context window.
@@ -245,7 +278,7 @@ For coding agents:
 The current backend is optimized for strong single-user interactive latency,
 not high-concurrency serving.
 
-## 8. Your installed Pi packages
+## 9. Your installed Pi packages
 
 Your existing package list can stay. Packages/extensions add prompt/tool
 surface area, so keep only things you actually use, but there is no backend
@@ -262,7 +295,7 @@ For Kubernetes/Talos work, native CLIs through Pi's bash tool (`kubectl`,
 `talosctl`, `argocd`, `gh`, `jq`) are usually more context-efficient than
 loading a huge MCP catalog.
 
-## 9. Optional global `~/.pi/agent/AGENTS.md`
+## 10. Optional global `~/.pi/agent/AGENTS.md`
 
 ```markdown
 # Environment
@@ -270,6 +303,7 @@ loading a huge MCP catalog.
 - Free local token volume is not infinite context. Keep reads targeted and
   compact long sessions.
 - Prefer actual CLI/tool evidence over guessing.
+- For current date/time, run `date` (and `date -u` for UTC); never guess it.
 
 # Kubernetes / homelab
 - GitOps only for changes: edit Git and let ArgoCD reconcile.
@@ -285,7 +319,7 @@ loading a huge MCP catalog.
 Pi discovers project context files, so this repo's existing instruction files
 remain useful; do not duplicate the whole repository policy globally.
 
-## 10. Backend source of truth
+## 11. Backend source of truth
 
 Pi should not carry backend tuning beyond capability metadata. Runtime tuning
 lives in:

--- a/docs/domains/ai-gpu/pi-agent-local-dev.md
+++ b/docs/domains/ai-gpu/pi-agent-local-dev.md
@@ -1,107 +1,63 @@
-# Pi Agent — Claude-Code-Grade Local Dev on the Single-3090 Backend
+# Pi.dev Agent — local coding against Qwen3.8-27B
 
-> **Current state:** `qwen3.8-27b` runs on the sole RTX 3090 via vLLM with
-> AutoRound W4A16, fp8 KV at 65,536 tokens, native vision, and MTP-2. See
-> [`model-catalog.md`](model-catalog.md) for the backend source of truth.
-
-> Goal: fully local coding agents that match the Claude Code *capability set*
-> — tools, repo context, skills, research — without using Claude Code. The
-> toolchain is **[pi](https://github.com/badlogic/pi-mono) (primary) +
-> [OpenCode](https://opencode.ai) (companion, §7)**, both backed by the
-> cluster's tuned vLLM endpoint (`qwen3.8-27b`, one 3090, 64K context,
-> vision, tool calling). Free unlimited *volume*; keep paid frontier
-> **APIs** (Anthropic/OpenAI/Google keys in the agents' provider lists) for
-> the hardest 10%.
+> **Current state (2026-09-03):** the sole RTX 3090 serves `qwen3.8-27b`
+> through stock llama.cpp `b10752`, Q4_K_XL, q8_0 KV, MTP-2, native vision,
+> and a 65,536-token window. The canonical LAN endpoint is
+> `https://llama.vanillax.me/v1`.
 >
-> Stack targets: Kubernetes/Talos GitOps (this repo), JavaScript/Node/
-> TypeScript, Python, React Native, Temporal.io.
->
-> Last updated: 2026-08-30 (Qwen3.8 topology and explicit Pi thinking levels).
+> This document is for **Pi.dev / Pi coding agent**, not Raspberry Pi.
 
-## Architecture
+Pi is a workstation client. Nothing in `~/.pi/agent/` deploys to Kubernetes.
+The cluster owns the model/runtime; Pi only needs an OpenAI-compatible provider
+entry and the model metadata that lets it expose the right reasoning levels,
+context window, image input, and token accounting.
 
-<div class="dgm">
-  <div class="dgm-head">
-    <span class="dgm-head__title">One request, workstation to silicon</span>
-    <span class="dgm-head__sub">Every pi turn walks this path. Nothing here is a separate hop you configure — the client picks a base URL and the rest is already deployed.</span>
-  </div>
-  <div class="dgm-flow">
-    <div class="dgm-node dgm-node--client">
-      <span class="dgm-node__badge">client</span>
-      <span class="dgm-node__title">pi — workstation TUI</span>
-      <span class="dgm-node__sub">Agent config lives in <code>~/.pi/agent/</code></span>
-      <span class="dgm-node__meta">Nothing on this row deploys to the cluster</span>
-    </div>
-    <div class="dgm-link dgm-link--client" aria-hidden="true"></div>
-    <div class="dgm-node dgm-node--edge">
-      <span class="dgm-node__badge">gateway</span>
-      <span class="dgm-node__title"><code>https://vllm.vanillax.me/v1</code></span>
-      <span class="dgm-node__sub">Internal Gateway API route, LAN only</span>
-      <span class="dgm-node__meta">HTTPRoute <code>timeouts: 30m</code> — long generations survive</span>
-    </div>
-    <div class="dgm-link dgm-link--edge dgm-link--d1" aria-hidden="true"></div>
-    <div class="dgm-node dgm-node--svc">
-      <span class="dgm-node__badge">inference</span>
-      <span class="dgm-node__title">vLLM · <code>qwen3.8-27b</code> · TP=1</span>
-      <span class="dgm-node__sub">64K context · vision · <code>qwen3_coder</code> tool parser</span>
-      <span class="dgm-node__meta">One model on the sole GPU</span>
-    </div>
-    <div class="dgm-row">
-      <div class="dgm-node dgm-node--gpu dgm-node--pulse">
-        <span class="dgm-node__badge">gpu 0</span>
-        <span class="dgm-node__title">RTX 3090</span>
-        <span class="dgm-node__meta">200W cap</span>
-      </div>
-    </div>
-  </div>
-  <p class="dgm-foot">The card is exposed by the NVIDIA infrastructure DaemonSet. Whole-card and mutually exclusive — vLLM holding it means llama-cpp and ComfyUI are scaled to zero.</p>
-</div>
+## 1. Update Pi itself
 
-Everything agent-side lives on the workstation (`~/.pi/agent/`); nothing here
-deploys to the cluster. The backend is already agent-tuned **server-side** —
-don't fight these from the client:
+```bash
+# Pi CLI only
+pi update --self
 
-| Server flag (see `my-apps/ai/vllm/deployment.yaml`) | Why pi cares |
-|---|---|
-| `--served-model-name qwen3.8-27b` | the `id` pi must send |
-| `--max-model-len 65536` | matches `contextWindow` below |
-| `--max-num-seqs 3` | three sequence slots share the card; long requests can still queue |
-| `--enable-auto-tool-choice` + `--tool-call-parser qwen3_coder` | pi's tool calls parse natively |
-| `--reasoning-parser qwen3` + thinking off by default | pi gets clean content; thinking is opt-in per request |
-| `--override-generation-config` (temp 0.7 / top_p 0.8 / top_k 20 / presence 1.5) | correct Qwen agent sampling — leave pi's sampling unset |
-| `--limit-mm-per-prompt {"image": 1, "video": 0}` | one image per request; compact before sending a different screenshot |
-| HTTPRoute `timeouts: 30m` | long generations won't be cut by the gateway |
+# Or Pi + installed packages/extensions
+pi update --all
+```
 
-## 1. Point pi at the cluster — `~/.pi/agent/models.json`
+Useful checks:
+
+```bash
+pi --version
+pi list
+```
+
+Pi's current package manager also supports `pi update --models` for refreshed
+remote catalogs, but the homelab model below is defined locally in
+`models.json`, so that command is not required for this backend.
+
+## 2. `~/.pi/agent/models.json`
+
+Use a dedicated custom provider for the homelab llama.cpp endpoint:
 
 ```json
 {
   "providers": {
-    "vanillax-vllm": {
-      "baseUrl": "https://vllm.vanillax.me/v1",
+    "vanillax-llama": {
+      "baseUrl": "https://llama.vanillax.me/v1",
       "api": "openai-completions",
-      "apiKey": "none",
+      "apiKey": "local-no-key-required",
       "compat": {
         "supportsDeveloperRole": false,
-        "supportsReasoningEffort": false,
+        "supportsReasoningEffort": true,
         "supportsUsageInStreaming": true,
         "maxTokensField": "max_tokens",
-        "thinkingFormat": "chat-template",
-        "chatTemplateKwargs": {
-          "enable_thinking": { "$var": "thinking.enabled" },
-          "reasoning_effort": {
-            "$var": "thinking.effort",
-            "omitWhenOff": true
-          }
-        }
+        "thinkingFormat": "reasoning_effort"
       },
       "models": [
         {
           "id": "qwen3.8-27b",
-          "name": "Qwen3.8 27B (vLLM, 1x3090, 64K)",
+          "name": "Qwen3.8 27B (llama.cpp, 1x3090, 65K)",
           "reasoning": true,
           "thinkingLevelMap": {
-            "off": "off",
+            "off": "none",
             "minimal": null,
             "low": "low",
             "medium": "medium",
@@ -125,704 +81,206 @@ don't fight these from the client:
 }
 ```
 
-Set the per-model startup default in `~/.pi/agent/settings.json`:
+Why these compatibility settings:
+
+- `openai-completions` matches llama.cpp's `/v1/chat/completions` API.
+- `supportsDeveloperRole: false` keeps Pi on a single normal `system` message;
+  Qwen3.8's template is stricter than OpenAI's role model and this avoids
+  duplicate/developer-system edge cases.
+- llama.cpp now accepts top-level OpenAI-style `reasoning_effort`, so the old
+  vLLM-era `chat_template_kwargs` workaround is intentionally gone.
+- Qwen3.8 accepts `low`, `medium`, and `xhigh`; `none` disables thinking.
+  Unsupported Pi levels are explicitly `null`, so Pi hides/clamps them instead
+  of inventing values the model template does not understand.
+- `input: ["text", "image"]` enables Pi screenshot/image input.
+- sampling is deliberately not set in Pi. The production server owns the
+  validated Qwen sampling defaults: temp 0.7, top-p 0.8, top-k 20, min-p 0,
+  presence penalty 1.5, repeat penalty 1.0.
+
+`models.json` reloads whenever `/model` is opened, so a Pi restart is usually
+not needed after editing it.
+
+## 3. `~/.pi/agent/settings.json`
+
+Make the homelab model the default and use **medium** reasoning for normal coding:
 
 ```json
 {
+  "defaultProvider": "vanillax-llama",
+  "defaultModel": "qwen3.8-27b",
+  "defaultThinkingLevel": "medium",
   "modelThinkingLevels": {
-    "vanillax-vllm/qwen3.8-27b": "medium"
+    "vanillax-llama/qwen3.8-27b": "medium"
   }
 }
 ```
 
-Qwen3.8's template defaults an omitted `reasoning_effort` to `xhigh`. The old
-`qwen-chat-template` shortcut sent only the on/off switch, so enabling thinking
-could silently select the most aggressive mode and consume most of a turn's
-context. This is a client/template mismatch, not evidence of a vLLM backend
-bug. The explicit `chat-template` mapping sends exactly this per request:
+You can save the same settings interactively:
 
-| Command | Template kwargs | Use |
+1. `/model` → choose `vanillax-llama/qwen3.8-27b` → **Ctrl+S**.
+2. `/thinking` → choose `medium` → **Ctrl+S**.
+
+Recommended levels:
+
+| Pi level | Qwen request | Use |
 |---|---|---|
-| `pi --thinking off` | `enable_thinking: false` | trivial edits, lookups, and formatting |
-| `pi --thinking low` | `enable_thinking: true`, `reasoning_effort: low` | short tasks that need a little reasoning |
-| `pi --thinking medium` | `enable_thinking: true`, `reasoning_effort: medium` | normal coding, debugging, and agent work |
-| `pi --thinking xhigh` | `enable_thinking: true`, `reasoning_effort: xhigh` | genuinely hard reasoning only |
+| `off` | `reasoning_effort: none` | trivial edits, formatting, lookups |
+| `low` | `reasoning_effort: low` | short code changes |
+| `medium` | `reasoning_effort: medium` | default coding/debugging/agent work |
+| `xhigh` | `reasoning_effort: xhigh` | hard reasoning only |
 
-`off: "off"` declares Pi's off level, but `omitWhenOff` prevents that string
-from being sent as a Qwen effort. The null entries hide levels that the
-[Qwen3.8 template does not accept](https://huggingface.co/Qwen/Qwen3.8-27B/blob/main/chat_template.jinja).
-Keep vLLM's `--default-chat-template-kwargs '{"enable_thinking": false}'`:
-the backend remains non-thinking by default, while Pi opts in explicitly for
-each enabled request. `models.json` hot-reloads when `/model` is opened.
+Do not use `xhigh` as the everyday default. It consumes much more generation
+budget and is exactly the overthinking behavior this setup is trying to avoid.
 
-- `supportsReasoningEffort: false` prevents a duplicate top-level
-  `reasoning_effort`; Qwen receives it inside `chat_template_kwargs`.
-- `supportsUsageInStreaming: true` preserves vLLM's streamed usage counters.
-- `input: ["text","image"]` enables pi's screenshot flow (the 27B is
-  multimodal).
-- Select with `/model` or `pi --model qwen3.8-27b`. Verify tools work:
-  `pi "read package.json and summarize the scripts"` — you should see a
-  `read` tool call, not a hallucinated answer.
+## 4. Start and verify
 
-## 2. Claude Code → pi capability map
+Normal launch:
 
-| Claude Code | pi equivalent | Notes |
-|---|---|---|
-| `CLAUDE.md` | `AGENTS.md` (global `~/.pi/agent/`, plus per-repo, concatenated up the dir tree) — and pi ≥0.80 **discovers `CLAUDE.md` natively** (see `--no-context-files` in `pi --help`) | no symlink needed: this repo's nested `CLAUDE.md`s load as-is |
-| Skills | Skills — **same Agent Skills standard** | `~/.pi/agent/skills/` or `.pi/skills/`; invoke `/skill:name` |
-| Slash commands | Prompt templates in `~/.pi/agent/prompts/` / `.pi/prompts/` | plain markdown, `/name` expands |
-| MCP servers | **`pi install npm:pi-mcp-adapter`** (not in core — see §4a) | token-efficient proxy: ONE `mcp` tool (~200 tokens) instead of hundreds of tool defs |
-| Subagents / Task | **`pi-subagents` package** (not in core) | parallel isolated agents — but see the `max-num-seqs 3` warning in §4a |
-| Plan mode | **`pi-plan` package** — read-only planning + approval-based execution | the Claude Code plan-mode equivalent |
-| Session resume / compact | `pi -c`, `pi -r`, `/compact` — plus a **session TREE**: `/fork`, `/tree`, branch and switch | sessions are JSONL trees, not linear — better than Claude Code for exploring alternatives |
-| Permission modes | ⚠️ **none by default — "YOLO mode"** | see the safety note below; `trust.json` + `--tools`/`--exclude-tools` + opt-in permission-gating extensions |
-| Hooks | 25 in-process TypeScript extension events (tool streaming, bash spawn interception, dynamic system prompt, context access) | richer than Claude Code's 14 shell hooks |
-| Custom tools/hooks | TypeScript extensions in `~/.pi/agent/extensions/` | can replace built-ins, add checkpointing; `--mode rpc` drives pi from external scripts |
+```bash
+pi
+```
 
-The design difference: Claude Code ships everything integrated; pi keeps the
-**core minimal** and everything else — MCP, subagents, memory, planning — is
-opt-in via the [pi.dev/packages](https://pi.dev/packages) ecosystem
-(`pi install npm:<pkg>` / `pi install git:<repo>`; `pi list` / `pi update
---all` to manage). For a batteries-included start there's **LazyPi** — but
-read the local-model verdict in §4a before running it. On this stack the
-shell still covers most needs — every system we run (Kubernetes, ArgoCD,
-Temporal, git, pnpm, uv) has a first-class CLI — so treat packages as
-additive, not required.
+Explicit launch while testing the migration:
 
-## 3. Global `~/.pi/agent/AGENTS.md` starter
+```bash
+pi --provider vanillax-llama --model qwen3.8-27b --thinking medium
+```
+
+Or select the provider-qualified model in one argument:
+
+```bash
+pi --model vanillax-llama/qwen3.8-27b --thinking medium
+```
+
+List what Pi sees:
+
+```bash
+pi --list-models qwen3.8-27b
+```
+
+Inside a Pi `bash` tool invocation, Pi exposes the selected model and effective
+reasoning level:
+
+```bash
+printf '%s/%s\n' "$PI_PROVIDER" "$PI_MODEL"
+printf 'reasoning=%s\n' "$PI_REASONING_LEVEL"
+```
+
+Expected:
+
+```text
+vanillax-llama/qwen3.8-27b
+reasoning=medium
+```
+
+First tool test from the repository root:
+
+```text
+Read package.json and summarize the scripts. Do not guess; use the read tool.
+```
+
+You should see a real tool call. Then test an edit in a disposable branch and
+make Pi run the relevant tests/typecheck rather than merely describing them.
+
+## 5. Vision / screenshot test
+
+The production backend has the BF16 multimodal projector enabled. Attach a
+screenshot/image in Pi and ask a concrete question about it. Keep the image
+small enough that image tokens do not unnecessarily eat the 65K coding window.
+
+If text works but images fail, check the backend first:
+
+```bash
+kubectl -n llama-cpp logs deploy/llama-cpp-server --tail=200
+kubectl -n llama-cpp exec deploy/llama-cpp-server -- nvidia-smi
+```
+
+Do not point Pi at ComfyUI for vision; `qwen3.8-27b` itself is multimodal.
+
+## 6. Context discipline
+
+The server has one 65,536-token slot. Pi may have unlimited local token
+**volume**, but a single request does not have unlimited context.
+
+For coding agents:
+
+- prefer targeted `read`, `grep`, `find`, and `ls` over dumping whole trees;
+- `/compact` before the session becomes mostly historical tool output;
+- use `/new` between unrelated tasks;
+- avoid sending giant generated files, lockfiles, logs, or build artifacts;
+- one active llama.cpp sequence slot means parallel subagents contend for the
+  same GPU request slot rather than increasing throughput.
+
+The current backend is optimized for strong single-user interactive latency,
+not high-concurrency serving.
+
+## 7. Recommended Pi tools/packages
+
+Pi's built-ins (`read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`) are enough
+for most repository work. Add packages only where they solve a real workflow:
+
+```bash
+# MCP bridge, if you actually need MCP servers from Pi
+pi install npm:pi-mcp-adapter
+
+# Then inspect/update packages normally
+pi list
+pi update --all
+```
+
+Keep package count modest on the local model: every extension/tool definition
+adds prompt tokens. For Kubernetes/Talos work, native CLIs (`kubectl`,
+`talosctl`, `argocd`, `gh`, `jq`) through Pi's shell tool are usually more
+context-efficient than loading a giant MCP catalog.
+
+## 8. Global `~/.pi/agent/AGENTS.md` starter
 
 ```markdown
 # Environment
-- Local model (qwen3.8-27b on homelab vLLM). Free tokens, 64K window, but
-  PREFILL IS EXPENSIVE: keep context lean, prefer targeted reads over
-  dumping whole trees. Compact or /new between unrelated tasks.
-- You have bash. Prefer CLIs over guessing: kubectl, talosctl, argocd,
-  temporal, gh, jq, curl.
+- Primary local model: qwen3.8-27b on homelab llama.cpp, one RTX 3090, 65K.
+- Free local token volume is not infinite context. Keep reads targeted and
+  compact long sessions.
+- Prefer actual CLI/tool evidence over guessing.
 
-# Kubernetes / homelab (talos-argocd-proxmox repo)
-- GitOps ONLY: never kubectl apply/edit/delete to fix state — change git,
-  let ArgoCD sync. kubectl is for READING (get/describe/logs/events).
-- Directory = ArgoCD Application. Every YAML must be listed in its
-  kustomization.yaml. Follow the repo's CLAUDE.md files — they are law.
-- Secrets: 1Password + ExternalSecret. Never write a secret into git.
+# Kubernetes / homelab
+- GitOps only for changes: edit Git and let ArgoCD reconcile.
+- kubectl is for inspection unless explicitly told otherwise.
+- Follow repository CLAUDE.md / AGENTS.md instructions.
+- Secrets go through 1Password + ExternalSecret; never commit them.
 
-# TypeScript / Node
-- pnpm. Strict TS. No `any` without a comment. Vitest for tests.
-- Match existing lint/format config; run `pnpm tsc --noEmit && pnpm lint`
-  before declaring done.
-
-# Python
-- uv for envs/deps. ruff for lint+format. pytest. Type hints on public
-  functions.
-
-# React Native
-- Expo unless the repo says bare. Never edit ios/android generated dirs
-  by hand in managed projects. After native dep changes: rebuild dev
-  client, not just metro reload.
-
-# Temporal
-- Workflow code MUST be deterministic: no Date.now/Math.random/direct IO
-  in workflows — use activities, side effects, or workflow APIs.
-- Versioning: use patching/versioned workflows for changes to in-flight
-  workflow definitions. Test with @temporalio/testing time-skipping.
-
-# Verification discipline
-- Done = ran it. Tests, typecheck, or a real invocation — paste the output.
+# Verification
+- Done means verified: run tests, typecheck/lint, or the real command and
+  report the result.
 ```
 
-Per-repo `AGENTS.md` adds specifics (commands, layout). For *this* repo the
-nested `CLAUDE.md` files already contain the right content — reuse them.
+Pi discovers project context files, so this repo's existing instruction files
+remain useful; do not duplicate the whole repository policy into the global
+file.
 
-## 4. Skills for the stack
+## 9. Backend source of truth
 
-Skills are directories with a `SKILL.md` (Agent Skills standard — same format
-Claude Code uses, so they're portable both ways). Suggested starter set under
-`~/.pi/agent/skills/`:
+Pi should not carry backend-specific tuning beyond capability metadata. The
+cluster owns runtime tuning in:
 
-### `k8s-debug/SKILL.md`
+- `my-apps/ai/llama-cpp/deployment.yaml`
+- `my-apps/ai/llama-cpp/README.md`
+- `docs/domains/ai-gpu/model-catalog.md`
 
-```markdown
----
-name: k8s-debug
-description: Read-only triage of the homelab Kubernetes cluster (Talos +
-  ArgoCD). Use when asked to investigate pod failures, sync errors, PVC
-  issues, or GPU workload state.
----
+Current production shape:
 
-READ-ONLY. Diagnose with kubectl get/describe/logs/events and argocd CLI;
-propose fixes as git diffs against talos-argocd-proxmox, never kubectl
-apply/edit.
-
-Triage order:
-1. `kubectl get applications -n argocd | grep -v 'Synced.*Healthy'`
-2. `kubectl -n <ns> get pods,pvc,events --sort-by=.lastTimestamp | tail -30`
-3. `kubectl -n <ns> logs <pod> --previous --tail=100` for crash loops
-4. GPU apps (vllm/llama-cpp/comfyui) are mutually-exclusive whole-card
-   scale-swaps — "Pending + 0/2 nodes available (gpu)" usually means another
-   GPU app holds the cards, NOT a broken scheduler.
-5. Backups: `kubectl -n <ns> get snapshotpolicy,snapshotschedule,restore,snapshot`
+```text
+Qwen3.8-27B UD-Q4_K_XL
+stock llama.cpp b10752
+1x RTX 3090
+65,536 context
+q8_0 target + draft KV
+MTP Q4_0, n-max=2
+BF16 vision projector
+~42-43 tok/s observed interactive decode
+~22.7 GiB VRAM under generation
+220 W cap
 ```
 
-### `research/SKILL.md`
-
-```markdown
----
-name: research
-description: Web research via the homelab's local search stack (SearXNG +
-  Perplexica). Use for library docs, error messages, release notes, or any
-  "look this up" request.
----
-
-Two tiers, both local/private:
-
-1. Quick lookups — SearXNG JSON:
-   `curl -s 'https://search.vanillax.me/search?q=QUERY&format=json' | jq '.results[:5] | .[] | {title, url, content}'`
-   (needs `format: json` enabled in SearXNG settings — check once)
-2. Synthesized answers with citations — Perplexica (vane v1.12) API.
-   Schema pinned against the deployed version (verified 2026-07-05): the old
-   `focusMode` field is GONE; `sources` is an array and `chatModel`/
-   `embeddingModel` are required `{providerId, key}` objects. Use
-   `"stream": true` — non-stream buffers the whole agent run (can exceed
-   120s); streaming returns `sources` events in seconds:
-   `curl -sN -m 180 https://perplexica.vanillax.me/api/search -H 'Content-Type: application/json' -d '{"query":"QUERY","sources":["web"],"optimizationMode":"speed","stream":true,"chatModel":{"providerId":"llama-cpp-cluster","key":"qwen3.8-27b"},"embeddingModel":{"providerId":"transformers-default","key":"Xenova/all-MiniLM-L6-v2"}}'`
-   (output is ND-JSON events: `sources` then `response` chunks; if models
-   change, re-list with `curl -s https://perplexica.vanillax.me/api/providers`.
-   The chat model is the SAME vLLM instance pi runs on — each call takes one
-   of the two `--max-num-seqs` slots.)
-
-Fetch promising URLs with `curl -sL` and read the content — don't answer
-from snippets alone. Cite URLs in the final answer.
-```
-
-### `temporal-dev/SKILL.md`
-
-```markdown
----
-name: temporal-dev
-description: Inspect and debug Temporal workflows on the homelab cluster
-  (worker versioning, stuck workflows, task queue backlogs).
----
-
-UI: https://temporal.vanillax.me
-CLI: port-forward the frontend first (verify svc name in the temporal ns):
-  `kubectl -n temporal port-forward svc/temporal-frontend 7233:7233 &`
-  `temporal --address localhost:7233 workflow list --query 'ExecutionStatus="Running"'`
-Useful: `temporal workflow show -w <id>` (event history — find the stuck
-activity), `temporal task-queue describe -t <queue>` (are workers polling?).
-KEDA scales workers off task-queue depth — a backlog with 0 workers means
-check the ScaledObject before blaming the worker image.
-```
-
-JS/TS, Python, and React Native generally don't need skills — they need the
-conventions in `AGENTS.md` plus pi's built-in `read/edit/bash/grep`: the model
-runs `pnpm test`, `tsc`, `ruff`, `pytest`, `npx expo` like any other command.
-Add a skill only when a workflow has non-obvious steps worth encoding (e.g.
-a `release/` skill for your publishing checklist).
-
-## 4a. Extensions: MCP, subagents, plan mode
-
-Core pi has none of these; the package ecosystem does. What's worth installing
-here, and why the choices interact with the *local* backend:
-
-```bash
-pi install npm:pi-mcp-adapter   # MCP servers (restart pi after)
-pi install npm:pi-plan          # read-only plan mode + approve-to-execute
-# npm:pi-subagents — NOT installed (removed 2026-07-06: zero usage in session
-# history, and wide fan-outs fight --max-num-seqs 3 anyway; reinstall if a
-# real parallel-isolation need appears — read the warning below first)
-```
-
-**MCP via `pi-mcp-adapter`** — config lives in `~/.pi/agent/mcp.json` (global)
-or `.mcp.json` / `.pi/mcp.json` (per-project), Claude-compatible format:
-
-```json
-{
-  "mcpServers": {
-    "chrome-devtools": {
-      "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp@latest"]
-    },
-    "some-http-server": {
-      "url": "http://localhost:3845/mcp",
-      "headers": { "Authorization": "Bearer ${API_KEY}" }
-    }
-  }
-}
-```
-
-Manage with `/mcp` (interactive panel), `/mcp setup`, `/mcp reconnect <server>`.
-
-Why this adapter is the right one for a **local** model specifically: it
-exposes **one `mcp` proxy tool (~200 tokens) instead of hundreds of tool
-definitions**, with on-demand tool search and lazy server lifecycle (connect
-on first call, disconnect after idle). On the 27B, prefill is the tax (gotcha
-#1) and every tool definition is resent each turn — a fat MCP toolset would
-bloat every single request. Keep proxy mode as the default; promote only your
-hottest 2–3 tools to `"directTools"` if the model fumbles the proxy calls.
-
-Useful servers for this stack: `chrome-devtools-mcp` (React/React-Native web
-debugging — the one capability plain bash can't fake), a Kubernetes MCP server
-if you want structured cluster reads instead of the `k8s-debug` skill's
-kubectl calls, GitHub MCP for PR/issue flows. Skip MCP wrappers for things
-with good CLIs (temporal, argocd) — the CLI costs zero context.
-
-**Subagents (`pi-subagents`) — reinstalled 2026-07-24, for one specific
-reason: `kimi-consult` (§9).** It was removed 2026-07-06 (zero usage, and
-every extension is failure surface — see the scripted-mode section) with the
-warning that parallel subagents each open their own request against vLLM,
-where `--max-num-seqs 3` means a fan-out of 4+ queues. That warning still
-holds for **general-purpose subagents against the local backend** — but
-`kimi-consult` doesn't hit vLLM at all; it's a single subagent pinned to a
-*different* model/provider (Kimi K3 via LiteLLM → Moonshot's API), so it
-doesn't touch the `max-num-seqs` budget. Don't reintroduce wide parallel
-fan-outs of `worker`/`scout`/etc. against the local model without reading the
-warning above first; `kimi-consult` alone doesn't reopen that problem.
-
-**Plan mode (`pi-plan`)** — read-only propose→approve→execute. Recommended
-default for anything touching this repo, since a wrong `kubectl` habit here
-becomes a cluster incident; it pairs with the `k8s-debug` skill's
-"diagnose read-only, fix via git" rule.
-
-### ⚠️ Scripted mode (`pi -p`) reliability — learned the hard way (2026-07-06)
-
-Driving pi non-interactively (`pi -p`, cron, CI, benchmark harnesses) hit an
-**intermittent pre-request hang**: the node event loop parks before the first
-HTTP request ever leaves the machine (server provably idle, ~0 CPU), and pi
-has **no client-side request timeout**, so it hangs until the HTTPRoute's 30m
-cut. Reproduced 5× in one session; forensics stack-sampled to the event loop.
-What we know:
-
-- **`@narumitw/pi-goal` was the main aggravator** — it reacts to task-shaped
-  prompts ("fix X", "implement Y") pre-request; trivial prompts ("run ls")
-  always passed. Removing it (`pi remove npm:@narumitw/pi-goal`) fixed the
-  streak instantly — but ONE recurrence without it says it's a startup race
-  pi-goal aggravates, not solely causes.
-- **`--no-extensions` does NOT unload settings.json packages** — it only
-  disables extension *discovery*. Bisecting with `-ne` proves nothing about
-  installed packages; use `pi remove` (or `pi config`) to actually exclude one.
-- Interactive TUI use is unaffected — this is a scripted-mode problem.
-
-Operational rules for scripted pi:
-1. Put the instructions in a `TASK.md` and prompt just
-   `"Read TASK.md in this directory and do exactly what it says."` — short
-   argv prompts, instructions in files.
-2. Wrap every run in a watchdog: if no session-JSONL event appears within
-   ~2 min, kill and relaunch (a retry almost always lands).
-3. Constrain debugging turns: "no prose — write a repro, run it, minimal fix,
-   verify" (see gotcha #11 for why).
-
-### LazyPi — use the picker, not "install all" (local-model verdict)
-
-[LazyPi](https://lazypi.org/) (`npx @robzolkos/lazypi`) is a curated
-one-command bundle: 60+ community skills, 76 themes, MCP support, subagents,
-persistent memory, planning mode, diff review, a Claude Code CLI provider.
-Validated facts that matter for THIS setup:
-
-- **It coexists with our custom provider.** LazyPi installs packages into
-  `~/.pi/agent/` and never touches `models.json` — the homelab vLLM wiring
-  is untouched. Installs are idempotent (re-runs skip installed packages),
-  removal is per-package (`npx @robzolkos/lazypi remove <id>`), and the
-  installed pieces work independently of LazyPi afterward.
-- **The 60-skill firehose is a prefill tax on a local model.** pi loads
-  skills by progressive disclosure — full instructions load on demand, but
-  **every installed skill's name+description sits in the system prompt of
-  every request**. 60+ descriptions ≈ a couple thousand tokens re-prefilled
-  each turn on a backend where prefill is already the bottleneck (gotcha
-  #1), and it erodes pi's core advantage (a ~200-token system prompt).
-  Community reception says the same: the author's own retro
-  (["LazyPi made people mad"](https://www.zolkos.com/2026/04/21/lazypi-made-people-mad))
-  notes real praise as an onboarding ramp, alongside criticism that many
-  extensions "eat up a lot of system-prompt context" and most users
-  eventually pare down.
-- **A 27B is also more distractible than a frontier model.** More skill
-  descriptions = more invocation surface to fumble. pi's own docs admit
-  models "don't always" read the full SKILL.md before acting; keep the
-  skill list short so the daily driver can't grab the wrong one.
-- **Every extension is in-process failure surface, not just prompt bloat.**
-  Live evidence (2026-07-06): a single convenience extension (`pi-goal`)
-  silently wedged every scripted task-shaped run pre-request and cost an
-  hour to bisect (§4a scripted-mode section). Sixty more packages is sixty
-  more chances at that. The bar is now: an extension must justify itself
-  against "this might be the next thing I spend an hour bisecting."
-
-**Verdict: works with our model and setup, but run the interactive picker
-and take ~6–8 pieces, not everything.** Worth taking: `pi-mcp-adapter`,
-`pi-plan`, diff review, memory (trial it — it also injects
-context each turn), a theme. Skip: the bulk skill catalog (write the 3–4
-skills from §4 instead), usage tracking (local = $0), and the **Claude Code
-CLI provider** (this toolchain doesn't use Claude Code; frontier access is
-via plain API keys as built-in pi providers).
-
-**Verify after install:** send one message and read pi's live token footer.
-If the first-turn prompt grew by thousands of tokens vs. pre-LazyPi, prune
-skills until it's back near baseline; `npx @robzolkos/lazypi doctor` checks
-install health.
-
-### ⚠️ Safety note: pi ships in "YOLO mode"
-
-Unlike Claude Code's deny-first permissions, **pi executes tools with NO
-guardrails by default** (the author's position: "security in coding agents is
-mostly theater"). With a bash tool and a kubeconfig on the same machine,
-the model *can* run `kubectl delete`. Layered mitigation for cluster work:
-
-1. **Give pi a read-only kubeconfig.** Create a `view`-bound ServiceAccount
-   kubeconfig and export `KUBECONFIG` to it in pi sessions; keep the admin
-   kubeconfig out of the agent's environment. This is the only *hard*
-   guarantee on the list.
-2. `pi-plan` for propose→approve on anything mutating.
-3. AGENTS.md rules (GitOps-only) — soft, but the 27B follows them well with
-   the tuned sampling.
-4. An opt-in permission-gating extension from pi.dev/packages if you want
-   Claude-Code-style prompts for specific commands.
-
-## 4b. Workflow patterns worth stealing (community-proven)
-
-- **Multi-stage review loop, free at local prices:** spec → implement →
-  **review with a fresh context window** (`/fork` or a subagent) → fix → test.
-  On paid APIs this pattern doubles cost; on your hardware the only cost is
-  the prefill wait. This is the single most-cited pi extension pattern — and
-  the fresh-context review catches what the implementing context is blind to.
-- **Mix local + frontier in one session:** add your Anthropic/OpenAI key
-  alongside the homelab provider (built-in providers need only `/login` — no
-  models.json entry) and **Ctrl+P cycles models mid-session**. Daily loop on
-  `qwen3.8-27b` for free; hit a wall → Ctrl+P to a frontier model for one
-  hard turn → cycle back. This is the "local volume, frontier judgment"
-  economics from the wind-down plan, inside a single conversation.
-- **Session tree instead of restarts:** `/fork` before a risky refactor,
-  `/tree` + switch back if it goes sideways — cheaper than `/new` because the
-  shared prefix prefill is preserved by vLLM's prefix caching
-  (`--enable-prefix-caching` is on).
-- **Plans as files, not modes:** write plans to `PLAN.md` in-repo and have pi
-  read them per session — survives context resets, gets version control, and
-  works identically in OpenCode when you switch agents (§8).
-
-## 5. Research & RAG strategy
-
-- **Code understanding: agentic retrieval beats embedding RAG.** With 64K of
-  context and grep/read tools, pi navigates repos the way Claude Code does —
-  search, open, follow imports. Don't build a vector index of your code; it
-  goes stale and retrieves worse than the model's own targeted greps.
-- **Web research:** the `research` skill above (SearXNG for hits, Perplexica
-  for synthesized+cited answers). This is the local replacement for Claude
-  Code's WebSearch/WebFetch.
-- **Long-document Q&A:** read targeted sections into context; the live window is
-  64K. For a 500-page spec, use Perplexica-style retrieval first and read the
-  full document only if the targeted pass is insufficient.
-- **Offline references:** the Kiwix instance (wired into open-webui's mcpo)
-  is also plain HTTP — add a curl line to the research skill if devdocs/wiki
-  bundles are loaded.
-
-## 6. Operational gotchas (the ones that will bite)
-
-1. **Prefill is the tax, not decode.** pi resends the whole conversation
-   every turn; at long context each turn pays the prefill cost again, even
-   with chunked prefill enabled. Discipline: `/compact` at
-   milestones, `/new` per task, don't paste what the model can `read`.
-2. **Concurrency budget is 3.** `max-num-seqs 3` shares one card. Long prompts
-   can still consume the practical capacity and make later requests queue.
-3. **One image per request.** pi resends conversation history, but vLLM admits
-   only one image. `/compact` or `/new` before sending a different screenshot.
-4. **Internal route only.** `vllm.vanillax.me` resolves via the internal
-   gateway — works on LAN/VPN, not from outside. Don't expose the /v1
-   endpoint externally; it's unauthenticated.
-5. **Don't override sampling client-side.** Server defaults are the tuned
-   Qwen-agent profile (incl. presence_penalty 1.5, which stops tool-call
-   loops). If pi settings expose temperature etc., leave them unset.
-6. **After GPU scale-swaps, pi errors are expected.** If vLLM is scaled to 0
-   (image-gen session on the cards), pi gets connection errors — that's the
-   whole-card topology, not a bug. Scale vLLM back to 1 in git.
-7. **Do not leave Qwen3.8 thinking at its implicit level.** Its template
-   defaults an omitted effort to `xhigh`, which can spend a large turn on
-   reasoning and leave little room for final content. Use `medium` normally,
-   `off` for trivial work, and inspect `finish_reason` before blaming vLLM if
-   an `xhigh` turn returns little or no content.
-8. **vLLM fails loud, Ollama fails silent — that's a feature.** The
-   Ollama-based pi guides warn that oversizing `num_ctx` silently falls
-   back to CPU and "tanks tool-call reliability." vLLM has no such mode:
-   requests over budget error visibly. If pi starts erroring at huge
-   contexts, that's the 64K request ceiling talking — `/compact`, don't retry.
-9. **MTP is already enabled.** The active profile uses two speculative draft
-   tokens; do not copy the old dual-card MTP-3 forecast into this 24 GiB layout.
-10. **Scripted `pi -p` can hang pre-request, forever.** No client timeout;
-    intermittent startup race aggravated by prompt-reactive extensions
-    (pi-goal). Full story + workarounds (TASK.md prompts, watchdog+retry,
-    `--no-extensions` caveat) in §4a's scripted-mode section.
-11. **Open-ended debug prompts trigger mega-generations.** "Diagnose the root
-    cause" once produced a 25-minute unbounded think-ramble (model simulating
-    the program in its head instead of running it). Constrain debug turns to
-    tool use: write a repro, run it, minimal fix. And when giving the model
-    failing-test feedback, give the FULL expected output and quote the spec
-    rule — partial hints once produced a confident spec-violating "fix" that
-    masked the symptom and self-declared success.
-12. **The 27B's blind spots survive its own verification.** Benchmarked
-    2026-07-06 (hard cron+DAG-scheduler challenge, 32 hidden tests): one-shot
-    96.9% in ~10 min — genuinely strong, better cron algorithm than the
-    frontier reference — but a checklist+self-tests discipline run scored the
-    SAME 96.9% with the SAME bug: its self-written checklist omitted the rule
-    it misconceived, and its self-tests avoided the case. One round of
-    precise external feedback → 100% in 60s. Moral: local model writes the
-    code; an external oracle (real tests, frontier review) buys the last 3%.
-
-## 7. OpenCode alongside pi (same backend, different job)
-
-OpenCode is the second agent in the toolchain — same vLLM endpoint, same
-`AGENTS.md` files (both tools read them), different strengths. Wire it via
-`~/.config/opencode/opencode.json` (or per-project `opencode.json`):
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "homelab": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "Homelab vLLM (1x3090)",
-      "options": { "baseURL": "https://vllm.vanillax.me/v1" },
-      "models": {
-        "qwen3.8-27b": {
-          "name": "Qwen3.8-27B",
-          "limit": { "context": 65536, "output": 16384 }
-        }
-      }
-    }
-  },
-  "model": "homelab/qwen3.8-27b"
-}
-```
-
-The `models` key must exactly match the served model id (`qwen3.8-27b`);
-restart OpenCode after editing and it appears in the model picker. Frontier
-API keys slot in as normal OpenCode providers next to it.
-
-**When to reach for which:**
-
-| | pi | OpenCode |
-|---|---|---|
-| Philosophy | minimal core, you compose it | fuller IDE-in-terminal out of the box |
-| Code intelligence | grep/read | **built-in LSP** — real go-to-def/diagnostics |
-| MCP | via `pi-mcp-adapter` (token-lean proxy) | native |
-| Plan mode | `pi-plan` package | built-in plan/build agent modes |
-| Sessions | **tree with fork/branch** | linear |
-| Extensibility | TypeScript extensions, 25 events | config + MCP |
-| Best at (here) | k8s/GitOps flows with custom skills, experiments, session branching | day-in-day-out TS/Python/React-Native editing where LSP pays |
-
-Shared-backend rule: **both agents count against `--max-num-seqs 3`.** pi +
-OpenCode can run simultaneously, but a third long request may still exhaust
-practical capacity. OpenCode exposes
-per-model context limits in config (above) — keep them matching the server
-so it compacts instead of erroring at the ceiling.
-
-## 8. Verify checklist
-
-- [ ] `pi --list-models` shows `qwen3.8-27b`; `/model` selects it
-- [ ] `pi "run 'ls' and tell me what you see"` → real `bash` tool call
-- [ ] Tool-call loop test: "read X, edit Y, run tests" chain completes
-      without the model narrating instead of calling tools
-- [ ] `pi --thinking off` answers directly; `medium` and `xhigh` render
-      `<think>`-backed reasoning split by the server into `reasoning_content`
-- [ ] Paste a screenshot → model describes it (vision path through gateway)
-- [ ] `/skill:research quick lookup test` hits SearXNG and returns JSON
-- [ ] (if pi-mcp-adapter installed) `/mcp` lists servers; a proxy
-      `mcp({ search: ... })` call resolves a tool
-- [ ] Long session: `/compact` works and the next turn's prefill drops
-
-## 9. LiteLLM proxy — logging pi's LLM usage to PostHog
-
-A second, optional path: an in-cluster **LiteLLM proxy** (`my-apps/ai/litellm/`)
-sits between pi and its backends purely for observability — every request's
-tokens, cost, latency, and model land in the self-hosted PostHog instance's
-**LLM Analytics** (Clusters/Playground included, same ingestion feeds all
-three). It doesn't replace the direct vLLM path above; it's a second provider
-you opt into per-model.
-
-```mermaid
-flowchart TD
-    subgraph WS["💻 Workstation"]
-        PI["pi TUI<br/>driven by ONE model at a time"]
-        SEL{"/model — which model drives<br/>this session? (manual, explicit choice)"}
-        SUB{"mid-task: is this hard enough to<br/>escalate? (qwen's own judgment,<br/>steered by AGENTS.md)"}
-        PI --> SEL
-        PI -.->|"while qwen is driving"| SUB
-    end
-
-    SEL -->|"vanillax-vllm<br/>(default — NOT logged)"| VROUTE["https://vllm.vanillax.me/v1<br/>(direct, bypasses LiteLLM)"]
-    SEL -->|"vanillax-litellm<br/>(manual switch — logged)"| LROUTE["https://litellm.vanillax.me/v1"]
-    SUB -->|"yes → subagent tool call<br/>agent: kimi-consult"| LROUTE
-
-    subgraph CLUSTER["☸️ Kubernetes cluster"]
-        VROUTE --> VLLM["vLLM<br/>1x RTX 3090 · qwen3.8-27b"]
-        LROUTE --> LITELLM["LiteLLM proxy<br/>looks up model → real backend + real key"]
-        LITELLM -->|"hosted_vllm/qwen3.8-27b"| VLLM
-        LITELLM -->|"moonshot/kimi-k3"| MOONSHOT
-        LITELLM -.->|"success/failure_callback"| CAPTURE["PostHog capture"]
-        CAPTURE --> CH[("ClickHouse")]
-        CH --> UI["PostHog UI<br/>Traces / Generations / Users"]
-
-        OP["1Password item:<br/>litellm"] --> ES["ExternalSecret"] --> SECRET[("k8s Secret<br/>litellm-secrets")] --> LITELLM
-    end
-
-    subgraph EXT["🌐 External"]
-        MOONSHOT["Moonshot API<br/>api.moonshot.ai — real $ cost"]
-    end
-```
-
-**The one thing worth being precise about:** the everyday `vanillax-vllm` path is
-**not logged**. Only traffic through LiteLLM — a manual `/model` switch, or a
-`kimi-consult` escalation — shows up in PostHog.
-
-### How the routing decision actually works
-
-There are two *different* decisions hiding in "how does pi know to use qwen or
-k3" — don't conflate them:
-
-**1. Which model drives the session — manual, not automatic.** pi runs one
-model at a time as the "brain" of a session; it doesn't dynamically pick
-per-message. You choose it explicitly (`/model` or `--model`) and it stays
-active — reading prompts, deciding tool calls, writing every response — until
-you switch it. pi never swaps its own driver model on its own initiative.
-
-**2. Whether the driver calls out to Kimi mid-task — automatic, an LLM
-judgment call, not routing logic.** This is a **tool call**, not routing:
-
-1. `@narumitw/pi-subagents` registers a `subagent` tool the driver (qwen) can
-   call like any other tool (read/edit/bash/…).
-2. `{"agent": "kimi-consult"}` is a valid argument because
-   `~/.pi/agent/agents/kimi-consult.md` declares an agent by that name, with
-   `model: vanillax-litellm/kimi-k3` in its frontmatter.
-3. Whether qwen actually emits that call on a given turn is qwen's own
-   reasoning, steered (not forced) by the "Escalate to Kimi K3" section in
-   `AGENTS.md`. It's non-deterministic — the same task might or might not
-   trigger it, same as deciding whether to reach for `grep`.
-4. When it fires, `pi-subagents` (plain extension code, not an LLM) spawns a
-   **second, separate pi process** configured per `kimi-consult.md` — pinned
-   to `vanillax-litellm/kimi-k3`, read-only tools only — runs it to
-   completion, and hands its final answer back to qwen as the tool result.
-   Qwen keeps driving, now with Kimi's opinion in context.
-
-No box "decides" between qwen and Kimi — qwen always decides, and Kimi only
-ever appears as a tool result inside qwen's own conversation, never as a peer.
-
-### What each box does
-
-| Box | What it actually does |
-|---|---|
-| `vanillax-vllm` / `vanillax-litellm` (`models.json` entries) | Not services — client-side config only. Each tells pi "here's a base URL, an API key, and the model IDs + specs available there." Selecting a model just points pi's OpenAI-compatible HTTP client at one entry. |
-| **LiteLLM proxy** | The only box doing real work in the middle. Per request: validate `Authorization: Bearer <master_key>` → read the `model` field → look it up in its own `model_list` for the *real* upstream + *real* credentials → forward using its own server-side key (pi never sees Moonshot's key or vLLM's) → stream the response back → fire-and-forget a PostHog event with token/cost/latency. A dictionary lookup + credential swap, nothing smarter. |
-| **vLLM** | Doesn't know or care that LiteLLM exists. Identical GPU backend either way — the direct route and the LiteLLM-proxied route are just two different front doors to the same service. |
-| **Moonshot's API** | Third-party SaaS, entirely outside the cluster. LiteLLM is just an HTTP client of it, same as pi would be directly — except pi's request only ever carries LiteLLM's master key, which Moonshot has never heard of. |
-| **PostHog capture → ClickHouse** | `capture` validates/buffers events; the rows land in ClickHouse, which Traces/Generations query. The Dashboard tab's errors come from a *different* PostHog component (Django querying Postgres for cached-insight metadata) — unrelated to whether events reached ClickHouse. |
-| **1Password → ExternalSecret → k8s Secret** | External Secrets Operator polls 1Password Connect hourly and materializes values as a real `Secret` object in the `litellm` namespace; the Deployment pulls it in as env vars at container start. Only the LiteLLM pod's environment ever holds `MOONSHOT_API_KEY` — it never reaches your workstation. |
-
-### Cluster side (already deployed, GitOps-managed)
-
-`my-apps/ai/litellm/` — a plain non-GPU app (no scale-swap concerns, unlike
-the AI workloads above). Config highlights worth knowing before touching it:
-
-- `drop_params: true` — **required**, not cosmetic. Kimi K3 fixes
-  `temperature`/`top_p`/`n`/`presence_penalty`/`frequency_penalty` server-side
-  and **rejects** requests that override them, rather than ignoring the
-  override. Without `drop_params`, any client that sends its own sampling
-  values breaks Kimi K3 calls through this proxy.
-- `model_info.input_cost_per_token`/`output_cost_per_token` set explicitly
-  per model — `0` for vLLM (self-hosted), `0.000003`/`0.000015` for Kimi K3
-  ($3/$15 per million, Moonshot's July 2026 pricing). Set explicitly rather
-  than relying on LiteLLM's built-in cost map, since Kimi K3 may be too new
-  for it.
-- Secrets (`master_key`, `moonshot_api_key`, `posthog_api_key`) come from the
-  1Password item **`litellm`** in vault `homelab-prod` via the standard
-  `ExternalSecret` pattern — see `my-apps/CLAUDE.md` if it ever needs
-  recreating.
-- **Memory gotcha (learned the hard way):** the container OOMKilled
-  (exit 137) within ~11s of starting at a 512Mi limit — LiteLLM's Python/
-  FastAPI stack + cost-map load at boot needs more than that. Current
-  limit is 1536Mi (512Mi request). If you see a `CrashLoopBackOff` with
-  `reason: OOMKilled` in `kubectl describe pod -n litellm`, this is why —
-  don't chase it as a config bug.
-
-### Client side — `~/.pi/agent/models.json`
-
-Add a second provider alongside the one in §1 (don't replace it — vLLM stays
-reachable directly too):
-
-```json
-"vanillax-litellm": {
-  "baseUrl": "https://litellm.vanillax.me/v1",
-  "api": "openai-completions",
-  "apiKey": "<LITELLM_MASTER_KEY>",
-  "models": [
-    {
-      "id": "kimi-k3",
-      "name": "Kimi K3 (via LiteLLM, logged to PostHog)",
-      "reasoning": true,
-      "input": ["text", "image"],
-      "contextWindow": 1000000,
-      "maxTokens": 131072,
-      "cost": { "input": 3, "output": 15, "cacheRead": 0.3, "cacheWrite": 0 }
-    }
-  ]
-}
-```
-
-Get the master key onto disk without ever pasting it into a chat/agent
-session — run this yourself:
-
-```bash
-KEY=$(op read "op://homelab-prod/litellm/master_key")
-jq --arg key "$KEY" '.providers["vanillax-litellm"].apiKey = $key' \
-  ~/.pi/agent/models.json > ~/.pi/agent/models.json.tmp \
-  && mv ~/.pi/agent/models.json.tmp ~/.pi/agent/models.json
-unset KEY
-```
-
-Verify: `pi --list-models` should list both `vanillax-vllm/qwen3.8-27b` and
-`vanillax-litellm/kimi-k3`. Selecting the latter with `/model` and sending a
-message routes it through LiteLLM → Moonshot, logged to PostHog.
-
-### Kimi K3 API specifics (learned from Moonshot's docs, not assumed)
-
-- **1M token context**, default max output 131,072 (ceiling 1,048,576) — not
-  the 64K/16K from the vLLM numbers above; it's a different
-  model on a different backend.
-- **`reasoning_effort`** (`low`/`high`/`max`, default `max`) replaces a
-  binary thinking toggle — and **can't be disabled**. K3 always reasons at
-  max depth unless told otherwise, which is exactly what you want from a
-  "consult on hard problems" model, so nothing to configure.
-- The fixed-sampling-params behavior above (`drop_params: true`) is the one
-  real gotcha — everything else behaves like a normal OpenAI-compatible
-  chat model.
-
-### The `kimi-consult` subagent
-
-`~/.pi/agent/agents/kimi-consult.md` defines a custom subagent (via
-`@narumitw/pi-subagents`, §4a) pinned to `vanillax-litellm/kimi-k3`,
-read-only tools (`read`/`grep`/`find`/`ls`). The daily-driver Qwen3.8 agent
-calls it via the `subagent` tool —
-`{"agent": "kimi-consult", "task": "..."}` — for a second opinion on
-genuinely hard problems: an ambiguous spec, a bug it isn't converging on, an
-architecture tradeoff. `~/.pi/agent/AGENTS.md`'s "Escalate to Kimi K3" section
-tells the main agent when this is worth the cost (~$3/$15 per million tokens,
-unlike free local Qwen) instead of leaving it to reach for automatically.
-
-Because `kimi-consult` calls Moonshot's API rather than the local vLLM
-endpoint, it does **not** consume any of the `--max-num-seqs 3` budget from
-§4a/§6 — it's the one subagent use case that doesn't reopen that contention
-problem.
-
-### Verify checklist
-
-- [ ] `kubectl get pods -n litellm` — `Running`/`1/1 Ready`, no OOMKilled
-- [ ] `curl -H "Authorization: Bearer $LITELLM_MASTER_KEY" https://litellm.vanillax.me/v1/models`
-      lists both `qwen3.8-27b` and `kimi-k3`
-- [ ] `pi --list-models` shows `vanillax-litellm/kimi-k3`
-- [ ] A message through `/model vanillax-litellm/kimi-k3` shows up in
-      PostHog → AI engineering → LLM analytics within a few seconds
-- [ ] `{"agent": "kimi-consult", "task": "say hello"}` via the `subagent`
-      tool returns a Kimi K3 response, also logged to PostHog
-
-## Related docs
-
-- [`model-catalog.md`](model-catalog.md) — what `qwen3.8-27b` is, app→backend wiring
-- [`3090-llm-optimization.md`](3090-llm-optimization.md) — engine/KV analysis, power profile, wind-down roadmap
-- [`my-apps/ai/litellm/`](https://github.com/mitchross/talos-argocd-proxmox/tree/main/my-apps/ai/litellm) — §9's proxy source (config, secrets, deployment)
-- [LiteLLM docs — Moonshot AI provider](https://docs.litellm.ai/docs/providers/moonshot) · [PostHog LLM analytics](https://posthog.com/docs/llm-analytics) · [Kimi K3 quickstart](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart)
-- [pi docs — models](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/models.md) · [pi coding agent](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) · [pi.dev/packages](https://pi.dev/packages) · [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter)
-- Community: [disler/pi-vs-claude-code](https://github.com/disler/pi-vs-claude-code/blob/main/COMPARISON.md) (feature-by-feature map; source for the YOLO-mode and session-tree notes) · [InsiderLLM pi + local models guide](https://insiderllm.com/guides/pi-agent-local-models-ollama/) (local Qwen tool-calling gotchas) · [owainlewis review](https://newsletter.owainlewis.com/p/is-pi-better-than-claude-code) (multi-stage review-loop extension pattern)
+If the model ID stays `qwen3.8-27b`, Pi does not need a config change for an
+engine patch or quant replacement unless the capabilities/context/reasoning
+contract changes.

--- a/infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml
+++ b/infrastructure/controllers/nvidia-gpu-operator/powerlimit-daemonset.yaml
@@ -58,8 +58,8 @@ spec:
               value: "all"
             - name: NVIDIA_DRIVER_CAPABILITIES
               value: "utility"
-            # 200W is a HOUSE-CIRCUIT constraint, not an efficiency choice (290W flickered the basement lights).
-            # Do not raise toward the 290W efficiency knee without confirming the circuit.
+            # 220W is the current HOUSE-CIRCUIT constraint, not an efficiency choice.
+            # Do not raise toward the ~290W efficiency knee without confirming the circuit.
             - name: POWER_LIMIT_WATTS
               value: "220"
             - name: REAPPLY_SECONDS

--- a/my-apps/ai/CLAUDE.md
+++ b/my-apps/ai/CLAUDE.md
@@ -37,6 +37,8 @@ One active OpenAI-compatible local backend, **NOT ollama**:
   path; it avoids a reported cuBLAS multimodal prefill failure.
 - **`--image-min-tokens 1024` is intentional** for Qwen vision/grounding
   correctness.
+- **Do not re-add `--cache-reuse` while multimodal is enabled.** llama.cpp
+  disables it with the projector loaded and only emits a warning.
 - **Local = unlimited token volume (free), not an infinite request window.**
 
 ## GPU Topology
@@ -56,8 +58,8 @@ is CPU-only and deliberately does not carry that label.
   env; they override the device-plugin/CDI injection.
 - The infrastructure `nvidia-powerlimit` DaemonSet is the exception because it
   administers the physical card without consuming a workload allocation.
-- The 3090 power cap is a house-circuit constraint. Do not raise it as a casual
-  performance tweak.
+- The current **220 W** 3090 power cap is a house-circuit constraint. Do not
+  raise it as a casual performance tweak.
 
 ## GPU Workload Pattern
 

--- a/my-apps/ai/llama-cpp/README.md
+++ b/my-apps/ai/llama-cpp/README.md
@@ -4,8 +4,8 @@
 as the rollback path.
 
 - in cluster: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`
-- LAN compatibility endpoint: `https://vllm.vanillax.me/v1`
-- alternate LAN endpoint: `https://llama.vanillax.me/v1`
+- canonical LAN endpoint: `https://llama.vanillax.me/v1`
+- compatibility LAN endpoint: `https://vllm.vanillax.me/v1`
 - API model: `qwen3.8-27b`
 
 ## Production profile
@@ -13,6 +13,7 @@ as the rollback path.
 | Setting | Value |
 |---|---|
 | GPU | 1x RTX 3090 24 GB |
+| Power cap | 220 W |
 | Engine | stock llama.cpp `b10752`, official CUDA12 linux/amd64 image |
 | Target | `unsloth/Qwen3.8-27B-GGUF` `UD-Q4_K_XL` |
 | Target size | ~17.6 GB |
@@ -24,10 +25,15 @@ as the rollback path.
 | Concurrency | one slot |
 | Storage | verified NFS archive -> GPU-node local NVMe cache |
 
-The goal is an everyday backend, not a maximum-context benchmark. Community
-single-3090 Qwen3.8-27B results show this dense/full-GPU shape is dramatically
-faster than the Flash-Next CPU-MoE layout previously tested here, while keeping
-vision, reasoning, tools and MTP.
+Observed after the 2026-09-03 production cutover: normal Open WebUI responses
+sustained about **42-43 generated tok/s**; under generation the RTX 3090 showed
+about **22,740 MiB / 24,576 MiB VRAM**, **87% GPU utilization**, and **216 W /
+220 W**. Treat these as the first real-machine baseline, not a synthetic ceiling.
+
+The goal is an everyday backend, not a maximum-context benchmark. This
+dense/full-GPU shape is roughly an order of magnitude faster on this exact host
+than the Flash-Next IQ4_XS CPU-MoE trial, while retaining vision, reasoning,
+tools and MTP.
 
 ## Pinned inputs
 
@@ -39,12 +45,18 @@ vision, reasoning, tools and MTP.
 `b10751` fixed the Qwen3.8-27B MTP KV-initialization regression reported in
 `b10745`; `b10752` is the next official image and contains that fix.
 
-## Storage
+## Storage and startup ordering
 
 The wave -1 download hook SHA-verifies the model, projector and MTP artifact on
 TrueNAS NFS. The wave 0 cache-sync hook copies only those three files into the
 GPU worker's node-local `ai-model-cache` PVC. The serving pod mounts only the
 NVMe cache.
+
+A revisioned `.qwen38-27b-cache-ready` stamp is written only after all three
+artifacts finish local-NVMe hydration. `wait-for-model-cache` blocks the serving
+container until that exact revision and all files are present. This prevents an
+existing Deployment from crash-looping while Argo hooks are still staging a
+new model.
 
 Old Flash-Next artifacts may remain on NFS/NVMe for manual recovery, but they
 are not downloaded, synchronized or referenced by the active manifests.
@@ -56,9 +68,15 @@ are not downloaded, synchronized or referenced by the active manifests.
 - `GGML_CUDA_CUBLAS_COMPUTE_TYPE=fp32` avoids an Ampere multimodal cuBLAS
   failure observed during vision prefill.
 - `--image-min-tokens 1024` favors vision/grounding correctness.
-- reasoning defaults to low effort; clients can override per request.
+- reasoning defaults to low effort; clients can override per request using
+  OpenAI-compatible `reasoning_effort`.
 - `--reasoning-preserve` keeps reasoning state coherent across multi-turn use.
-- `--cache-reuse 256` improves repeated-prefix / agent workloads.
+- Prefix `--cache-reuse` is intentionally omitted: llama.cpp disables it when
+  the multimodal projector is loaded, so keeping the flag only produces a
+  misleading startup warning.
+- Sampling stays server-owned at temp 0.7 / top-p 0.8 / top-k 20 / min-p 0 /
+  presence penalty 1.5 / repeat penalty 1.0 unless a client explicitly
+  overrides it.
 
 ## Cutover / rollback
 

--- a/my-apps/ai/llama-cpp/README.md
+++ b/my-apps/ai/llama-cpp/README.md
@@ -68,8 +68,10 @@ are not downloaded, synchronized or referenced by the active manifests.
 - `GGML_CUDA_CUBLAS_COMPUTE_TYPE=fp32` avoids an Ampere multimodal cuBLAS
   failure observed during vision prefill.
 - `--image-min-tokens 1024` favors vision/grounding correctness.
-- reasoning defaults to low effort; clients can override per request using
-  OpenAI-compatible `reasoning_effort`.
+- reasoning defaults to low effort server-side. Qwen3.8 separately controls
+  `enable_thinking` and reasoning effort (`low`, `medium`, `xhigh`); clients
+  that expose an off switch must send `enable_thinking=false`, not merely omit
+  `reasoning_effort`. The Pi.dev guide documents the exact mapping.
 - `--reasoning-preserve` keeps reasoning state coherent across multi-turn use.
 - Prefix `--cache-reuse` is intentionally omitted: llama.cpp disables it when
   the multimodal projector is loaded, so keeping the flag only produces a

--- a/my-apps/ai/llama-cpp/deployment.yaml
+++ b/my-apps/ai/llama-cpp/deployment.yaml
@@ -103,8 +103,6 @@ spec:
             - q8_0
             - --cache-type-v-draft
             - q8_0
-            - --cache-reuse
-            - "256"
             - --parallel
             - "1"
             - --jinja

--- a/my-apps/ai/open-webui/README.md
+++ b/my-apps/ai/open-webui/README.md
@@ -1,174 +1,93 @@
 # Open WebUI
 
-Self-hosted ChatGPT-style frontend for the cluster's local LLM stack. Wires
-Open WebUI up to vLLM (OpenAI-compatible API), SearXNG for web search,
-ComfyUI for image generation, Kiwix for offline RAG, and an MCP tool proxy
-(MCPO) for everything else.
+Self-hosted ChatGPT-style frontend for the cluster's local AI stack.
 
-## Architecture
+## Active wiring
 
-```
-                       https://open-webui.vanillax.me
-                                   │
-                        Gateway (Cilium) → HTTPRoute
-                                   │
-                           ┌───────┴────────┐
-                           │   Open WebUI   │  (this app — Deployment)
-                           └───┬───┬──┬──┬──┘
-               OpenAI-compat   │   │  │  └── MCPO (tools)
-                               │   │  │        ├── mcpo-time (port 8000)
-                               │   │  │        ├── mcpo-multi (port 8001, fs/memory/sqlite)
-                               │   │  │        └── mcpo-kiwix (port 8002, Kiwix fetch)
-                               │   │  └── ComfyUI (image gen) ─→ Z-Image-Turbo / Qwen-Image-Edit
-                               │   └── SearXNG (web search)
-                               └── vllm-service.vllm:8080/v1  (primary LLM)
+```text
+https://open-webui.vanillax.me
+        |
+        v
+Open WebUI
+  |-- llama.cpp -> qwen3.8-27b (chat / reasoning / tools / vision)
+  |-- SearXNG   -> web search
+  |-- MCPO      -> MCP-backed tools
+  |-- ComfyUI   -> image generation
+  `-- local CPU SentenceTransformer / Whisper -> RAG + STT
 ```
 
-Open WebUI itself is stateless UI + SQLite (on a PVC). The heavy lifting is
-elsewhere: vLLM holds the model in VRAM, ComfyUI owns the image-gen GPU,
-SearXNG handles search, and MCPO exposes tool endpoints as OpenAPI. RAG
-embeddings run **locally inside the Open WebUI pod** (built-in
-SentenceTransformer, CPU) — no external embedding dependency. Open WebUI runs
-on a CPU worker; local Whisper STT is CPU-backed.
+The canonical LLM connection is:
 
-## Model & backend
+- endpoint: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`
+- model: `qwen3.8-27b`
+- context: `65536`
 
-> ⚠️ **Source of truth is `open-webui-configmap.env`.** If you change models,
-> update the env file — don't trust this README over the live config.
+`open-webui-configmap.env` is the source of truth. Persistent Open WebUI model
+configuration is disabled so GitOps values win over stale DB-stored connection
+settings.
 
-Currently wired up (see `open-webui-configmap.env`):
+## Current model profile
 
-| Role                  | Model / Value                                                  |
-|-----------------------|----------------------------------------------------------------|
-| Chat backend          | `OPENAI_API_BASE_URL=http://vllm-service.vllm.svc.cluster.local:8080/v1` |
-| `DEFAULT_MODELS`      | `qwen3.8-27b` — vLLM `--served-model-name` |
-| `VISION_MODELS`       | `qwen3.8-27b` |
-| `TASK_MODEL`          | `qwen3.8-27b` |
-| `TASK_MODEL_EXTERNAL` | `qwen3.8-27b` |
-| `CONTEXT_WINDOW`      | `65536` (64K) — keep aligned with vLLM `--max-model-len`. If smaller, Open WebUI silently trims history / RAG before sending. |
-| Sampling              | `TEMPERATURE=0.7`, `TOP_P=0.80`, `MIN_P=0.0` |
-| Image generation      | ComfyUI — Z-Image-Turbo (text→img, 9 steps), Qwen-Image-Edit-2511 (edit) |
-| Embeddings            | Built-in local SentenceTransformer (CPU, in-pod) — no external service |
-| STT / TTS             | Whisper `medium` on CPU (in-pod), OpenAI TTS voice `alloy` |
+| Role | Value |
+|---|---|
+| Chat/default | `qwen3.8-27b` |
+| Vision | `qwen3.8-27b` |
+| Task/title model | `qwen3.8-27b` |
+| Backend | stock llama.cpp `b10752` |
+| Target | Qwen3.8-27B `UD-Q4_K_XL` |
+| Context | 65,536 |
+| MTP | Q4_0 draft, `n-max=2` |
+| KV | q8_0 target + draft |
+| Sampling | temp 0.7, top-p 0.8, min-p 0; server also owns top-k 20 and presence penalty 1.5 |
+| Vision projector | BF16 |
 
-vLLM is served from `my-apps/ai/vllm/deployment.yaml`; the Open WebUI
-model ID must match its `--served-model-name`. It advertises only `qwen3.8-27b`
-so the model selector stays clean.
+The production backend defaults to low reasoning. Open WebUI can request more
+reasoning per conversation, but do not make xhigh the everyday default.
 
-## Performance tuning (env ConfigMap)
+## Performance baseline
 
-Non-default env vars that matter, grouped by why they exist:
-
-### FastAPI / HTTP
-
-| Var                                    | Value | Why |
-|----------------------------------------|-------|-----|
-| `THREAD_POOL_SIZE`                     | `500` | Default (40) chokes under concurrent chat + RAG + tool calls. |
-| `AIOHTTP_CLIENT_TIMEOUT`               | `1800` (30 min) | Matches the HTTPRoute timeout so long completions aren't cut off mid-stream. |
-| `AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST`    | `30` | Model list probe timeout. |
-| `CHAT_RESPONSE_STREAM_DELTA_CHUNK_SIZE`| `5`  | Batch 5 tokens per SSE push. Cuts CPU/network overhead vs per-token flushing. |
-| `ENABLE_COMPRESSION_MIDDLEWARE`        | `True` | Gzip HTTP responses — meaningful for large RAG payloads. |
-| `MODELS_CACHE_TTL` / `ENABLE_BASE_MODELS_CACHE` | `300` / `False` | Keep Open WebUI from caching an empty model list if vLLM is down during startup. |
-| `ENABLE_QUERIES_CACHE`                 | `True` | Reuse LLM-generated RAG search queries across similar prompts. |
-
-### RAG
-
-| Var                          | Value  | Why |
-|------------------------------|--------|-----|
-| `CHUNK_SIZE` / `CHUNK_OVERLAP`| 800 / 150 (~18%) | Smaller chunks improve precision w/ hybrid search; 18% overlap preserves cross-chunk context. |
-| `RAG_TOP_K`                  | `10`   | Hybrid search retrieves more; model does the culling. |
-| `ENABLE_RAG_HYBRID_SEARCH`   | `True` | BM25 + embedding — better recall on technical content than pure vector. |
-| `RAG_SYSTEM_CONTEXT`         | `True` | Inject retrieved chunks into the system message (better for KV cache reuse than stuffing user msg). |
-| `RAG_EMBEDDING_BATCH_SIZE`   | `8` | Batch size for the built-in local embedder. |
-| `USE_CUDA_DOCKER`            | `false` | Open WebUI has no GPU; vLLM reserves the sole 3090. Embeddings run on CPU in-pod (default `RAG_EMBEDDING_ENGINE`, no external service). |
-| `PDF_EXTRACT_IMAGES`         | `True` | Required for vision RAG over PDF diagrams. |
-
-### UX
-
-| Var                                   | Value  | Why |
-|---------------------------------------|--------|-----|
-| `ENABLE_AUTOCOMPLETE_GENERATION`      | `False` | Fires on every keystroke → massive API load for marginal UX gain. |
-| `ENABLE_PERSISTENT_CONFIG`            | `False` | Forces Open WebUI to use GitOps env values instead of stale DB-stored connection settings. |
-| `SHOW_THOUGHTS`                       | `True` | Render `<think>` blocks from thinking-capable models. |
+After the 2026-09-03 cutover, ordinary Open WebUI responses measured roughly
+42-43 generated tok/s on the single RTX 3090. Under generation the card showed
+about 22.7 GiB VRAM used and high GPU utilization at the 220 W cap.
 
 ## Features
 
-- **Web search** — SearXNG-backed, private. Click `+` in chat to enable per-message. Config: `WEB_SEARCH_*`, `SEARXNG_QUERY_URL`.
-- **RAG** — upload PDFs/docs, hybrid (BM25 + embedding) search. See `KIWIX_RAG_INSTRUCTIONS.md` for the offline-encyclopedia RAG setup via `fetch`.
-- **Tools via MCPO** — wired through `OPENAPI_API_ENDPOINTS`:
-  - `mcpo-time` — current time/date
-  - `mcpo-multi` — filesystem, memory, SQLite
-  - `mcpo-kiwix` — offline encyclopedia fetch tool
-- **Image generation** — ComfyUI backend, 9-step Z-Image-Turbo default, LLM-enhanced prompts (`ENABLE_IMAGE_PROMPT_GENERATION`).
-- **Voice** — Whisper `medium` STT in-pod, OpenAI TTS (voice `alloy`).
-- **Custom functions** — `function-loader-job.yaml` loads custom functions (e.g., `har-analyzer-function.py`) into the UI.
+- **Web search**: SearXNG (`WEB_SEARCH_*`, `SEARXNG_QUERY_URL`).
+- **RAG**: local CPU embeddings, hybrid BM25/vector retrieval.
+- **Tools**: MCPO endpoints from `OPENAPI_API_ENDPOINTS`.
+- **Vision**: the same `qwen3.8-27b` model; no separate vision LLM.
+- **Image generation**: ComfyUI, separate from the chat model.
+- **Voice**: local Whisper STT; configured TTS remains OpenAI-compatible.
 
-### What is MCP / MCPO?
+## Important env settings
 
-**MCP** (Model Context Protocol) is Anthropic's spec for exposing tools to
-LLMs (filesystem ops, web fetch, DB queries, etc.). **MCPO** is an OpenAPI
-proxy in front of MCP servers, so any OpenAPI-aware client — including Open
-WebUI's Tools tab — can call them without speaking MCP natively.
+- `ENABLE_PERSISTENT_CONFIG=False`: GitOps model/backend settings stay authoritative.
+- `CONTEXT_WINDOW=65536`: keep aligned with llama.cpp `--ctx-size`.
+- `DEFAULT_MODELS`, `VISION_MODELS`, `TASK_MODEL`, `TASK_MODEL_EXTERNAL`: all `qwen3.8-27b`.
+- `AIOHTTP_CLIENT_TIMEOUT=1800`: matches long-generation Gateway timeouts.
+- `ENABLE_AUTOCOMPLETE_GENERATION=False`: avoids constant background LLM traffic.
+- `USE_CUDA_DOCKER=false`: Open WebUI stays CPU-only; llama.cpp owns the RTX 3090.
 
-In this cluster, MCPO exposes three tool bundles as OpenAPI endpoints
-(`8000/8001/8002`) and Open WebUI auto-registers them via
-`OPENAPI_API_ENDPOINTS`. The `Settings → Tools` UI path in the original
-README is the *manual* way to register more — the three above are already
-wired in via ConfigMap.
+## Debugging
 
-## Deployment
+Check the backend directly before blaming the UI:
 
-Applied by ArgoCD automatically (directory = Application). Files:
-
-| File                      | Purpose                                                          |
-|---------------------------|------------------------------------------------------------------|
-| `namespace.yaml`          | `open-webui` namespace                                           |
-| `open-webui-configmap.env`| **All** env-based config. Source of truth for behavior.          |
-| `deployment.yaml`         | Open WebUI main Deployment (stateful via PVC below)              |
-| `loader.js`               | Formats vLLM usage telemetry for the response tooltip       |
-| `pvc.yaml`                | SQLite + uploaded files persist here                             |
-| `service.yaml`            | ClusterIP for HTTPRoute                                          |
-| `httproute.yaml`          | External HTTPRoute to `open-webui.vanillax.me`                   |
-| `mcpo-deployment.yaml`    | MCPO Deployment (three tool bundles, ports 8000/8001/8002)       |
-| `mcp-config.yaml`         | Multi-tool server config (filesystem/memory/sqlite)              |
-| `mcp-kiwix.yaml`          | Kiwix fetch tool config                                          |
-| `function-loader-job.yaml`| One-shot Job — loads `har-analyzer-function.py` into the UI      |
-| `kustomization.yaml`      | Ties it all together. **Must list every YAML** under `resources:` |
-
-Force a manual apply (bypassing ArgoCD, for dev):
 ```bash
-kubectl apply -k my-apps/ai/open-webui/
+kubectl -n llama-cpp get pods
+kubectl -n llama-cpp logs deploy/llama-cpp-server --tail=200
+kubectl -n llama-cpp exec deploy/llama-cpp-server -- nvidia-smi
+curl -s https://llama.vanillax.me/v1/models
 ```
 
-## Access
+Then confirm the UI pod received the rendered ConfigMap:
 
-- Public: https://open-webui.vanillax.me (Cloudflare tunnel → gateway-external)
+```bash
+kubectl -n open-webui get pods
+kubectl -n open-webui describe deploy/open-webui
+```
 
-## Troubleshooting
+## GPU ownership
 
-**No models showing up in the UI**
-- Check `curl -s http://vllm-service.vllm.svc.cluster.local:8080/v1/models` from inside the cluster — what model name is advertised?
-- Compare against `DEFAULT_MODELS` in `open-webui-configmap.env`. It must match vLLM's `--served-model-name` exactly.
-- If Open WebUI cached an empty model list while vLLM was crashlooping, restart `deploy/open-webui` after the backend is healthy.
-
-**Tools tab is empty**
-- `kubectl logs -n open-webui deploy/mcpo` — MCPO pods crash loudly if the API keys don't match `OPENAPI_API_ENDPOINTS`.
-- Test endpoint directly: `kubectl exec -n open-webui deploy/open-webui -- curl -s http://mcpo.open-webui.svc.cluster.local:8000/openapi.json`
-
-**Web search returns nothing**
-- Verify SearXNG is alive: `kubectl get pods -n searxng`
-- `SEARXNG_QUERY_URL` must include `&format=json` — without JSON format Open WebUI silently drops results.
-
-**Long completions cut off mid-stream**
-- `AIOHTTP_CLIENT_TIMEOUT=1800` handles 30-min generations. If you're running longer, bump this *and* the `HTTPRoute` timeout — the shorter of the two wins.
-
-## Gotchas
-
-- **Env ConfigMap is law.** `ENABLE_PERSISTENT_CONFIG=False` forces Open WebUI
-  to read these GitOps values on restart; UI edits to connection/model settings
-  are session-only.
-- **MCPO key must match** between the MCPO Deployment env and
-  `OPENAPI_API_ENDPOINTS` — format is
-  `name:url:api_key;name:url:api_key;…`.
-- **PVC is RWO.** Deployment uses `strategy: Recreate` (see
-  `my-apps/CLAUDE.md` — RWO + RollingUpdate = Multi-Attach deadlock).
+Open WebUI itself does not request a GPU. The single RTX 3090 belongs to the
+active llama.cpp Deployment. ComfyUI/SwarmUI/vLLM are mutually exclusive
+whole-card workloads and remain parked unless a GitOps scale-swap is performed.

--- a/my-apps/ai/open-webui/README.md
+++ b/my-apps/ai/open-webui/README.md
@@ -50,6 +50,18 @@ After the 2026-09-03 cutover, ordinary Open WebUI responses measured roughly
 42-43 generated tok/s on the single RTX 3090. Under generation the card showed
 about 22.7 GiB VRAM used and high GPU utilization at the 220 W cap.
 
+## Date/time grounding
+
+`DEFAULT_SYSTEM_PROMPT` injects `{{CURRENT_DATE}}`, `{{CURRENT_WEEKDAY}}`, and
+`{{CURRENT_TIMEZONE}}` so Qwen is not forced to guess the current date. Exact
+current time, timezone conversion, and calendar arithmetic should use the
+`mcpo-time` tool.
+
+Do not add `{{CURRENT_TIME}}` or `{{CURRENT_DATETIME}}` to the persistent system
+prompt: Open WebUI resolves them on every request, changing the prompt prefix
+and hurting KV/prefix reuse on long conversations. The date-only variable
+changes once per day.
+
 ## Features
 
 - **Web search**: SearXNG (`WEB_SEARCH_*`, `SEARXNG_QUERY_URL`).

--- a/my-apps/ai/open-webui/open-webui-configmap.env
+++ b/my-apps/ai/open-webui/open-webui-configmap.env
@@ -52,7 +52,11 @@ OPENAPI_API_ENDPOINTS=mcpo-time:http://mcpo.open-webui.svc.cluster.local:8000:mc
 # Title/tag generation uses the same advertised model.
 TASK_MODEL=qwen3.8-27b
 TASK_MODEL_EXTERNAL=qwen3.8-27b
-DEFAULT_SYSTEM_PROMPT="You have access to an offline encyclopedia (Kiwix) via the 'fetch' tool.\nThe Kiwix server is located at: http://kiwix.kiwix.svc.cluster.local:8080\n\nTo search for information:\n1. Use the 'fetch' tool to search: \"http://kiwix.kiwix.svc.cluster.local:8080/search?pattern=YOUR_SEARCH_QUERY\"\n2. The result will be an HTML page containing search results. Read the links from this page.\n3. To read an article, use 'fetch' again on the article URL found in the search results (e.g., \"http://kiwix.kiwix.svc.cluster.local:8080/content/wikipedia_en_all_maxi_2025-08/Article_Name\").\n\nWhen asked about general knowledge or historical facts, ALWAYS check the offline encyclopedia first using these steps.\nCITE your sources by referencing the article title.\n"
+# CURRENT_DATE/WEEKDAY/TIMEZONE are resolved by Open WebUI per request. Avoid
+# CURRENT_TIME/CURRENT_DATETIME here because second-level prompt changes destroy
+# prefix/KV reuse on long chats. Use mcpo-time when exact current time or date
+# arithmetic matters.
+DEFAULT_SYSTEM_PROMPT="Current date: {{CURRENT_DATE}} ({{CURRENT_WEEKDAY}}).\nUser timezone: {{CURRENT_TIMEZONE}}.\nFor exact current time, timezone conversion, date arithmetic, or relative-date questions, use the time tool instead of guessing.\n\nYou have access to an offline encyclopedia (Kiwix) via the 'fetch' tool.\nThe Kiwix server is located at: http://kiwix.kiwix.svc.cluster.local:8080\n\nTo search for information:\n1. Use the 'fetch' tool to search: \"http://kiwix.kiwix.svc.cluster.local:8080/search?pattern=YOUR_SEARCH_QUERY\"\n2. The result will be an HTML page containing search results. Read the links from this page.\n3. To read an article, use 'fetch' again on the article URL found in the search results (e.g., \"http://kiwix.kiwix.svc.cluster.local:8080/content/wikipedia_en_all_maxi_2025-08/Article_Name\").\n\nWhen asked about general knowledge or historical facts, ALWAYS check the offline encyclopedia first using these steps.\nCITE your sources by referencing the article title.\n"
 ENABLE_IMAGE_GENERATION=True
 IMAGE_GENERATION_ENGINE=comfyui
 COMFYUI_BASE_URL=http://comfyui-service.comfyui.svc.cluster.local:8188

--- a/my-apps/ai/surfsense/CLAUDE.md
+++ b/my-apps/ai/surfsense/CLAUDE.md
@@ -25,7 +25,7 @@ Do not split these child folders into independent Argo Applications unless there
 | `kopiur/postgres-data.yaml` | Hourly Postgres backup + Restore |
 | `kopiur/object-store.yaml` | Daily knowledge/object-store backup + Restore |
 | `externalsecret.yaml` | 1Password-backed application/database/Zero secrets; wave -1 |
-| `global_llm_config.yaml` | Operator-owned global chat model catalog; points SurfSense at the in-cluster vLLM service |
+| `global_llm_config.yaml` | Operator-owned global chat model catalog; points SurfSense at the active in-cluster llama.cpp service |
 | `selfhost.env` | Non-secret self-host policy: zero signup wallet and all hosted-style billing switches disabled |
 | `scripts/reconcile-credit-policy.sh` | SQL reconciliation script mounted into the credit-policy hook through a generated ConfigMap |
 | `httproute.yaml` | Single-origin external routing that mirrors SurfSense's upstream Caddy contract |
@@ -54,8 +54,8 @@ Do not put the Kopiur `Restore` CR in an earlier isolated wave than its PVC. The
 6. **Zero is not backed up and has no PVC.** Its SQLite replica is `emptyDir`; replacement resyncs from Postgres.
 7. **Mirror SurfSense's upstream same-origin proxy contract exactly.** `/auth/callback` goes to the frontend; `/auth`, `/users`, `/api/v1`, and `/zero/context` go to the backend; remaining `/zero` traffic goes to zero-cache; everything else goes to the frontend. The `/users/me` and `/zero/context` exceptions are required for authenticated dashboard startup. Do not collapse these into broad `/auth` or `/zero` routes without preserving the more-specific exceptions.
 8. **Do not add upstream OpenSandbox's Docker socket to Talos.** Talos has no Docker daemon/socket. `SANDBOX_ENABLED=FALSE` is intentional until a Kubernetes-native or remote sandbox provider is selected.
-9. **Do not request a GPU.** The active RTX 3090 belongs to vLLM. SurfSense uses CPU embeddings and calls vLLM for chat.
-10. **Local vLLM is free infrastructure, not a credit-metered provider.** Keep `qwen3.8-27b` at `billing_tier: free`. `selfhost.env` must keep `DEFAULT_CREDIT_MICROS_BALANCE=0` and hosted-style billing switches disabled. The credit-policy hook must reconcile restored or pre-policy wallet rows before workloads start; do not replace it with manual SQL or fake premium model entries.
+9. **Do not request a GPU.** The active RTX 3090 belongs to llama.cpp. SurfSense uses CPU embeddings and calls llama.cpp for chat.
+10. **Local llama.cpp is free infrastructure, not a credit-metered provider.** Keep `qwen3.8-27b` at `billing_tier: free`. `selfhost.env` must keep `DEFAULT_CREDIT_MICROS_BALANCE=0` and hosted-style billing switches disabled. The credit-policy hook must reconcile restored or pre-policy wallet rows before workloads start; do not replace it with manual SQL or fake premium model entries.
 11. **Reuse cluster SearXNG** at `http://searxng.searxng.svc.cluster.local:8080`; do not deploy another copy.
 12. **Secrets stay in 1Password.** Item `surfsense`: `secret_key`, `db_password`, `zero_admin_password`, `zero_query_api_key`.
 13. **Obsidian sync is client-pushed through a loopback Kubernetes tunnel.** The CachyOS plugin syncs only Mink `wiki/` through `127.0.0.1:18000`; do not add a server-side vault mount, route note-body bursts through Cloudflare, or commit the plugin PAT.
@@ -71,8 +71,8 @@ The SurfSense backend image does not set a non-root `USER`, so object-store data
 
 ## Local AI
 
-- Base URL: `http://vllm-service.vllm.svc.cluster.local:8080/v1`
+- Base URL: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`
 - Model: `qwen3.8-27b`
 - Billing tier: `free`
 
-Do not point SurfSense at the parked llama.cpp service unless the repo's AI backend state changes.
+Do not point SurfSense at the parked vLLM backend unless the repo's AI backend state changes.

--- a/my-apps/ai/surfsense/README.md
+++ b/my-apps/ai/surfsense/README.md
@@ -41,13 +41,13 @@ Fields:
 
 ## Local AI
 
-SurfSense uses the existing in-cluster OpenAI-compatible backend through its
+SurfSense uses the active in-cluster OpenAI-compatible llama.cpp backend through its
 operator-owned global model catalog:
 
-- Base URL: `http://vllm-service.vllm.svc.cluster.local:8080/v1`
+- Base URL: `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1`
 - Model: `qwen3.8-27b`
 - Config: `global_llm_config.yaml`, mounted at `/app/app/config/global_llm_config.yaml`
-- Context budget: 48,000 input + 16,384 output, leaving 1,152 tokens for request/tool overhead inside vLLM's 65,536-token window
+- Context budget: 48,000 input + 16,384 output, leaving 1,152 tokens for request/tool overhead inside llama.cpp's 65,536-token window
 - Billing tier: `free` — this is local infrastructure, not a metered provider
 
 Initial embeddings use CPU-local `sentence-transformers/all-MiniLM-L6-v2`, so SurfSense does not request a GPU.
@@ -74,33 +74,6 @@ and sending that burst through Cloudflare can produce managed-WAF 403s.
 
 This deployment does not use SurfSense's hosted credit wallet for local infrastructure. `selfhost.env` is materialized as `surfsense-selfhost-policy` and loaded by the API, worker, Beat, and migration containers.
 
-The policy keeps new-user wallet balance at zero and explicitly disables ETL, crawl, captcha, platform-scrape, and Stripe credit billing. This also keeps Auto mode eligible for the local `billing_tier: free` vLLM model instead of treating a default signup credit balance as premium-provider eligibility.
+The policy keeps new-user wallet balance at zero and explicitly disables ETL, crawl, captcha, platform-scrape, and Stripe credit billing. This also keeps Auto mode eligible for the local `billing_tier: free` llama.cpp model instead of treating a default signup credit balance as premium-provider eligibility.
 
 SurfSense upstream defaults new users to a $5 wallet. The versioned `surfsense-credit-policy-v1` Sync hook runs after schema migrations and idempotently resets restored or pre-policy wallet balances before the API, worker, Beat, and Zero start. Its checked-in `scripts/reconcile-credit-policy.sh` is mounted through a hash-suffixed Kustomize-generated ConfigMap, so the executable policy stays out of the Job YAML. A fresh deployment and a restored deployment therefore converge on the same no-credit policy without manual SQL.
-
-## Storage and DR
-
-### Durable
-
-- `surfsense-postgres-data` — `longhorn`, RWO, hourly Kopiur snapshots, restore-before-bind. PostgreSQL runs as uid/gid `999`, uses a `PGDATA` subdirectory, checksums, logical replication, and a pre-snapshot `CHECKPOINT` hook.
-- `surfsense-object-store` — `longhorn`, RWO, daily Kopiur snapshots, restore-before-bind. SurfSense stores uploaded blobs and workspace knowledge-store Git working trees under this filesystem. API and worker are in the same pod specifically so both see the exact same volume without requiring RWX storage.
-
-### Disposable
-
-- Redis keeps a small `longhorn` RWO PVC for ordinary restart continuity and is explicitly backup-exempt.
-- Zero's SQLite replica uses `emptyDir` and resyncs from PostgreSQL after replacement.
-- `/shared_tmp` is `emptyDir` shared by API and worker and is disposable.
-
-## Routing
-
-The external HTTPRoute mirrors SurfSense 0.0.39's upstream Caddy single-origin contract:
-
-- `/auth/callback*` -> frontend
-- `/auth/*` -> backend
-- `/users/*` -> backend
-- `/api/v1/*` -> backend
-- `/zero/context` -> backend
-- remaining `/zero/*` -> Zero/WebSocket
-- everything else -> frontend
-
-The more-specific `/auth/callback` and `/zero/context` matches are intentional. The authenticated dashboard also requires `/users/me` to reach FastAPI; routing `/users/*` to the frontend produces an HTML 404 and the frontend surfaces `Failed to parse response`.


### PR DESCRIPTION
## What

Post-cutover cleanup for the working Qwen3.8-27B llama.cpp production backend.

The measured production shape is unchanged: stock llama.cpp b10752, Qwen3.8-27B UD-Q4_K_XL, q8_0 target/draft KV, MTP Q4_0 n-max=2, BF16 vision, 65,536 context, one RTX 3090.

### Runtime/config cleanup

- remove `--cache-reuse 256`: llama.cpp explicitly disables it when the multimodal projector is loaded, so it only produced a misleading warning
- keep all other measured-working inference knobs unchanged
- make the GPU power-limit comments match the real configured/live 220 W cap
- add Open WebUI date grounding using `CURRENT_DATE`, `CURRENT_WEEKDAY`, and `CURRENT_TIMEZONE`
- tell Open WebUI to use the existing `mcpo-time` tool for exact current time, timezone conversion, and date arithmetic
- intentionally avoid `CURRENT_TIME`/`CURRENT_DATETIME` in the persistent system prompt so the prompt prefix does not change every request and destroy KV/prefix reuse

### Pi.dev

Replace the old vLLM-specific Pi.dev guide with the current llama.cpp setup:

- provider `vanillax-llama` -> `https://llama.vanillax.me/v1`
- canonical model remains `qwen3.8-27b`
- 65,536 context + image input
- explicit `chat_template_kwargs` mapping for Qwen3.8 reasoning:
  - off -> `enable_thinking=false`
  - low/medium/xhigh -> `enable_thinking=true` plus the exact supported effort
  - `preserve_thinking=true` for multi-turn replay
- keep both Pi `defaultThinkingLevel` and per-model `modelThinkingLevels` at medium
- preserve the user's existing Pi package list and Kimi model while renaming only the old `vanillax-vllm/qwen3.8-27b` entry
- document `date` / `date -u` through Pi's built-in bash tool as the current-date/time source of truth instead of asking the model to guess

### Agent/docs consistency

- root `CLAUDE.md` now says llama.cpp is active and vLLM is parked
- nested AI agent guidance matches the current backend and 220 W cap
- model catalog records the measured ~42-43 tok/s, ~22.7 GiB VRAM, 216/220 W production baseline
- GPU scale-swap runbook has the correct active/parked truth table
- Open WebUI and SurfSense docs no longer describe vLLM as the active backend

## What does not change

- model/quant
- MTP depth
- context window
- KV type
- sampling
- vision projector
- CUDA graph setting
- Ampere vision fp32 compute workaround
- API model id (`qwen3.8-27b`)
- vLLM rollback artifacts or compatibility DNS alias

This PR is intentionally a cleanup/freeze of the configuration that is already running at ~42-43 tok/s on the single RTX 3090.