### PR TITLE
ai: finish live llama.cpp consumer rewiring

### DIFF
--- a/monitoring/keep/values.yaml
+++ b/monitoring/keep/values.yaml
@@ -60,7 +60,7 @@ backend:
       llama-cpp-local:
         type: vllm
         authentication:
-          api_url: http://vllm-service.vllm.svc.cluster.local:8080/v1
+          api_url: http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1
           api_key: none
     workflows:
       - id: holmes-rca

--- a/my-apps/development/news-reader/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/development/news-reader/temporal-workers/temporal-worker-deployment.yaml
@@ -45,7 +45,7 @@ spec:
           # Controller injects TEMPORAL_ADDRESS/NAMESPACE/DEPLOYMENT_NAME/WORKER_BUILD_ID — do not set them here.
           env:
             - name: LLM_URL
-              value: "http://vllm-service.vllm.svc.cluster.local:8080/v1/chat/completions"
+              value: "http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1/chat/completions"
             - name: LLM_MODEL
               value: "qwen3.8-27b"
             - name: REDDIT_FRONTEND

--- a/my-apps/media/karakeep/karakeep/karakeep-configuration.env
+++ b/my-apps/media/karakeep/karakeep/karakeep-configuration.env
@@ -1,5 +1,5 @@
 NEXTAUTH_URL=https://karakeep.vanillax.me
-OPENAI_BASE_URL=http://vllm-service.vllm.svc.cluster.local:8080/v1
+OPENAI_BASE_URL=http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1
 OPENAI_API_KEY=sk-required
 OLLAMA_KEEP_ALIVE=5m
 INFERENCE_TEXT_MODEL=qwen3.8-27b

--- a/my-apps/media/worldmonitor/configmap.yaml
+++ b/my-apps/media/worldmonitor/configmap.yaml
@@ -11,8 +11,8 @@ data:
   LOCAL_API_CLOUD_FALLBACK: "false"
   # AIS relay (internal service)
   WS_RELAY_URL: "http://worldmonitor-ais-relay:3004"
-  # LLM — in-cluster vLLM (qwen3.8-27b)
-  LLM_API_URL: "http://vllm-service.vllm.svc.cluster.local:8080/v1/chat/completions"
+  # LLM — active in-cluster llama.cpp (qwen3.8-27b)
+  LLM_API_URL: "http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1/chat/completions"
   LLM_MODEL: "qwen3.8-27b"
-  # Must be non-empty: the generic LLM provider is skipped when LLM_API_KEY is empty; vLLM accepts any value.
+  # Must be non-empty: the generic LLM provider is skipped when LLM_API_KEY is empty; llama.cpp accepts any value.
   LLM_API_KEY: "not-needed"

--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             # Pin both values: the digest call is best-effort and silently falls
             # back to facts-only prose when a backend or model id is stale.
             - name: DIGEST_LLM_URL
-              value: http://vllm-service.vllm.svc.cluster.local:8080/v1/chat/completions
+              value: http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1/chat/completions
             - name: DIGEST_LLM_MODEL
               value: qwen3.8-27b
             - name: INGEST_TOKEN


### PR DESCRIPTION
Post-cutover audit found five live applications still reaching the active Qwen3.8-27B backend through the old `vllm-service` compatibility alias. They work today because that Service is an `ExternalName` to llama.cpp, but normal Git-managed consumers should call the canonical service directly.

This PR rewires only those live consumers:

- WorldMonitor
- Keep provider
- Deal Scout digest
- Karakeep text/vision inference
- News Reader Temporal worker

All keep the canonical model id `qwen3.8-27b`; only the endpoint changes to `http://llama-cpp-service.llama-cpp.svc.cluster.local:8080`.

No llama.cpp model/runtime settings change. The old `vllm-service` alias remains for persistent/out-of-Git clients, especially already-imported n8n workflows. Checked-in n8n workflow exports will be cleaned separately because they are source exports rather than the live DB-backed workflows.