### PR TITLE
docs(ai): capture current Pi.dev launcher setup

### DIFF
--- a/docs/domains/ai-gpu/model-catalog.md
+++ b/docs/domains/ai-gpu/model-catalog.md
@@ -72,7 +72,8 @@ imported n8n workflows.
 
 Git-managed consumers should use `llama-cpp-service` directly. Current direct
 consumers include Open WebUI, Perplexica/Vane, LiteLLM, Presenton, SurfSense,
-HolmesGPT, Hindsight, Project Nomad, and the ComfyUI vision bridge.
+HolmesGPT, Hindsight, Project Nomad, the ComfyUI vision bridge, WorldMonitor,
+Keep, Deal Scout, Karakeep, and the News Reader Temporal worker.
 
 ## Pi.dev
 
@@ -82,6 +83,19 @@ Pi.dev uses the same `qwen3.8-27b` API id through
 `enable_thinking` from its valid effort values (`low`, `medium`, `xhigh`), Pi
 uses explicit `chat_template_kwargs` so `off` really disables thinking and
 `medium` is the normal coding default.
+
+The workstation launchers are:
+
+```bash
+alias pi-qwen-only='pi --model vanillax-llama/qwen3.8-27b --thinking medium'
+alias pi-withk3='pi --model vanillax-litellm/kimi-k3'
+```
+
+`pi-qwen-only` is the clean local-Qwen path. `pi-withk3` starts on Kimi K3 but
+keeps Qwen available through `/model` because both are enabled in Pi settings.
+Old Pi sessions created under the retired `vanillax-vllm` provider can retain
+that provider name in session metadata; use a new session when validating the
+current llama.cpp provider.
 
 ## Rollback
 

--- a/docs/domains/ai-gpu/pi-agent-local-dev.md
+++ b/docs/domains/ai-gpu/pi-agent-local-dev.md
@@ -172,7 +172,43 @@ Current Pi supports both `defaultThinkingLevel` and per-model
 `modelThinkingLevels`; keeping the per-model value means this Qwen model starts
 at medium even if another provider later uses a different global default.
 
-## 4. Start and verify
+## 4. Workstation launchers (`~/.zshrc`)
+
+The workstation uses two convenience aliases:
+
+```bash
+alias pi-qwen-only='pi --model vanillax-llama/qwen3.8-27b --thinking medium'
+alias pi-withk3='pi --model vanillax-litellm/kimi-k3'
+```
+
+`pi-qwen-only` always starts a fresh Qwen session on the local llama.cpp backend
+with medium reasoning. `pi-withk3` starts on Kimi K3 through LiteLLM; because
+both models remain enabled in Pi settings, `/model` can still switch that
+session to `vanillax-llama/qwen3.8-27b` when needed.
+
+Persist the aliases in `~/.zshrc`, then reload the shell:
+
+```bash
+source ~/.zshrc
+
+type pi-qwen-only
+type pi-withk3
+```
+
+Expected:
+
+```text
+pi-qwen-only is an alias for pi --model vanillax-llama/qwen3.8-27b --thinking medium
+pi-withk3 is an alias for pi --model vanillax-litellm/kimi-k3
+```
+
+If an existing Pi session was created before the provider rename, resuming it
+may still show `vanillax-vllm` in the status bar because the session metadata
+stores the old provider identity. That does **not** mean the new provider config
+failed. Use a new session for clean llama.cpp validation rather than reusing an
+old `vanillax-vllm` session.
+
+## 5. Start and verify
 
 Normal launch after the settings change:
 
@@ -186,16 +222,23 @@ Explicit launch while validating:
 pi --provider vanillax-llama --model qwen3.8-27b --thinking medium
 ```
 
-Or:
+Or use the workstation launcher:
 
 ```bash
-pi --model vanillax-llama/qwen3.8-27b --thinking medium
+pi-qwen-only
 ```
 
 Check discovery:
 
 ```bash
 pi --list-models qwen3.8-27b
