### PR TITLE
power: add last-month totals, move September to the non-summer rate

### DIFF
--- a/docs/domains/power/metering.md
+++ b/docs/domains/power/metering.md
@@ -60,11 +60,11 @@ device watts ──integration──▶ kWh ──utility_meter──▶ daily /
 The all-in marginal rate is `(energy + delivery riders) × (1 + sales tax)`. The
 energy component steps between three windows:
 
-| Window | When |
-|---|---|
-| Summer on-peak | June–September, weekdays 14:00–19:00 |
-| Summer off-peak | June–September, all other hours |
-| Non-summer | October–May |
+| Window | When | All-in rate |
+|---|---|---|
+| Summer on-peak | June–August, weekdays 14:00–19:00 | ~$0.289 |
+| Summer off-peak | June–August, all other hours | ~$0.238 |
+| Non-summer | September–May | ~$0.216 |
 
 Rates live in `my-apps/home/home-assistant/configuration.yaml` under
 `input_number:`. **Git is the source of truth** — the `initial:` values reset the
@@ -74,6 +74,25 @@ the file, not the dashboard.
 Cost integrates a live USD/hour rate rather than applying a flat tariff after
 the fact, so a workload that runs only during on-peak hours is priced at on-peak
 rates.
+
+### Last month, and other finished totals
+
+The `*_monthly` sensors are month-to-date and reset on the 1st, so they are the
+wrong thing to compare against a bill. Home Assistant's `utility_meter` keeps the
+previous cycle in a `last_period` attribute, and template sensors surface it:
+
+| Sensor | What it holds |
+|---|---|
+| `sensor.homelab_cost_last_month` | Last calendar month's finished total |
+| `sensor.homelab_total_energy_last_month` | Last month's kWh |
+| `sensor.homelab_cost_yesterday` | Yesterday's finished cost |
+| `sensor.<prefix>_cost_last_month` | Per-device, last month |
+| `sensor.<prefix>_energy_last_month` | Per-device, last month |
+
+These stop moving once the cycle closes, which is what makes them comparable
+month to month. The dashboards' *This Month vs Last* panel subtracts one from the
+other — expect it to read negative early in the month, since a young month has
+simply not accrued yet.
 
 ## Where to look
 

--- a/monitoring/prometheus-stack/dashboards/homelab-power.json
+++ b/monitoring/prometheus-stack/dashboards/homelab-power.json
@@ -1101,6 +1101,442 @@
       "id": 17
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 18,
+      "title": "Last completed month",
+      "type": "row",
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Cost Last Month",
+      "description": "The finished total for the previous calendar month, from utility_meter's last_period. Unlike Cost This Month it no longer moves.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.homelab_cost_last_month\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 32
+      },
+      "id": 19
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Energy Last Month",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "kwatth",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.homelab_total_energy_last_month\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 32
+      },
+      "id": 20
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Cost Yesterday",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 4
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.homelab_cost_yesterday\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 32
+      },
+      "id": 21
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "This Month vs Last",
+      "description": "Month-to-date minus last month's finished total. Negative early in the month is normal \u2014 it only means the month is young, not that costs fell.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.homelab_cost_monthly\"}) - max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.homelab_cost_last_month\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 32
+      },
+      "id": 22
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "bargauge",
+      "title": "Cost Last Month \u2014 Per Device",
+      "description": "Last month's finished cost, per device.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sortBy": "Value",
+        "sortDesc": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_unit_usd{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_cost_last_month\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_cost_last_month\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "legendFormat": "{{plug}}",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "id": 23
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "bargauge",
+      "title": "Energy Last Month \u2014 Per Device",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "kwatth",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sortBy": "Value",
+        "sortDesc": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_energy_kwh{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_energy_last_month\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_energy_last_month\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "legendFormat": "{{plug}}",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 24
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 25,
+      "title": "Annualised what-ifs",
+      "type": "row",
+      "panels": []
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -1171,9 +1607,9 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 31
+        "y": 46
       },
-      "id": 18
+      "id": 26
     },
     {
       "datasource": {
@@ -1234,9 +1670,9 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 31
+        "y": 46
       },
-      "id": 19
+      "id": 27
     },
     {
       "collapsed": false,
@@ -1244,9 +1680,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 53
       },
