### PR TITLE
fix(radar-ng): own the PriorityClass it references

### DIFF
--- a/infrastructure/controllers/gpu-priority-classes/priority-classes.yaml
+++ b/infrastructure/controllers/gpu-priority-classes/priority-classes.yaml
@@ -25,14 +25,3 @@ metadata:
 value: 50
 globalDefault: false
 preemptionPolicy: PreemptLowerPriority
----
-# Production data pipelines: outrank general homelab apps, still yield to primary AI workloads.
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: app-critical
-  annotations:
-    description: "Production data pipelines (radar-ng ingestion + tile origin)"
-value: 500
-globalDefault: false
-preemptionPolicy: PreemptLowerPriority

--- a/my-apps/development/radar-ng/kustomization.yaml
+++ b/my-apps/development/radar-ng/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - vpa.yaml
   - namespace.yaml
+  - priorityclass.yaml
   - pvcs.yaml
   - services.yaml
   - httproute.yaml

--- a/my-apps/development/radar-ng/priorityclass.yaml
+++ b/my-apps/development/radar-ng/priorityclass.yaml
@@ -1,0 +1,13 @@
+# Owned here, not by a shared app: a stale render in another Application left every
+# pod in this namespace rejected with "no PriorityClass with name app-critical was found".
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: app-critical
+  annotations:
+    description: "Production data pipelines: above general homelab apps, below primary AI workloads"
+    # Cluster-scoped and referenced by every workload here, so it must exist before them.
+    argocd.argoproj.io/sync-wave: "-5"
+value: 500
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority


### PR DESCRIPTION
## The bug I shipped in #2204

`app-critical` was defined in `infrastructure/controllers/gpu-priority-classes` (wave 4) but referenced by workloads in `my-apps/development/radar-ng` (wave 6). Wave ordering was correct, but that is not enough: an Application can report `Synced` at a stale revision, and the next wave proceeds anyway.

That is exactly what happened during the radar-ng namespace rebuild. The priority-class app was serving a render from before the merge, so the class did not exist, and every pod was rejected:

```
Error creating: pods "tile-server-87d799768-" is forbidden:
  no PriorityClass with name app-critical was found
```

Nothing in the namespace could start — not the workers, not the tile server. It needed a manual hard refresh of a *different* application to unblock.

## Fix

radar-ng is the only consumer, so it now owns the definition in its own directory at `sync-wave: -5`, ahead of every workload that names it. The three GPU classes stay shared and unchanged.

Beyond removing the stale-render coupling, this also makes app deletion coherent: tonight the radar-ng Application was deleted and recreated, and a self-owned PriorityClass is removed and recreated with it rather than leaving pods pointing at a reference no app is guaranteed to restore.

If a second app ever needs this class, promote it back to a shared location deliberately rather than by accident.

## Validation

- Full-repo aggregate render: 101 directories, `fail=0`.
- `app-critical` is defined exactly **once** across the entire repo.
- Renders in radar-ng as `value=500, wave=-5`; the GPU app now renders only its three `gpu-workload-*` classes.
- `validate-argocd-apps.sh` PASSED; `validate-vpa-policies.py` 0 errors; `validate-kopiur-coverage.py` OK.

## Sync note

The wave-4 app prunes the class before the wave-6 app recreates it, so there is a brief window where it does not exist. Any pod created in that window gets the `FailedCreate` above, and the ReplicaSet controller retries until it succeeds — the same self-healing retry observed during the incident. No manual step required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1L7LjtxSVaLdDpyuhpq3D