+```
+
+Expected model row:
+
+```text
+provider        model        context  max-out  thinking  images
+vanillax-llama  qwen3.8-27b  65.5K    16.4K    yes       yes
 ```
 
 Inside Pi, `/model` should show `vanillax-llama/qwen3.8-27b`, and the statusline
@@ -211,7 +254,7 @@ Read package.json and summarize the scripts. Do not guess; use the read tool.
 You should see a real `read` tool call. Then test a small edit in a disposable
 branch and require Pi to run the relevant tests/typecheck.
 
-## 5. Verify reasoning control directly
+## 6. Verify reasoning control directly
 
 ```bash
 pi --model vanillax-llama/qwen3.8-27b --thinking off \
@@ -224,7 +267,7 @@ pi --model vanillax-llama/qwen3.8-27b --thinking medium \
 If Pi says `off` but the backend still emits a reasoning block, inspect the
 request/backend logs before changing model flags.
 
-## 6. Current date/time in Pi
+## 7. Current date/time in Pi
 
 Pi's model is not a clock. Do not trust Qwen to infer today's date from model
 training, file timestamps, or session text.
@@ -248,7 +291,7 @@ What is today's date? Verify with the shell before answering.
 
 You should see a bash call to `date` rather than a guessed date.
 
-## 7. Vision / screenshot test
+## 8. Vision / screenshot test
 
 The production backend has the BF16 multimodal projector enabled. Attach a
 screenshot/image in Pi and ask a concrete question about it.
@@ -262,7 +305,7 @@ kubectl -n llama-cpp exec deploy/llama-cpp-server -- nvidia-smi
 
 Do not point Pi at ComfyUI for vision; `qwen3.8-27b` itself is multimodal.
 
-## 8. Context discipline
+## 9. Context discipline
 
 The server has one 65,536-token slot. Local token **volume** is free, but a
 single request still has a finite context window.
@@ -278,7 +321,7 @@ For coding agents:
 The current backend is optimized for strong single-user interactive latency,
 not high-concurrency serving.
 
-## 9. Your installed Pi packages
+## 10. Your installed Pi packages
 
 Your existing package list can stay. Packages/extensions add prompt/tool
 surface area, so keep only things you actually use, but there is no backend
@@ -295,7 +338,7 @@ For Kubernetes/Talos work, native CLIs through Pi's bash tool (`kubectl`,
 `talosctl`, `argocd`, `gh`, `jq`) are usually more context-efficient than
 loading a huge MCP catalog.
 
-## 10. Optional global `~/.pi/agent/AGENTS.md`
+## 11. Optional global `~/.pi/agent/AGENTS.md`
 
 ```markdown
 # Environment
@@ -319,7 +362,7 @@ loading a huge MCP catalog.
 Pi discovers project context files, so this repo's existing instruction files
 remain useful; do not duplicate the whole repository policy globally.
 
-## 11. Backend source of truth
+## 12. Backend source of truth
 
 Pi should not carry backend tuning beyond capability metadata. Runtime tuning
 lives in:


### PR DESCRIPTION
Updates the AI docs to match the workstation and live-consumer state after the llama.cpp cutover.

- documents the permanent zsh launchers:
  - `pi-qwen-only` -> `vanillax-llama/qwen3.8-27b --thinking medium`
  - `pi-withk3` -> `vanillax-litellm/kimi-k3`
- explains that `pi-withk3` can still switch to Qwen through `/model`
- records the expected `pi --list-models qwen3.8-27b` output
- notes that old Pi sessions created under `vanillax-vllm` can retain that provider name in saved session metadata even after the provider migration
- refreshes the model catalog's direct-consumer list with the five applications rewired in #2207: WorldMonitor, Keep, Deal Scout, Karakeep, and News Reader

Docs only; no runtime, model, routing, or consumer configuration changes.