-      "id": 20,
+      "id": 28,
       "title": "Idle floor \u2014 what it costs to do nothing",
       "type": "row",
       "panels": []
@@ -1321,9 +1757,9 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 39
+        "y": 54
       },
-      "id": 21
+      "id": 29
     },
     {
       "datasource": {
@@ -1395,9 +1831,9 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 39
+        "y": 54
       },
-      "id": 22
+      "id": 30
     },
     {
       "datasource": {
@@ -1469,9 +1905,9 @@
         "h": 6,
         "w": 6,
         "x": 12,
-        "y": 39
+        "y": 54
       },
-      "id": 23
+      "id": 31
     },
     {
       "datasource": {
@@ -1531,9 +1967,9 @@
         "h": 6,
         "w": 6,
         "x": 18,
-        "y": 39
+        "y": 54
       },
-      "id": 24
+      "id": 32
     },
     {
       "collapsed": false,
@@ -1541,9 +1977,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 60
       },
-      "id": 25,
+      "id": 33,
       "title": "Usage over time",
       "type": "row",
       "panels": []
@@ -1609,9 +2045,9 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 61
       },
-      "id": 26
+      "id": 34
     },
     {
       "datasource": {
@@ -1696,9 +2132,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 55
+        "y": 70
       },
-      "id": 27
+      "id": 35
     },
     {
       "datasource": {
@@ -1772,9 +2208,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 55
+        "y": 70
       },
-      "id": 28
+      "id": 36
     },
     {
       "datasource": {
@@ -1837,9 +2273,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 63
+        "y": 78
       },
-      "id": 29
+      "id": 37
     },
     {
       "datasource": {
@@ -1902,9 +2338,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 63
+        "y": 78
       },
-      "id": 30
+      "id": 38
     },
     {
       "collapsed": false,
@@ -1912,9 +2348,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 71
+        "y": 86
       },
-      "id": 31,
+      "id": 39,
       "title": "Electrical",
       "type": "row",
       "panels": []
@@ -1980,9 +2416,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 72
+        "y": 87
       },
-      "id": 32
+      "id": 40
     },
     {
       "datasource": {
@@ -2045,9 +2481,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 72
+        "y": 87
       },
-      "id": 33
+      "id": 41
     },
     {
       "collapsed": false,
@@ -2055,9 +2491,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 80
+        "y": 95
       },
-      "id": 34,
+      "id": 42,
       "title": "Reading this dashboard",
       "type": "row",
       "panels": []
@@ -2074,9 +2510,9 @@
         "h": 15,
         "w": 24,
         "x": 0,
-        "y": 81
+        "y": 96
       },
-      "id": 35
+      "id": 43
     }
   ],
   "refresh": "30s",

--- a/my-apps/home/home-assistant/configuration.yaml
+++ b/my-apps/home/home-assistant/configuration.yaml
@@ -547,6 +547,7 @@ template:
   - sensor:
       # now()-based templates re-render every minute; float(<bill default>) keeps this right
       # before the input_number sliders are first touched.
+      # Summer is June-August: September bills at the non-summer rate.
       - name: "Current Electricity Rate"
         unique_id: current_electricity_rate
         unit_of_measurement: "USD/kWh"
@@ -554,7 +555,7 @@ template:
         icon: mdi:cash-multiple
         state: >
           {% set n = now() %}
-          {% set summer = n.month in [6, 7, 8, 9] %}
+          {% set summer = n.month in [6, 7, 8] %}
           {% set onpeak = summer and n.weekday() < 5 and 14 <= n.hour < 19 %}
           {% if onpeak %}
             {% set e = states('input_number.rate_summer_onpeak') | float(0.151904) %}
@@ -572,7 +573,7 @@ template:
         icon: mdi:clock-outline
         state: >
           {% set n = now() %}
