### PR TITLE
fix: bound Argo cache staleness and stop two restart loops

### DIFF
--- a/infrastructure/controllers/argocd/values.yaml
+++ b/infrastructure/controllers/argocd/values.yaml
@@ -63,10 +63,14 @@ configs:
     # change", and skipped the Deployment apply — selfHeal can't help because the
     # controller perceives no drift. A manual hard refresh fixed it instantly.
     # "0" (disabled) let that stale state persist indefinitely (cluster cache is
-    # watch-based with no resync-duration knob in this version). 1h bounds the
-    # worst-case staleness window to one hour. Raise toward 2h-4h if the hourly
-    # all-apps manifest regeneration pressures the repo-servers.
-    timeout.hard.reconciliation: "1h"
+    # watch-based; v3.5.2 still exposes no --cluster-cache-resync-duration, so
+    # --app-hard-resync is the only lever). 1h proved far too wide: 2026-09-03
+    # the same masquerade hit four times in one session (open-meteo, llama-cpp,
+    # gpu-priority-classes, radar-ng), each needing a manual hard refresh, and
+    # one of them wedged a namespace rebuild because a referenced PriorityClass
+    # never rendered. 15m bounds the window to roughly one merge-and-verify loop.
+    # Raise toward 30m-1h if the resync pressures the repo-servers.
+    timeout.hard.reconciliation: "15m"
     # Global diff noise cleanup for resources normalized by their controllers.
     # Keep these system-level so AppSets only carry app-specific rules.
     #

--- a/monitoring/coroot/coroot.yaml
+++ b/monitoring/coroot/coroot.yaml
@@ -88,9 +88,10 @@ spec:
     resources:
       requests:
         cpu: 50m
-        memory: 128Mi
+        memory: 256Mi
+      # 512Mi OOMKilled the agent 140x; it reached 427Mi minutes after a restart.
       limits:
-        memory: 512Mi
+        memory: 1Gi
   logsTTL: 3d
   tracesTTL: 3d
   profilesTTL: 3d

--- a/monitoring/prometheus-stack/dcgm-exporter.yaml
+++ b/monitoring/prometheus-stack/dcgm-exporter.yaml
@@ -70,14 +70,16 @@ spec:
               memory: 128Mi
             limits:
               memory: 512Mi
-          # DCGM /health stalls past the 1s default while the GPU is under load; 1s probes = restart loops.
+          # /health stalls under GPU load and podMapper's API calls can DeadlineExceed;
+          # 5s still killed it 509x, so allow a slow answer and require 3 misses.
           livenessProbe:
             httpGet:
               path: /health
               port: 9400
             initialDelaySeconds: 45
             periodSeconds: 30
-            timeoutSeconds: 5
+            timeoutSeconds: 20
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Three independent stability fixes.

## 1. ArgoCD stale-render masquerade — `timeout.hard.reconciliation` 1h → 15m

**Symptom:** an app reports `Synced` at the correct revision while the live object still runs the old spec. A manual `argocd.argoproj.io/refresh=hard` fixes it instantly.

**It is not git-polling lag.** The webhook is configured and healthy:

```
hook 609575416 active=true url=https://argocd-webhook.vanillax.me/api/webhook events=push
2026-09-03T05:24:57Z push status=OK code=200
2026-09-03T05:22:05Z push status=OK code=200
```

The webhook triggers a *soft* refresh, which re-reads manifests but reuses the controller's cluster live-state cache. That cache is watch-based and can desync. With server-side diff enabled, a stale cache makes the diff return "no change", the apply is skipped, and the app is reported Synced. `selfHeal` cannot help — the controller perceives no drift.

Only a hard refresh invalidates both caches, and `--app-hard-resync` is the only knob that schedules one. Confirmed against the running binary that v3.5.2 still has no cluster-cache resync flag:

```
--app-hard-resync int                  (default 3600)
--app-state-cache-expiration duration  (default 1h0m0s)
--default-cache-expiration duration    (default 24h0m0s)
```

**1h proved far too wide.** On 2026-09-03 this hit four times in one session — open-meteo, llama-cpp, gpu-priority-classes, and radar-ng — each requiring a manual hard refresh. One was not cosmetic: `infrastructure-gpu-priority-classes` reported `Synced` at a revision predating the merge that added the `app-critical` PriorityClass, so every pod in the rebuilding radar-ng namespace was rejected with `no PriorityClass with name app-critical was found` and the namespace could not start at all.

15m bounds the window to roughly one merge-and-verify loop. Raise toward 30m–1h if the resync pressures the repo-servers.

## 2. coroot cluster-agent OOM loop — 512Mi → 1Gi

140 restarts, all OOMKilled. It reached 427Mi within minutes of a restart, so the 512Mi ceiling was simply undersized for this cluster. Request also raised 128Mi → 256Mi so the scheduler reserves something closer to real usage.

## 3. dcgm-exporter liveness loop — 5s → 20s, `failureThreshold: 3`

509 restarts. `/health` stalls past the probe timeout while the GPU is under load, and podMapper's Kubernetes API calls intermittently `DeadlineExceeded`. The file already carried a 1s → 5s relaxation; 5s was still not enough. Allowing a slow answer and requiring three consecutive misses stops a single slow scrape from killing the pod, while still catching a genuinely dead exporter within ~90s.

## Not included

**`project-nomad/flatnotes`** (35 restarts, CrashLoopBackOff) is a *data* problem, not a manifest one: the Whoosh search index on the `flatnotes-data` PVC is corrupted (`TypeError: ord() expected a character` in `TOC.read`). No config change fixes it — the index directory has to be wiped so it rebuilds, or restored. Left alone deliberately since it needs an operator decision about the index data.

The other entries in tonight's restart survey need no action: the truenas-csi and posthog spikes were transient and self-recovered, and the bulk of the remaining counts trace to the single 2026-09-02 05:11 UTC all-node restart.

## Validation

- Full-repo aggregate render: 101 directories, `fail=0`.
- `validate-argocd-apps.sh` PASSED; `validate-vpa-policies.py` 0 errors (4 pre-existing warnings); `validate-kopiur-coverage.py` OK.
- Rendered `argocd-cm` confirms `timeout.hard.reconciliation: 15m`; dcgm DaemonSet confirms `timeoutSeconds: 20` / `failureThreshold: 3`; coroot confirms `1Gi`.

## After merge

The controller reads the hard-resync period at startup, so it needs a restart to take effect:

```sh
kubectl rollout restart statefulset/argocd-application-controller -n argocd
kubectl -n argocd get cm argocd-cm -o jsonpath='{.data.timeout\.hard\.reconciliation}'
kubectl -n coroot get pods -w          # agent should stop OOMKilling
kubectl -n prometheus-stack get pods -l app=dcgm-exporter -w
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1L7LjtxSVaLdDpyuhpq3D