-          {% set summer = n.month in [6, 7, 8, 9] %}
+          {% set summer = n.month in [6, 7, 8] %}
           {% set onpeak = summer and n.weekday() < 5 and 14 <= n.hour < 19 %}
           {% if onpeak %}Summer On-Peak
           {% elif summer %}Summer Off-Peak
@@ -705,6 +706,143 @@ template:
         state: >
           {{ (states('sensor.hp_elite_estimated_current_consumption') | float(0) / 1000
             * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
+
+      # ----- last completed month (utility_meter last_period) -----
+      - name: "GPU PSU Cost Last Month"
+        unique_id: gpu_psu_cost_last_month
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:calendar-check
+        state: >
+          {{ state_attr('sensor.gpu_psu_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "NAS PSU Cost Last Month"
+        unique_id: nas_psu_cost_last_month
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:calendar-check
+        state: >
+          {{ state_attr('sensor.nas_psu_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "TrueNAS Server Cost Last Month"
+        unique_id: truenas_server_cost_last_month
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:calendar-check
+        state: >
+          {{ state_attr('sensor.truenas_server_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "HP SFF Cost Last Month"
+        unique_id: hp_sff_cost_last_month
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:calendar-check
+        state: >
+          {{ state_attr('sensor.hp_sff_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "Shed Lab Cost Last Month"
+        unique_id: shed_lab_cost_last_month
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:calendar-check
+        state: >
+          {{ state_attr('sensor.shed_lab_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "Gaming PC Cost Last Month"
+        unique_id: gaming_pc_cost_last_month
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:calendar-check
+        state: >
+          {{ state_attr('sensor.gaming_pc_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "HP Elite Estimated Cost Last Month"
+        unique_id: hp_elite_estimated_cost_last_month
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:calendar-check
+        state: >
+          {{ state_attr('sensor.hp_elite_estimated_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "GPU PSU Energy Last Month"
+        unique_id: gpu_psu_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.gpu_psu_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "NAS PSU Energy Last Month"
+        unique_id: nas_psu_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.nas_psu_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "TrueNAS Server Energy Last Month"
+        unique_id: truenas_server_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.truenas_server_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "HP SFF Energy Last Month"
+        unique_id: hp_sff_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.hp_sff_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "Shed Lab Energy Last Month"
+        unique_id: shed_lab_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.shed_lab_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "Gaming PC Energy Last Month"
+        unique_id: gaming_pc_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.gaming_pc_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "HP Elite Estimated Energy Last Month"
+        unique_id: hp_elite_estimated_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.hp_elite_estimated_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "Homelab Cost Last Month"
+        unique_id: homelab_cost_last_month
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:calendar-check
+        state: >
+          {{ state_attr('sensor.homelab_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "Homelab Cost Yesterday"
+        unique_id: homelab_cost_yesterday
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:calendar-arrow-left
+        state: >
+          {{ state_attr('sensor.homelab_cost_daily', 'last_period') | float(0) | round(4) }}
+
+      - name: "Homelab Total Energy Last Month"
+        unique_id: homelab_total_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.homelab_total_energy_monthly', 'last_period') | float(0) | round(3) }}
 
       # ----- live % of total draw (entity slug == *_power_share) -----
       - name: "GPU PSU Power Share"

--- a/my-apps/home/home-assistant/lovelace-homelab-power.yaml
+++ b/my-apps/home/home-assistant/lovelace-homelab-power.yaml
@@ -85,6 +85,54 @@ views:
           - entity: sensor.homelab_cost_yearly
             name: This Year
 
+      - type: glance
+        title: Last completed month
+        show_state: true
+        columns: 3
+        entities:
+          - entity: sensor.homelab_cost_last_month
+            name: Cost last month
+          - entity: sensor.homelab_total_energy_last_month
+            name: Energy last month
+          - entity: sensor.homelab_cost_yesterday
+            name: Cost yesterday
+
+      - type: entities
+        title: Cost last month — per device
+        entities:
+          - entity: sensor.gpu_psu_cost_last_month
+            name: Threadripper Host
+          - entity: sensor.nas_psu_cost_last_month
+            name: NAS Drive PSU
+          - entity: sensor.truenas_server_cost_last_month
+            name: TrueNAS (DL360)
+          - entity: sensor.hp_sff_cost_last_month
+            name: HP SFF + Optiplex
+          - entity: sensor.shed_lab_cost_last_month
+            name: Shed (HP micro, solar)
+          - entity: sensor.gaming_pc_cost_last_month
+            name: Gaming PC (7800X3D + 3090)
+          - entity: sensor.hp_elite_estimated_cost_last_month
+            name: HP Elite (estimated)
+
+      - type: entities
+        title: Energy last month — per device
+        entities:
+          - entity: sensor.gpu_psu_energy_last_month
+            name: Threadripper Host
+          - entity: sensor.nas_psu_energy_last_month
+            name: NAS Drive PSU
+          - entity: sensor.truenas_server_energy_last_month
+            name: TrueNAS (DL360)
+          - entity: sensor.hp_sff_energy_last_month
+            name: HP SFF + Optiplex
+          - entity: sensor.shed_lab_energy_last_month
+            name: Shed (HP micro, solar)
+          - entity: sensor.gaming_pc_energy_last_month
+            name: Gaming PC (7800X3D + 3090)
+          - entity: sensor.hp_elite_estimated_energy_last_month
+            name: HP Elite (estimated)
+
       - type: grid
         title: Share of total draw
         columns: 3


### PR DESCRIPTION
Follow-up to #2210.

## September was billing at the summer rate

The rate model treated months 6–9 as summer, so the live all-in rate read **$0.23835** (summer off-peak) when the actual rate is ~21¢/kWh. Summer is **June–August** here, which puts September on the non-summer leg at **$0.21612**. On-peak/off-peak still applies June–August.

| Window | When | All-in rate |
|---|---|---|
| Summer on-peak | June–August, weekdays 14:00–19:00 | ~$0.289 |
| Summer off-peak | June–August, all other hours | ~$0.238 |
| Non-summer | September–May | ~$0.216 |

## Last month was missing

The `*_monthly` sensors are month-to-date and reset on the 1st, so nothing on the dashboards showed a **finished** month you could hold against a bill.

`utility_meter` already keeps the previous cycle in its `last_period` attribute, so this surfaces it directly rather than trying to reconstruct it from Prometheus history:

| Sensor | What it holds |
|---|---|
| `homelab_cost_last_month` | Last calendar month's finished total |
| `homelab_total_energy_last_month` | Last month's kWh |
| `homelab_cost_yesterday` | Yesterday's finished cost |
| `<prefix>_cost_last_month` | Per-device, last month |
| `<prefix>_energy_last_month` | Per-device, last month |

These stop moving once the cycle closes, which is what makes them comparable month to month.

Grafana gains a **Last completed month** row — cost, energy, yesterday, and a this-month-vs-last delta — plus per-device leaderboards. The annualised what-if panels move under their own row so they aren't mistaken for finished figures. Lovelace gains the same cards.

One caveat worth knowing: *This Month vs Last* reads negative early in the month. That means the month is young, not that costs fell.

## Generator bug

The config generator split `configuration.yaml` on comment text that the previous run had itself rewritten. Re-running appended a second copy of every generated block instead of replacing it. It now regenerates from a pristine base and splits on top-level keys — verified idempotent across repeated runs.

## Verification

- **43 dashboard queries run against live Prometheus.** All seven devices resolve with correct legends. The only empty results are the new `last_period` sensors, which don't exist until Home Assistant restarts.
- Both kustomizations build clean; every meter and integration source resolves; all `state_attr` targets point at real `utility_meter` entities.

## Deploying

```
kubectl rollout restart deployment/home-assistant -n home-assistant
```

The last-month sensors read zero until the first cycle closes on Oct 1 — `last_period` has nothing in it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UR94eADHzmr6xmFVi59vww
