### PR TITLE
power: rebuild metering around the seven real plugs, split homelab from office

### DIFF
--- a/docs/domains/power/metering.md
+++ b/docs/domains/power/metering.md
@@ -1,51 +1,43 @@
 # Power & Cost Metering
 
-Every always-on box in the homelab sits behind a TP-Link Tapo P115 smart plug.
-Home Assistant reads watts from each plug, integrates them into kWh, prices that
-against the live time-of-use electricity rate, and exposes the result to
-Grafana. This page is the map of what is metered, what it costs, and how to add
-a plug.
+Every always-on box and both office workstations sit behind a TP-Link Tapo P115
+smart plug. Home Assistant reads watts from each plug, integrates them into kWh,
+prices that against the live time-of-use electricity rate, and exposes the
+result to Grafana. This page is the map of what is metered, how it is grouped,
+what it costs, and how to add a plug.
 
 ## What is metered
 
-| Plug (HA device) | Entity prefix | What it powers |
+| Plug (HA device) | Entity prefix | Group | What it powers |
+|---|---|---|---|
+| Threadripper Host | `threadripper_*` | homelab | Threadripper X399 host (`192.168.10.14`): GPU worker + general worker VMs, 1x RTX 3090 |
+| NAS Drive PSU | `nas_psu_*` | homelab | The drive-shelf PSU for the NAS |
+| TrueNAS (DL360) | `truenas_*` | homelab | The TrueNAS/DL360 host itself (`192.168.10.133`) |
+| HP SFF + Optiplex | `hp_sff_*` | homelab | **Two hosts on one outlet**: HP 8500 SFF (`.21`) and Dell Optiplex 8500 |
+| HP Elite Mini G9 | `hp_elite_*` | homelab | HP Elite Mini 600 G9 (`.22`) |
+| Gaming PC | `gaming_pc_*` | office | 7800X3D workstation with the second RTX 3090. **Not a cluster node** |
+| MacBook + Monitor | `macbook_*` | office | Office desk |
+
+**Not metered:** the HP micro in the shed (`.20`). It runs off its own solar and
+battery bank, has no plug, and would cost nothing on the bill anyway. Its supply
+side (MPPT yield, battery bank voltage and state of charge) lives in the separate
+Grafana **Solar MPPT Monitor** dashboard (`solar-mppt-monitor`).
+
+Household plugs (dryer, TV, office lamps, the garage fridge) exist in Home
+Assistant but are outside this accounting: the Prometheus filter only exports
+the prefixes above.
+
+### Groups
+
+| Group | Members | Use it for |
 |---|---|---|
-| threadripper-gpus | `gpu_psu_*` | Threadripper X399 host (`192.168.10.14`) — GPU worker + general worker VMs, 1x RTX 3090 |
-| Nas psu | `nas_psu_*` | The drive-shelf PSU for the NAS |
-| Truenas Server | `truenas_server_*` | The TrueNAS/DL360 host itself (`192.168.10.133`) |
-| HP SFF | `hp_sff_*` | **Two hosts on one outlet**: HP SFF (`.21`) and Dell Optiplex (`.16`) |
-| Shed Lab | `shed_lab_*` | HP micro in the shed (`.20`), solar-fed, behind the Wi-Fi bridge |
-| Gaming PC | `gaming_pc_*` | 7800X3D workstation with the second RTX 3090 — **not a cluster node** |
-| *(none)* | `hp_elite_estimated_*` | HP Elite Mini 600 G9 (`.22`) — **no plug; a tunable assumed figure**, see below |
+| `homelab_*` | The five always-on servers | The number to compare against the bill |
+| `office_*` | Gaming PC + MacBook | Workstations. Metered and priced, but not locked on, so expected to swing to zero |
+| `combined_*` | Everything | Total household draw from metered plugs |
 
-Two plugs exist but are deliberately outside the homelab accounting: the garage
-fridge (which confusingly still carries the `basement_homelab_*` entity prefix
-from an earlier name) and the household plugs. Both are filtered out in
-`configuration.yaml`.
-
-> **Entity prefixes are frozen.** `gpu_psu` is the Threadripper host and
-> `basement_homelab` is a fridge. Renaming an entity prefix orphans every
-> statistic recorded under it, so the real hardware is named in `friendly_name`
-> (`customize.yaml`) instead.
-
-### The two figures that are not measurements
-
-**HP Elite is estimated, not metered.** It has no smart plug, so its draw is a
-flat number from `input_number.hp_elite_estimated_watts` (default **30 W**).
-That default is a working figure, not a reading: ServeTheHome measured the same
-Elite Mini 600 G9 chassis at 4–5.5 W idle and 60–65 W under load, and this host
-runs a Talos worker continuously rather than idling. Adjust the input to taste —
-or better, fit a plug and delete the estimate. Its entities are deliberately
-prefixed `hp_elite_estimated_*` so a future plug named "HP Elite" lands on a
-clean `hp_elite_*` prefix without colliding.
-
-**The shed costs nothing.** It runs off its own solar and battery bank, so
-`shed_lab_cost_rate` is pinned to zero: the shed contributes watts and kWh to
-the totals but never dollars. Everything priced in this system is based on
-`sensor.homelab_grid_power` — total draw minus the solar-fed plugs — not on
-`homelab_total_power`. What the shed's own supply is doing (MPPT yield, battery
-bank voltage and state of charge) lives in the separate Grafana **Solar MPPT
-Monitor** dashboard (`solar-mppt-monitor`).
+Each group has `<group>_total_power`, `<group>_total_energy` (with
+daily/weekly/monthly/yearly meters), `<group>_cost_rate`, `<group>_cost` (same
+meters), and the finished-period sensors below.
 
 ## How cost is computed
 
@@ -53,8 +45,6 @@ Monitor** dashboard (`solar-mppt-monitor`).
 device watts ──integration──▶ kWh ──utility_meter──▶ daily / weekly / monthly / yearly kWh
       │
       └──× current all-in rate──▶ USD/h ──integration──▶ USD ──utility_meter──▶ daily / … / yearly USD
-                                   ▲
-                          pinned to 0 for solar-fed devices
 ```
 
 The all-in marginal rate is `(energy + delivery riders) × (1 + sales tax)`. The
@@ -67,7 +57,7 @@ energy component steps between three windows:
 | Non-summer | September–May | ~$0.216 |
 
 Rates live in `my-apps/home/home-assistant/configuration.yaml` under
-`input_number:`. **Git is the source of truth** — the `initial:` values reset the
+`input_number:`. **Git is the source of truth**: the `initial:` values reset the
 UI sliders on every Home Assistant restart, so a permanent rate change goes in
 the file, not the dashboard.
 
@@ -75,7 +65,7 @@ Cost integrates a live USD/hour rate rather than applying a flat tariff after
 the fact, so a workload that runs only during on-peak hours is priced at on-peak
 rates.
 
-### Last month, and other finished totals
+### Finished periods
 
 The `*_monthly` sensors are month-to-date and reset on the 1st, so they are the
 wrong thing to compare against a bill. Home Assistant's `utility_meter` keeps the
@@ -83,83 +73,91 @@ previous cycle in a `last_period` attribute, and template sensors surface it:
 
 | Sensor | What it holds |
 |---|---|
-| `sensor.homelab_cost_last_month` | Last calendar month's finished total |
-| `sensor.homelab_total_energy_last_month` | Last month's kWh |
-| `sensor.homelab_cost_yesterday` | Yesterday's finished cost |
+| `sensor.<group>_cost_last_month` | Last calendar month's finished total |
+| `sensor.<group>_total_energy_last_month` | Last month's kWh |
+| `sensor.<group>_cost_yesterday` | Yesterday's finished cost |
 | `sensor.<prefix>_cost_last_month` | Per-device, last month |
 | `sensor.<prefix>_energy_last_month` | Per-device, last month |
 
-These stop moving once the cycle closes, which is what makes them comparable
-month to month. The dashboards' *This Month vs Last* panel subtracts one from the
-other — expect it to read negative early in the month, since a young month has
-simply not accrued yet.
+These stop moving once the cycle closes. The dashboards' *This Month vs Last*
+panel subtracts one from the other; expect it to read negative early in the
+month, since a young month has not accrued yet.
 
 ## Where to look
 
 | Surface | What it is |
 |---|---|
-| Grafana **Homelab Power & Cost** (`homelab-power-cost`) | The main view: live and billable draw, cost today/month/year, hot-spot leaderboard, idle-floor analysis, and a "reading this dashboard" panel |
-| Grafana **Tapo Power Monitor** (`tapo-power-monitor`) | Raw per-plug telemetry — watts, volts, amps, energy today |
-| Grafana **Solar MPPT Monitor** (`solar-mppt-monitor`) | The shed's supply side: Epever MPPT yield and Daly BMS battery bank |
+| Grafana **Homelab Power & Cost** (`homelab-power-cost`) | The main view: homelab and office draw, cost today/month/year, hot-spot leaderboard, idle-floor analysis, and a "reading this dashboard" panel |
+| Grafana **Tapo Power Monitor** (`tapo-power-monitor`) | Raw per-plug telemetry: watts, volts, amps, energy today |
 | Home Assistant **Homelab Power** dashboard | Same numbers inside HA, plus the editable rate inputs |
-| HA **Energy** dashboard | Configured in the UI; add each `sensor.<prefix>_energy` as an Individual device |
+| HA **Energy** dashboard | Configured in the UI; each `sensor.<prefix>_energy` is an Individual device |
+
+### How Grafana names a plug
+
+The dashboards do not carry a device list. Every query selects the entity IDs
+for its group and derives the display name from the metric's `friendly_name`
+label by stripping the trailing metric words (`Power`, `Energy`, `Cost`,
+`Voltage`, `Current`, `Share`). That is why `customize.yaml` sets every
+friendly name to `<Device> <Metric ...>`, and why a device display name must
+not itself contain one of those words.
 
 ### Reading the numbers
 
 **The idle floor is the bill.** Peak draw is brief; the 24-hour minimum runs
 8,760 hours a year. When the *Baseline Cost / Year* panel accounts for most of
-*Cost This Year*, workload tuning will not move the number — only removing or
+*Cost This Year*, workload tuning will not move the number. Only removing or
 consolidating hardware does.
 
 **Run-rate panels are what-ifs, not forecasts.** *Run-Rate / Year* and *Cost /
 Year If Left At This Draw* annualise the current instant to answer "what does
-leaving this on cost me?". Use *Cost This Month* for an actual bill estimate.
+leaving this on cost me?". Use *Cost This Month* or *Cost Last Month* for a bill
+estimate.
 
 **The HP SFF plug cannot be attributed.** It feeds two hosts. Split the outlet
 before concluding which of the two to retire.
 
-**Total draw and billable draw are different numbers.** *Total Power Now*
-includes the solar shed; *Billable Draw* does not, and every cost figure follows
-the billable line.
-
 ## Safety: the power-off lockout
 
-The `Homelab plug power-off lockout` automation turns any always-on plug back on
-if it is switched off, and raises a persistent notification. It covers the
-Threadripper, NAS PSU, TrueNAS, HP SFF and Shed plugs. The Gaming PC plug is
-deliberately excluded — that machine is meant to be powered down.
+The `Homelab plug power-off lockout` automation turns any homelab plug back on
+if it is switched off and raises a persistent notification. It covers the five
+homelab plugs. The office plugs are deliberately excluded: those machines are
+meant to be powered down.
 
 Hiding a switch via `customize.yaml` is cosmetic only; the automation is the
 real enforcement. **To intentionally power-cycle a plug, disable the automation
 first.**
 
-> The automation triggers on switch entity IDs (`switch.gpu_psu`,
-> `switch.hp_sff`, …). A typo there fails silently — the automation loads fine
+> The automation triggers on switch entity IDs (`switch.threadripper`,
+> `switch.hp_sff`, …). A typo there fails silently: the automation loads fine
 > and simply never fires. Verify a change against
 > **Developer Tools → States** before trusting it.
 
 ## Adding a plug
 
 1. Adopt the plug in the Tapo app, then add it to Home Assistant through the
-   TP-Link integration. Note the entity prefix Home Assistant derives from the
-   device name — that prefix is permanent.
-2. In `my-apps/home/home-assistant/configuration.yaml`, add the prefix to
-   `prometheus.filter.include_entity_globs`, then add its energy integration,
-   cost integration, four energy `utility_meter`s, four cost `utility_meter`s,
-   a `*_cost_rate` template, a `*_power_share` template, and a
-   `*_energy_share_today` template. Add it to the `Homelab Total Power` and
-   `Homelab Total Energy Today` sums.
-3. Add `friendly_name` entries in `customize.yaml`, and the switch to the
-   lockout automation if the device must stay on.
-4. Add it to `lovelace-homelab-power.yaml` and to the device list in both
-   Grafana dashboards under `monitoring/prometheus-stack/dashboards/`. Those are
-   plain `.json` files assembled into ConfigMaps by `configMapGenerator`, not
-   JSON embedded in YAML — edit the `.json`, never a rendered manifest.
+   TP-Link integration. Rename the device in HA to the display name you want,
+   then rename its entities so they share one short prefix (`sensor.<prefix>_current_consumption`,
+   `switch.<prefix>`, …). The prefix is permanent: renaming it later orphans
+   every statistic recorded under it.
+2. In `my-apps/home/home-assistant/configuration.yaml`, add
+   `sensor.<prefix>_*` to `prometheus.filter.include_entity_globs`, then add its
+   energy integration, cost integration, four energy `utility_meter`s, four cost
+   `utility_meter`s, a `*_cost_rate` template, `*_cost_last_month` and
+   `*_energy_last_month` templates, and a `*_power_share` template. Add it to
+   the `Total Power` template of its group and of `combined`.
+3. Add `friendly_name` entries in `customize.yaml` (`<Device> <Metric ...>`
+   form), and the switch to the lockout automation if the device must stay on.
+4. Add it to `lovelace-homelab-power.yaml`, and to the entity regex of the
+   per-plug queries in both Grafana dashboards under
+   `monitoring/prometheus-stack/dashboards/`. Those are plain `.json` files
+   assembled into ConfigMaps by `configMapGenerator`; edit the `.json`, never a
+   rendered manifest.
+5. Add `sensor.<prefix>_energy` as an Individual device on the HA Energy dashboard.
 
 > **The `name:` slug must equal the entity prefix.** Home Assistant derives the
 > entity ID from `name:`, so `name: "HP SFF Energy"` produces
 > `sensor.hp_sff_energy`. If the slug drifts, every template and dashboard
-> reference silently reads nothing — no error, just empty panels.
+> reference silently reads nothing: no error, just empty panels.
 
 Changes reach the pod through the `config` ConfigMap and an initContainer that
 copies files onto the PVC, so **Home Assistant must restart** to pick them up:
@@ -177,4 +175,18 @@ kubectl exec -n home-assistant deploy/home-assistant -c home-assistant -- \
 ```
 
 Newly created integrations and utility meters start at zero. Totals only fill in
-as data accumulates — an empty panel on day one is expected, not a bug.
+as data accumulates; an empty panel on day one is expected, not a bug.
+
+## Resetting the history
+
+Home Assistant keeps three kinds of state, and a "start fresh" has to clear all
+three or the old totals come back:
+
+| State | Where | How to clear |
+|---|---|---|
+| Recorder history + long-term statistics | `/config/home-assistant_v2.db` (+ `-wal`, `-shm`) on the PVC | Delete the files with HA stopped; it creates a fresh DB on start |
+| Running totals of every `integration` and `utility_meter` sensor | `/config/.storage/core.restore_state` | Delete the file with HA stopped. HA rewrites it on every clean shutdown, so a `kill -9` of the `homeassistant` process after deleting is what makes it stick |
+| Grafana history | Prometheus, 15-day retention | Nothing to do; old series age out |
+
+Renaming an entity prefix is the same operation from Home Assistant's point of
+view: the new prefix starts at zero and the old one is orphaned.

--- a/monitoring/prometheus-stack/dashboards/homelab-power.json
+++ b/monitoring/prometheus-stack/dashboards/homelab-power.json
@@ -9,6 +9,8 @@
   "links": [],
   "panels": [
     {
+      "type": "row",
+      "title": "At a glance — homelab (the five always-on servers)",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -17,8 +19,6 @@
         "y": 0
       },
       "id": 1,
-      "title": "At a glance",
-      "type": "row",
       "panels": []
     },
     {
@@ -27,8 +27,8 @@
         "uid": "prometheus"
       },
       "type": "stat",
-      "title": "Total Power Now",
-      "description": "Sum of every metered plug. The HP Elite mini PC has no plug and is NOT counted.",
+      "title": "Homelab Draw Now",
+      "description": "Sum of the five server plugs.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -49,11 +49,11 @@
               },
               {
                 "color": "orange",
-                "value": 700
+                "value": 600
               },
               {
                 "color": "red",
-                "value": 1000
+                "value": 800
               }
             ]
           }
@@ -101,15 +101,15 @@
         "uid": "prometheus"
       },
       "type": "stat",
-      "title": "Burn Rate",
-      "description": "USD/hour at the current draw and the current TOU rate.",
+      "title": "Homelab Burn Rate",
+      "description": "USD per hour at the current all-in rate.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "unit": "currencyUSD",
-          "decimals": 3,
+          "decimals": 4,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -163,8 +163,8 @@
         "uid": "prometheus"
       },
       "type": "stat",
-      "title": "Cost Today",
-      "description": "Resets at midnight.",
+      "title": "Homelab Cost Today",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -189,7 +189,7 @@
               },
               {
                 "color": "red",
-                "value": 4
+                "value": 3
               }
             ]
           }
@@ -237,143 +237,7 @@
         "uid": "prometheus"
       },
       "type": "stat",
-      "title": "Billable Draw",
-      "description": "Total draw minus the solar-fed shed. This is what the cost figures price.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "unit": "watt",
-          "decimals": 1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 400
-              },
-              {
-                "color": "orange",
-                "value": 700
-              },
-              {
-                "color": "red",
-                "value": 1000
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.homelab_grid_power\"})",
-          "legendFormat": "",
-          "refId": "A",
-          "instant": true,
-          "range": false
-        }
-      ],
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 18,
-        "y": 1
-      },
-      "id": 5
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "type": "stat",
-      "title": "Energy Today",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "unit": "kwatth",
-          "decimals": 2,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.homelab_total_energy_today\"})",
-          "legendFormat": "",
-          "refId": "A",
-          "instant": true,
-          "range": false
-        }
-      ],
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 0,
-        "y": 7
-      },
-      "id": 6
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "type": "stat",
-      "title": "Cost This Month",
+      "title": "Homelab Cost This Month",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -434,12 +298,12 @@
         }
       ],
       "gridPos": {
-        "h": 5,
+        "h": 6,
         "w": 6,
-        "x": 6,
-        "y": 7
+        "x": 18,
+        "y": 1
       },
-      "id": 7
+      "id": 5
     },
     {
       "datasource": {
@@ -447,7 +311,69 @@
         "uid": "prometheus"
       },
       "type": "stat",
-      "title": "Cost This Year",
+      "title": "Homelab Energy Today",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "kwatth",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.homelab_total_energy_daily\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 7
+      },
+      "id": 6
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Homelab Cost This Year",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -510,10 +436,10 @@
       "gridPos": {
         "h": 5,
         "w": 6,
-        "x": 12,
+        "x": 6,
         "y": 7
       },
-      "id": 8
+      "id": 7
     },
     {
       "datasource": {
@@ -522,14 +448,14 @@
       },
       "type": "stat",
       "title": "Rate Now ($/kWh)",
-      "description": "All-in marginal rate: (energy + delivery riders) x (1 + tax).",
+      "description": "All-in marginal rate: (energy + riders) x (1 + tax).",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "unit": "currencyUSD",
-          "decimals": 4,
+          "decimals": 5,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -572,10 +498,10 @@
       "gridPos": {
         "h": 5,
         "w": 6,
-        "x": 18,
+        "x": 12,
         "y": 7
       },
-      "id": 9
+      "id": 8
     },
     {
       "datasource": {
@@ -583,15 +509,15 @@
         "uid": "prometheus"
       },
       "type": "stat",
-      "title": "Run-Rate / Year",
-      "description": "Annualised from the CURRENT instant billable draw \u2014 a what-if, not a forecast.",
+      "title": "Office Cost Today",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "unit": "currencyUSD",
-          "decimals": 0,
+          "decimals": 2,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -601,15 +527,15 @@
               },
               {
                 "color": "yellow",
-                "value": 300
+                "value": 1
               },
               {
                 "color": "orange",
-                "value": 600
+                "value": 2
               },
               {
                 "color": "red",
-                "value": 1000
+                "value": 3
               }
             ]
           }
@@ -636,7 +562,94 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max by (entity) (homeassistant_sensor_unit_usd_per_h{entity=\"sensor.homelab_cost_rate\"}) * 8760",
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.office_cost_daily\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 7
+      },
+      "id": 9
+    },
+    {
+      "type": "row",
+      "title": "Office (Gaming PC + MacBook) and combined",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 10,
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Office Draw Now",
+      "description": "Gaming PC + MacBook. Not locked on; expected to swing to zero.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "watt",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 400
+              },
+              {
+                "color": "orange",
+                "value": 600
+              },
+              {
+                "color": "red",
+                "value": 800
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.office_total_power\"})",
           "legendFormat": "",
           "refId": "A",
           "instant": true,
@@ -647,21 +660,243 @@
         "h": 5,
         "w": 6,
         "x": 0,
-        "y": 12
+        "y": 13
       },
-      "id": 10
+      "id": 11
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Office Cost This Month",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.office_cost_monthly\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 13
+      },
+      "id": 12
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Combined Draw Now",
+      "description": "Every metered plug.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "watt",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 600
+              },
+              {
+                "color": "orange",
+                "value": 900
+              },
+              {
+                "color": "red",
+                "value": 1200
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.combined_total_power\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 13
+      },
+      "id": 13
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Combined Cost This Month",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 40
+              },
+              {
+                "color": "orange",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 120
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.combined_cost_monthly\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 13
+      },
+      "id": 14
+    },
+    {
+      "type": "row",
+      "title": "Hot spots — who is costing what (all plugs)",
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 18
       },
-      "id": 11,
-      "title": "Hot spots \u2014 who is costing what",
-      "type": "row",
+      "id": 15,
       "panels": []
     },
     {
@@ -671,7 +906,7 @@
       },
       "type": "stat",
       "title": "Biggest Draw Right Now",
-      "description": "Name of the highest-drawing plug, with its wattage.",
+      "description": "Highest-drawing plug and its wattage.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -688,15 +923,15 @@
               },
               {
                 "color": "yellow",
-                "value": 400
+                "value": 120
               },
               {
                 "color": "orange",
-                "value": 700
+                "value": 200
               },
               {
                 "color": "red",
-                "value": 1000
+                "value": 300
               }
             ]
           }
@@ -723,8 +958,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "topk(1, label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_current_consumption\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_current_consumption\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\"))",
-          "legendFormat": "",
+          "expr": "topk(1, label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\"))",
+          "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
           "range": false
@@ -734,9 +969,9 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 18
+        "y": 19
       },
-      "id": 12
+      "id": 16
     },
     {
       "datasource": {
@@ -744,8 +979,8 @@
         "uid": "prometheus"
       },
       "type": "bargauge",
-      "title": "Live Draw \u2014 Per Plug",
-      "description": "Sorted by draw. This is the hot-spot list.",
+      "title": "Live Draw — Per Plug",
+      "description": "Sorted by draw.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -762,15 +997,15 @@
               },
               {
                 "color": "yellow",
-                "value": 400
+                "value": 120
               },
               {
                 "color": "orange",
-                "value": 700
+                "value": 200
               },
               {
                 "color": "red",
-                "value": 1000
+                "value": 300
               }
             ]
           }
@@ -798,7 +1033,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_current_consumption\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_current_consumption\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -809,9 +1044,9 @@
         "h": 6,
         "w": 10,
         "x": 6,
-        "y": 18
+        "y": 19
       },
-      "id": 13
+      "id": 17
     },
     {
       "datasource": {
@@ -819,7 +1054,8 @@
         "uid": "prometheus"
       },
       "type": "piechart",
-      "title": "Share of Total Draw",
+      "title": "Share of Combined Draw",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -860,7 +1096,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_current_consumption\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_current_consumption\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -871,9 +1107,9 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 18
+        "y": 19
       },
-      "id": 14
+      "id": 18
     },
     {
       "datasource": {
@@ -881,7 +1117,7 @@
         "uid": "prometheus"
       },
       "type": "bargauge",
-      "title": "Cost This Month \u2014 Per Plug (leaderboard)",
+      "title": "Cost This Month — Per Plug",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -935,7 +1171,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_unit_usd{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_cost_monthly\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_cost_monthly\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_unit_usd{entity=~\"sensor.threadripper_cost_monthly|sensor.nas_psu_cost_monthly|sensor.truenas_cost_monthly|sensor.hp_sff_cost_monthly|sensor.hp_elite_cost_monthly|sensor.gaming_pc_cost_monthly|sensor.macbook_cost_monthly\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -946,9 +1182,9 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 24
+        "y": 25
       },
-      "id": 15
+      "id": 19
     },
     {
       "datasource": {
@@ -956,7 +1192,7 @@
         "uid": "prometheus"
       },
       "type": "bargauge",
-      "title": "Cost Today \u2014 Per Plug",
+      "title": "Cost Today — Per Plug",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -964,7 +1200,7 @@
             "mode": "thresholds"
           },
           "unit": "currencyUSD",
-          "decimals": 3,
+          "decimals": 2,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -982,7 +1218,7 @@
               },
               {
                 "color": "red",
-                "value": 4
+                "value": 3
               }
             ]
           }
@@ -1010,7 +1246,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_unit_usd{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_cost_daily\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_cost_daily\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_unit_usd{entity=~\"sensor.threadripper_cost_daily|sensor.nas_psu_cost_daily|sensor.truenas_cost_daily|sensor.hp_sff_cost_daily|sensor.hp_elite_cost_daily|sensor.gaming_pc_cost_daily|sensor.macbook_cost_daily\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -1021,9 +1257,9 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 24
+        "y": 25
       },
-      "id": 16
+      "id": 20
     },
     {
       "datasource": {
@@ -1031,7 +1267,7 @@
         "uid": "prometheus"
       },
       "type": "bargauge",
-      "title": "Cost This Year \u2014 Per Plug",
+      "title": "Cost This Year — Per Plug",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1085,7 +1321,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_unit_usd{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_cost_yearly\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_cost_yearly\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_unit_usd{entity=~\"sensor.threadripper_cost_yearly|sensor.nas_psu_cost_yearly|sensor.truenas_cost_yearly|sensor.hp_sff_cost_yearly|sensor.hp_elite_cost_yearly|sensor.gaming_pc_cost_yearly|sensor.macbook_cost_yearly\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -1096,21 +1332,21 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 24
+        "y": 25
       },
-      "id": 17
+      "id": 21
     },
     {
+      "type": "row",
+      "title": "Last completed month (homelab)",
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 32
       },
-      "id": 18,
-      "title": "Last completed month",
-      "type": "row",
+      "id": 22,
       "panels": []
     },
     {
@@ -1120,7 +1356,7 @@
       },
       "type": "stat",
       "title": "Cost Last Month",
-      "description": "The finished total for the previous calendar month, from utility_meter's last_period. Unlike Cost This Month it no longer moves.",
+      "description": "Finished calendar month. Compare this against the bill.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1183,9 +1419,9 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 32
+        "y": 33
       },
-      "id": 19
+      "id": 23
     },
     {
       "datasource": {
@@ -1201,7 +1437,7 @@
             "mode": "thresholds"
           },
           "unit": "kwatth",
-          "decimals": 2,
+          "decimals": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1245,9 +1481,9 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 32
+        "y": 33
       },
-      "id": 20
+      "id": 24
     },
     {
       "datasource": {
@@ -1281,7 +1517,7 @@
               },
               {
                 "color": "red",
-                "value": 4
+                "value": 3
               }
             ]
           }
@@ -1319,9 +1555,9 @@
         "h": 6,
         "w": 6,
         "x": 12,
-        "y": 32
+        "y": 33
       },
-      "id": 21
+      "id": 25
     },
     {
       "datasource": {
@@ -1330,7 +1566,7 @@
       },
       "type": "stat",
       "title": "This Month vs Last",
-      "description": "Month-to-date minus last month's finished total. Negative early in the month is normal \u2014 it only means the month is young, not that costs fell.",
+      "description": "Month-to-date minus last month's finished total. Negative early in the month only means the month is young.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1381,9 +1617,9 @@
         "h": 6,
         "w": 6,
         "x": 18,
-        "y": 32
+        "y": 33
       },
-      "id": 22
+      "id": 26
     },
     {
       "datasource": {
@@ -1391,8 +1627,8 @@
         "uid": "prometheus"
       },
       "type": "bargauge",
-      "title": "Cost Last Month \u2014 Per Device",
-      "description": "Last month's finished cost, per device.",
+      "title": "Cost Last Month — Per Plug",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1445,7 +1681,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_unit_usd{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_cost_last_month\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_cost_last_month\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_unit_usd{entity=~\"sensor.threadripper_cost_last_month|sensor.nas_psu_cost_last_month|sensor.truenas_cost_last_month|sensor.hp_sff_cost_last_month|sensor.hp_elite_cost_last_month|sensor.gaming_pc_cost_last_month|sensor.macbook_cost_last_month\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -1456,9 +1692,9 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 38
+        "y": 39
       },
-      "id": 23
+      "id": 27
     },
     {
       "datasource": {
@@ -1466,7 +1702,232 @@
         "uid": "prometheus"
       },
       "type": "bargauge",
-      "title": "Energy Last Month \u2014 Per Device",
+      "title": "Energy Last Month — Per Plug",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "kwatth",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sortBy": "Value",
+        "sortDesc": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_last_month|sensor.nas_psu_energy_last_month|sensor.truenas_energy_last_month|sensor.hp_sff_energy_last_month|sensor.hp_elite_energy_last_month|sensor.gaming_pc_energy_last_month|sensor.macbook_energy_last_month\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "legendFormat": "{{plug}}",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 28
+    },
+    {
+      "type": "row",
+      "title": "Annualised what-ifs (not forecasts)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 29,
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Homelab Run-Rate / Year",
+      "description": "Current burn rate x 8760 h. What leaving it exactly like this costs.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 300
+              },
+              {
+                "color": "orange",
+                "value": 600
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd_per_h{entity=\"sensor.homelab_cost_rate\"}) * 8760",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 47
+      },
+      "id": 30
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "bargauge",
+      "title": "Cost / Year If Left At This Draw",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 300
+              },
+              {
+                "color": "orange",
+                "value": 600
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sortBy": "Value",
+        "sortDesc": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_unit_usd_per_h{entity=~\"sensor.threadripper_cost_rate|sensor.nas_psu_cost_rate|sensor.truenas_cost_rate|sensor.hp_sff_cost_rate|sensor.hp_elite_cost_rate|sensor.gaming_pc_cost_rate|sensor.macbook_cost_rate\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\") * 8760",
+          "legendFormat": "{{plug}}",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 6,
+        "y": 47
+      },
+      "id": 31
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "bargauge",
+      "title": "Energy Today — Per Plug",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1508,7 +1969,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_energy_kwh{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_energy_last_month\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_energy_last_month\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_daily|sensor.nas_psu_energy_daily|sensor.truenas_energy_daily|sensor.hp_sff_energy_daily|sensor.hp_elite_energy_daily|sensor.gaming_pc_energy_daily|sensor.macbook_energy_daily\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -1517,174 +1978,23 @@
       ],
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 38
+        "w": 9,
+        "x": 15,
+        "y": 47
       },
-      "id": 24
+      "id": 32
     },
     {
+      "type": "row",
+      "title": "Idle floor — what it costs to do nothing (homelab)",
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 54
       },
-      "id": 25,
-      "title": "Annualised what-ifs",
-      "type": "row",
-      "panels": []
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "type": "bargauge",
-      "title": "Cost / Year If Left At This Draw",
-      "description": "What each device would cost over a year if it never left its current draw. Solar-fed plugs read zero by design. Sizes the payback of turning something off; it is not a bill forecast.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "unit": "currencyUSD",
-          "decimals": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 300
-              },
-              {
-                "color": "orange",
-                "value": 600
-              },
-              {
-                "color": "red",
-                "value": 1000
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sortBy": "Value",
-        "sortDesc": true,
-        "valueMode": "color"
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_unit_usd_per_h{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_cost_rate\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_cost_rate\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\") * 8760",
-          "legendFormat": "{{plug}}",
-          "refId": "A",
-          "instant": true,
-          "range": false
-        }
-      ],
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 46
-      },
-      "id": 26
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "type": "bargauge",
-      "title": "Energy Today \u2014 Per Plug",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "unit": "kwatth",
-          "decimals": 3,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sortBy": "Value",
-        "sortDesc": true,
-        "valueMode": "color"
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_energy_kwh{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_energy_daily\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_energy_daily\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
-          "legendFormat": "{{plug}}",
-          "refId": "A",
-          "instant": true,
-          "range": false
-        }
-      ],
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 46
-      },
-      "id": 27
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 53
-      },
-      "id": 28,
-      "title": "Idle floor \u2014 what it costs to do nothing",
-      "type": "row",
+      "id": 33,
       "panels": []
     },
     {
@@ -1694,14 +2004,14 @@
       },
       "type": "stat",
       "title": "Idle Floor (24h min)",
-      "description": "Lowest total draw in 24h \u2014 the always-on baseline you pay for even when nothing runs.",
+      "description": "Lowest 5-min draw in the last 24h. This runs 8,760 h/yr.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "unit": "watt",
-          "decimals": 1,
+          "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1715,11 +2025,11 @@
               },
               {
                 "color": "orange",
-                "value": 700
+                "value": 600
               },
               {
                 "color": "red",
-                "value": 1000
+                "value": 800
               }
             ]
           }
@@ -1757,9 +2067,9 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 54
+        "y": 55
       },
-      "id": 29
+      "id": 34
     },
     {
       "datasource": {
@@ -1775,7 +2085,7 @@
             "mode": "thresholds"
           },
           "unit": "watt",
-          "decimals": 1,
+          "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1789,11 +2099,11 @@
               },
               {
                 "color": "orange",
-                "value": 700
+                "value": 600
               },
               {
                 "color": "red",
-                "value": 1000
+                "value": 800
               }
             ]
           }
@@ -1831,9 +2141,9 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 54
+        "y": 55
       },
-      "id": 30
+      "id": 35
     },
     {
       "datasource": {
@@ -1842,7 +2152,7 @@
       },
       "type": "stat",
       "title": "Baseline Cost / Year",
-      "description": "The idle floor, annualised. This is the number that only shrinks by removing or consolidating hardware.",
+      "description": "Idle floor priced at today's rate for a year. If this is most of Cost This Year, only removing hardware moves the bill.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1894,7 +2204,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "min_over_time((max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.homelab_grid_power\"}))[24h:5m]) / 1000 * scalar(max(homeassistant_sensor_unit_usd_per_kwh{entity=\"sensor.current_electricity_rate\"})) * 8760",
+          "expr": "min_over_time((max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.homelab_total_power\"}))[24h:5m]) / 1000 * scalar(max(homeassistant_sensor_unit_usd_per_kwh{entity=\"sensor.current_electricity_rate\"})) * 8760",
           "legendFormat": "",
           "refId": "A",
           "instant": true,
@@ -1905,9 +2215,9 @@
         "h": 6,
         "w": 6,
         "x": 12,
-        "y": 54
+        "y": 55
       },
-      "id": 31
+      "id": 36
     },
     {
       "datasource": {
@@ -1916,14 +2226,14 @@
       },
       "type": "stat",
       "title": "Headroom Above Idle",
-      "description": "Peak minus idle: how much of the draw is actual work vs. just being powered on.",
+      "description": "Peak minus idle: the part workload tuning can touch.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "unit": "watt",
-          "decimals": 1,
+          "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1967,21 +2277,21 @@
         "h": 6,
         "w": 6,
         "x": 18,
-        "y": 54
+        "y": 55
       },
-      "id": 32
+      "id": 37
     },
     {
+      "type": "row",
+      "title": "Usage over time",
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 61
       },
-      "id": 33,
-      "title": "Usage over time",
-      "type": "row",
+      "id": 38,
       "panels": []
     },
     {
@@ -1990,7 +2300,7 @@
         "uid": "prometheus"
       },
       "type": "timeseries",
-      "title": "Stacked Power \u2014 All Plugs",
+      "title": "Stacked Power — All Plugs",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2034,7 +2344,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_current_consumption\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_current_consumption\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -2045,9 +2355,9 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 62
       },
-      "id": 34
+      "id": 39
     },
     {
       "datasource": {
@@ -2055,7 +2365,7 @@
         "uid": "prometheus"
       },
       "type": "timeseries",
-      "title": "Total vs Billable vs Idle Floor",
+      "title": "Homelab vs Office vs Idle Floor",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2100,7 +2410,7 @@
             "uid": "prometheus"
           },
           "expr": "max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.homelab_total_power\"})",
-          "legendFormat": "total",
+          "legendFormat": "homelab",
           "refId": "A",
           "instant": false,
           "range": true
@@ -2110,8 +2420,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.homelab_grid_power\"})",
-          "legendFormat": "billable (excl. solar)",
+          "expr": "max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.office_total_power\"})",
+          "legendFormat": "office",
           "refId": "B",
           "instant": false,
           "range": true
@@ -2122,7 +2432,7 @@
             "uid": "prometheus"
           },
           "expr": "min_over_time((max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.homelab_total_power\"}))[24h:5m])",
-          "legendFormat": "idle floor (24h)",
+          "legendFormat": "homelab idle floor (24h)",
           "refId": "C",
           "instant": false,
           "range": true
@@ -2132,9 +2442,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 70
+        "y": 71
       },
-      "id": 35
+      "id": 40
     },
     {
       "datasource": {
@@ -2153,14 +2463,15 @@
           "custom": {
             "drawStyle": "line",
             "lineWidth": 1,
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "showPoints": "never",
             "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"
             }
-          }
+          },
+          "decimals": 3
         },
         "overrides": []
       },
@@ -2187,7 +2498,7 @@
             "uid": "prometheus"
           },
           "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.homelab_cost_daily\"})",
-          "legendFormat": "TOTAL",
+          "legendFormat": "HOMELAB",
           "refId": "A",
           "instant": false,
           "range": true
@@ -2197,9 +2508,20 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_unit_usd{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_cost_daily\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_cost_daily\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
-          "legendFormat": "{{plug}}",
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.office_cost_daily\"})",
+          "legendFormat": "OFFICE",
           "refId": "B",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_unit_usd{entity=~\"sensor.threadripper_cost_daily|sensor.nas_psu_cost_daily|sensor.truenas_cost_daily|sensor.hp_sff_cost_daily|sensor.hp_elite_cost_daily|sensor.gaming_pc_cost_daily|sensor.macbook_cost_daily\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "legendFormat": "{{plug}}",
+          "refId": "C",
           "instant": false,
           "range": true
         }
@@ -2208,9 +2530,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 70
+        "y": 71
       },
-      "id": 36
+      "id": 41
     },
     {
       "datasource": {
@@ -2218,7 +2540,7 @@
         "uid": "prometheus"
       },
       "type": "timeseries",
-      "title": "Energy Today \u2014 Per Plug (resets at midnight)",
+      "title": "Energy Today — Per Plug (resets at midnight)",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2229,14 +2551,15 @@
           "custom": {
             "drawStyle": "line",
             "lineWidth": 1,
-            "fillOpacity": 25,
+            "fillOpacity": 10,
             "showPoints": "never",
             "spanNulls": true,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             }
-          }
+          },
+          "decimals": 2
         },
         "overrides": []
       },
@@ -2262,7 +2585,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_energy_kwh{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_energy_daily\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_energy_daily\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_daily|sensor.nas_psu_energy_daily|sensor.truenas_energy_daily|sensor.hp_sff_energy_daily|sensor.hp_elite_energy_daily|sensor.gaming_pc_energy_daily|sensor.macbook_energy_daily\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -2273,9 +2596,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 78
+        "y": 79
       },
-      "id": 37
+      "id": 42
     },
     {
       "datasource": {
@@ -2283,7 +2606,7 @@
         "uid": "prometheus"
       },
       "type": "timeseries",
-      "title": "Share of Draw \u2014 Per Plug",
+      "title": "Share of Combined Draw — Per Plug",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2294,14 +2617,15 @@
           "custom": {
             "drawStyle": "line",
             "lineWidth": 1,
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "showPoints": "never",
             "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"
             }
-          }
+          },
+          "decimals": 1
         },
         "overrides": []
       },
@@ -2327,7 +2651,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_unit_percent{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc|hp_elite_estimated)_power_share\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_power_share\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_unit_percent{entity=~\"sensor.threadripper_power_share|sensor.nas_psu_power_share|sensor.truenas_power_share|sensor.hp_sff_power_share|sensor.hp_elite_power_share|sensor.gaming_pc_power_share|sensor.macbook_power_share\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -2338,21 +2662,21 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 78
+        "y": 79
       },
-      "id": 38
+      "id": 43
     },
     {
+      "type": "row",
+      "title": "Electrical",
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 86
+        "y": 87
       },
-      "id": 39,
-      "title": "Electrical",
-      "type": "row",
+      "id": 44,
       "panels": []
     },
     {
@@ -2362,7 +2686,7 @@
       },
       "type": "timeseries",
       "title": "Voltage",
-      "description": "Real plugs only \u2014 the estimated host reports no electrical telemetry.",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2372,14 +2696,15 @@
           "custom": {
             "drawStyle": "line",
             "lineWidth": 1,
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "showPoints": "never",
             "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"
             }
-          }
+          },
+          "decimals": 1
         },
         "overrides": []
       },
@@ -2405,7 +2730,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_voltage_v{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc)_voltage\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_voltage\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_voltage_v{entity=~\"sensor.threadripper_voltage|sensor.nas_psu_voltage|sensor.truenas_voltage|sensor.hp_sff_voltage|sensor.hp_elite_voltage|sensor.gaming_pc_voltage|sensor.macbook_voltage\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -2416,9 +2741,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 87
+        "y": 88
       },
-      "id": 40
+      "id": 45
     },
     {
       "datasource": {
@@ -2427,7 +2752,7 @@
       },
       "type": "timeseries",
       "title": "Current",
-      "description": "Real plugs only \u2014 the estimated host reports no electrical telemetry.",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2437,14 +2762,15 @@
           "custom": {
             "drawStyle": "line",
             "lineWidth": 1,
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "showPoints": "never",
             "spanNulls": true,
             "stacking": {
               "group": "A",
               "mode": "none"
             }
-          }
+          },
+          "decimals": 2
         },
         "overrides": []
       },
@@ -2470,7 +2796,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_current_a{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc)_current\"}), \"plug\", \"$1\", \"entity\", \"sensor\\\\.(.+)_current\"), \"plug\", \"threadripper\", \"plug\", \"gpu_psu\"), \"plug\", \"nas-drive-psu\", \"plug\", \"nas_psu\"), \"plug\", \"truenas\", \"plug\", \"truenas_server\"), \"plug\", \"hp-sff+optiplex\", \"plug\", \"hp_sff\"), \"plug\", \"shed\", \"plug\", \"shed_lab\"), \"plug\", \"gaming-pc\", \"plug\", \"gaming_pc\"), \"plug\", \"hp-elite (est.)\", \"plug\", \"hp_elite_estimated\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_current_a{entity=~\"sensor.threadripper_current|sensor.nas_psu_current|sensor.truenas_current|sensor.hp_sff_current|sensor.hp_elite_current|sensor.gaming_pc_current|sensor.macbook_current\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -2481,21 +2807,21 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 87
+        "y": 88
       },
-      "id": 41
+      "id": 46
     },
     {
+      "type": "row",
+      "title": "Reading this dashboard",
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 95
+        "y": 96
       },
-      "id": 42,
-      "title": "Reading this dashboard",
-      "type": "row",
+      "id": 47,
       "panels": []
     },
     {
@@ -2504,15 +2830,15 @@
       "title": "",
       "options": {
         "mode": "markdown",
-        "content": "### Where the money actually goes\n\n**Idle floor is the real bill.** Peak draw is dramatic but brief; the 24h minimum runs 8,760\nhours a year. If *Baseline Cost / Year* is most of *Cost This Year*, no amount of workload\ntuning helps \u2014 only removing or consolidating a box does.\n\n**Hot-spot triage, in order:**\n\n1. **Threadripper host** is the swing consumer. It idles high (big PSU, HDDs, one RTX 3090) and\n   spikes under inference. Check it against `docs/domains/ai-gpu/gpu-scale-swap.md` \u2014 the GPU\n   workloads are mutually exclusive whole-card allocations, so a backend left at `replicas: 1`\n   with nothing calling it is pure idle cost. `POWER_LIMIT_WATTS` caps the card's ceiling.\n2. **HP SFF + Optiplex share one plug.** A high reading here cannot be attributed to either box.\n   Split the outlet before drawing conclusions about which one to retire.\n3. **NAS Drive PSU vs TrueNAS Server** are two plugs on one machine \u2014 spinning disks vs the\n   host. Persistent draw on the drive PSU with an idle host means spindles that never sleep.\n4. **Gaming PC** is a workstation, not a cluster node. It is metered but deliberately NOT\n   power-locked, so it is expected to swing between zero and several hundred watts.\n\n**Two numbers here are not measurements:**\n\n- **HP Elite (est.)** has no smart plug. Its draw is a flat assumed figure set by\n  `input_number.hp_elite_estimated_watts` in Home Assistant, so it moves the totals without\n  ever reflecting reality. Fit a plug and the guess goes away.\n- **Shed is solar-fed**, so its cost rate is pinned to zero: it contributes watts and kWh but\n  no dollars, and *Billable Draw* is total draw minus the shed. What its own supply is doing \u2014\n  MPPT yield, battery bank state of charge \u2014 is on the **Solar MPPT Monitor** dashboard.\n\n**Numbers that are what-ifs, not forecasts:** *Run-Rate / Year* and *Cost / Year If Left At This\nDraw* annualise the current instant. They answer \"what does leaving this on cost me?\" \u2014 they are\nnot a prediction of next month's bill. Use *Cost This Month* for that.\n\n**Cost basis:** the all-in marginal rate \u2014 (energy + delivery riders) x (1 + sales tax) \u2014 which\nsteps between summer on-peak, summer off-peak and non-summer. Rates live in\n`my-apps/home/home-assistant/configuration.yaml` under `input_number:`; git is the source of\ntruth and the UI sliders reset to it on restart."
+        "content": "### Where the money actually goes\n\n**Idle floor is the real bill.** Peak draw is dramatic but brief; the 24h minimum runs 8,760\nhours a year. If *Baseline Cost / Year* is most of *Cost This Year*, no amount of workload\ntuning helps — only removing or consolidating a box does.\n\n**Groups.** *Homelab* is the five always-on servers and is the number to compare with the\nbill. *Office* is the Gaming PC and the MacBook: metered, priced, but not locked on, so it is\nexpected to swing to zero. *Combined* is both.\n\n**Hot-spot triage, in order:**\n\n1. **Threadripper host** is the swing consumer: big PSU, HDDs, one RTX 3090, and it spikes\n   under inference. A GPU backend left at `replicas: 1` with nothing calling it is pure idle\n   cost — see `docs/domains/ai-gpu/gpu-scale-swap.md`.\n2. **HP SFF + Optiplex share one plug.** A high reading here cannot be attributed to either\n   box. Split the outlet before deciding which one to retire.\n3. **NAS Drive PSU vs TrueNAS** are two plugs on one machine — spinning disks vs the host.\n   Persistent draw on the drive PSU with an idle host means spindles that never sleep.\n4. **HP Elite Mini G9** is the smallest server. If it is above ~40 W something is wrong.\n\n**Not metered:** the HP micro in the shed runs off its own solar and has no plug. Its supply\nside (MPPT yield, battery bank) is on the **Solar MPPT Monitor** dashboard.\n\n**What-ifs, not forecasts:** *Run-Rate / Year* and *Cost / Year If Left At This Draw*\nannualise the current instant. Use *Cost This Month* or *Cost Last Month* for a bill estimate.\n\n**Cost basis:** the all-in marginal rate — (energy + delivery riders) x (1 + sales tax) — which\nsteps between summer on-peak, summer off-peak and non-summer. Rates live in\n`my-apps/home/home-assistant/configuration.yaml` under `input_number:`; git is the source of\ntruth and the UI sliders reset to it on restart.\n\n**Plug names** come from each Home Assistant entity's `friendly_name` (customize.yaml), which\nmust read `<Device> <Metric ...>`; the dashboard strips the metric words."
       },
       "gridPos": {
-        "h": 15,
+        "h": 14,
         "w": 24,
         "x": 0,
-        "y": 96
+        "y": 97
       },
-      "id": 43
+      "id": 48
     }
   ],
   "refresh": "30s",

--- a/monitoring/prometheus-stack/dashboards/tapo-power-monitoring.json
+++ b/monitoring/prometheus-stack/dashboards/tapo-power-monitoring.json
@@ -9,6 +9,8 @@
   "links": [],
   "panels": [
     {
+      "type": "row",
+      "title": "Current Power",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -17,20 +19,25 @@
         "y": 0
       },
       "id": 1,
-      "title": "Current Power",
-      "type": "row"
+      "panels": []
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "type": "stat",
+      "title": "Live Power Draw",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
+          "unit": "watt",
+          "decimals": 1,
           "thresholds": {
+            "mode": "absolute",
             "steps": [
               {
                 "color": "green",
@@ -38,57 +45,59 @@
               },
               {
                 "color": "yellow",
-                "value": 100
+                "value": 120
               },
               {
                 "color": "orange",
-                "value": 500
+                "value": 200
               },
               {
                 "color": "red",
-                "value": 1000
+                "value": 300
               }
             ]
-          },
-          "unit": "watt",
-          "decimals": 1
-        }
+          }
+        },
+        "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 1
-      },
-      "id": 2,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
+        "justifyMode": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
-          ]
+          ],
+          "fields": "",
+          "values": false
         },
-        "textMode": "auto",
+        "textMode": "value_and_name",
         "wideLayout": true
       },
-      "title": "Live Power Draw",
-      "type": "stat",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc)_current_consumption\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.+)_current_consumption\"), \"name\", \"threadripper\", \"name\", \"gpu_psu\"), \"name\", \"nas-drive-psu\", \"name\", \"nas_psu\"), \"name\", \"truenas\", \"name\", \"truenas_server\"), \"name\", \"hp-sff+optiplex\", \"name\", \"hp_sff\"), \"name\", \"shed\", \"name\", \"shed_lab\"), \"name\", \"gaming-pc\", \"name\", \"gaming_pc\"), \"name\", \"hp-elite (est.)\", \"name\", \"hp_elite_estimated\")",
-          "legendFormat": "{{name}}",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "legendFormat": "{{plug}}",
           "refId": "A",
-          "instant": false,
-          "range": true
+          "instant": true,
+          "range": false
         }
-      ]
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2
     },
     {
+      "type": "row",
+      "title": "Power Over Time",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -97,66 +106,76 @@
         "y": 9
       },
       "id": 3,
-      "title": "Power Over Time",
-      "type": "row"
+      "panels": []
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "type": "timeseries",
+      "title": "Power Consumption Over Time",
+      "description": "",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "watt",
           "custom": {
-            "fillOpacity": 15,
-            "lineWidth": 2,
-            "spanNulls": false,
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
             "stacking": {
+              "group": "A",
               "mode": "none"
             }
           }
-        }
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "id": 4,
-      "options": {
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
         },
+        "overrides": []
+      },
+      "options": {
         "legend": {
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
+          "showLegend": true,
           "calcs": [
             "mean",
             "max",
             "lastNotNull"
           ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "title": "Power Consumption Over Time",
-      "type": "timeseries",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc)_current_consumption\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.+)_current_consumption\"), \"name\", \"threadripper\", \"name\", \"gpu_psu\"), \"name\", \"nas-drive-psu\", \"name\", \"nas_psu\"), \"name\", \"truenas\", \"name\", \"truenas_server\"), \"name\", \"hp-sff+optiplex\", \"name\", \"hp_sff\"), \"name\", \"shed\", \"name\", \"shed_lab\"), \"name\", \"gaming-pc\", \"name\", \"gaming_pc\"), \"name\", \"hp-elite (est.)\", \"name\", \"hp_elite_estimated\")",
-          "legendFormat": "{{name}}",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
           "range": true
         }
-      ]
+      ],
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 4
     },
     {
+      "type": "row",
+      "title": "Energy Usage",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -165,74 +184,73 @@
         "y": 20
       },
       "id": 5,
-      "title": "Energy Usage",
-      "type": "row"
+      "panels": []
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "type": "stat",
+      "title": "Energy Today",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
+          "unit": "kwatth",
+          "decimals": 2,
           "thresholds": {
+            "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "orange",
-                "value": 5
               }
             ]
-          },
-          "unit": "kwatth",
-          "decimals": 2
-        }
+          }
+        },
+        "overrides": []
       },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 21
-      },
-      "id": 6,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
+        "justifyMode": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
-          ]
+          ],
+          "fields": "",
+          "values": false
         },
-        "textMode": "auto",
+        "textMode": "value_and_name",
         "wideLayout": true
       },
-      "title": "Energy Today",
-      "type": "stat",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_energy_kwh{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc)_today_s_consumption\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.+)_today_s_consumption\"), \"name\", \"threadripper\", \"name\", \"gpu_psu\"), \"name\", \"nas-drive-psu\", \"name\", \"nas_psu\"), \"name\", \"truenas\", \"name\", \"truenas_server\"), \"name\", \"hp-sff+optiplex\", \"name\", \"hp_sff\"), \"name\", \"shed\", \"name\", \"shed_lab\"), \"name\", \"gaming-pc\", \"name\", \"gaming_pc\"), \"name\", \"hp-elite (est.)\", \"name\", \"hp_elite_estimated\")",
-          "legendFormat": "{{name}}",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_daily|sensor.nas_psu_energy_daily|sensor.truenas_energy_daily|sensor.hp_sff_energy_daily|sensor.hp_elite_energy_daily|sensor.gaming_pc_energy_daily|sensor.macbook_energy_daily\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "legendFormat": "{{plug}}",
           "refId": "A",
-          "instant": false,
-          "range": true
+          "instant": true,
+          "range": false
         }
-      ]
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 6
     },
     {
+      "type": "row",
+      "title": "Voltage & Current",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -241,104 +259,143 @@
         "y": 27
       },
       "id": 7,
-      "title": "Voltage & Current",
-      "type": "row"
+      "panels": []
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "type": "timeseries",
+      "title": "Voltage",
+      "description": "",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "volt",
           "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
             "fillOpacity": 10,
-            "lineWidth": 2,
-            "spanNulls": false
-          }
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_voltage_v{entity=~\"sensor.threadripper_voltage|sensor.nas_psu_voltage|sensor.truenas_voltage|sensor.hp_sff_voltage|sensor.hp_elite_voltage|sensor.gaming_pc_voltage|sensor.macbook_voltage\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "legendFormat": "{{plug}}",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ],
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
         "y": 28
       },
-      "id": 8,
-      "options": {
-        "tooltip": {
-          "mode": "multi"
-        },
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        }
-      },
-      "title": "Voltage",
-      "type": "timeseries",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_voltage_v{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc)_voltage\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.+)_voltage\"), \"name\", \"threadripper\", \"name\", \"gpu_psu\"), \"name\", \"nas-drive-psu\", \"name\", \"nas_psu\"), \"name\", \"truenas\", \"name\", \"truenas_server\"), \"name\", \"hp-sff+optiplex\", \"name\", \"hp_sff\"), \"name\", \"shed\", \"name\", \"shed_lab\"), \"name\", \"gaming-pc\", \"name\", \"gaming_pc\"), \"name\", \"hp-elite (est.)\", \"name\", \"hp_elite_estimated\")",
-          "legendFormat": "{{name}}",
-          "refId": "A",
-          "instant": false,
-          "range": true
-        }
-      ]
+      "id": 8
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "type": "timeseries",
+      "title": "Current",
+      "description": "",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "amp",
           "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
             "fillOpacity": 10,
-            "lineWidth": 2,
-            "spanNulls": false
-          }
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 28
-      },
-      "id": 9,
-      "options": {
-        "tooltip": {
-          "mode": "multi"
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 2
         },
+        "overrides": []
+      },
+      "options": {
         "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "title": "Current",
-      "type": "timeseries",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_current_a{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc)_current\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.+)_current\"), \"name\", \"threadripper\", \"name\", \"gpu_psu\"), \"name\", \"nas-drive-psu\", \"name\", \"nas_psu\"), \"name\", \"truenas\", \"name\", \"truenas_server\"), \"name\", \"hp-sff+optiplex\", \"name\", \"hp_sff\"), \"name\", \"shed\", \"name\", \"shed_lab\"), \"name\", \"gaming-pc\", \"name\", \"gaming_pc\"), \"name\", \"hp-elite (est.)\", \"name\", \"hp_elite_estimated\")",
-          "legendFormat": "{{name}}",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_current_a{entity=~\"sensor.threadripper_current|sensor.nas_psu_current|sensor.truenas_current|sensor.hp_sff_current|sensor.hp_elite_current|sensor.gaming_pc_current|sensor.macbook_current\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
           "range": true
         }
-      ]
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 9
     },
     {
+      "type": "row",
+      "title": "Total Power (All Plugs)",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -347,66 +404,75 @@
         "y": 36
       },
       "id": 10,
-      "title": "Total Power (All Plugs)",
-      "type": "row"
+      "panels": []
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "type": "timeseries",
+      "title": "Stacked Power (All Plugs)",
+      "description": "",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "watt",
           "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
             "fillOpacity": 25,
-            "lineWidth": 2,
-            "spanNulls": false,
+            "showPoints": "never",
+            "spanNulls": true,
             "stacking": {
+              "group": "A",
               "mode": "normal"
             }
           }
-        }
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 37
-      },
-      "id": 11,
-      "options": {
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
         },
+        "overrides": []
+      },
+      "options": {
         "legend": {
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
+          "showLegend": true,
           "calcs": [
             "mean",
             "max",
             "lastNotNull"
           ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "title": "Stacked Power (All Plugs)",
-      "type": "timeseries",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(max by (entity) (homeassistant_sensor_power_w{entity=~\"sensor\\\\.(gpu_psu|nas_psu|truenas_server|hp_sff|shed_lab|gaming_pc)_current_consumption\"}), \"name\", \"$1\", \"entity\", \"sensor\\\\.(.+)_current_consumption\"), \"name\", \"threadripper\", \"name\", \"gpu_psu\"), \"name\", \"nas-drive-psu\", \"name\", \"nas_psu\"), \"name\", \"truenas\", \"name\", \"truenas_server\"), \"name\", \"hp-sff+optiplex\", \"name\", \"hp_sff\"), \"name\", \"shed\", \"name\", \"shed_lab\"), \"name\", \"gaming-pc\", \"name\", \"gaming_pc\"), \"name\", \"hp-elite (est.)\", \"name\", \"hp_elite_estimated\")",
-          "legendFormat": "{{name}}",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
           "range": true
         }
-      ]
+      ],
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 11
     }
   ],
+  "refresh": "30s",
   "schemaVersion": 39,
   "tags": [
     "tapo",
@@ -423,8 +489,9 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "browser",
   "title": "Tapo Power Monitor",
   "uid": "tapo-power-monitor",
-  "version": 4
+  "version": 0,
+  "weekStart": ""
 }

--- a/my-apps/home/home-assistant/automations.yaml
+++ b/my-apps/home/home-assistant/automations.yaml
@@ -3,18 +3,18 @@
 - id: homelab_plug_poweroff_lockout
   alias: Homelab plug power-off lockout
   description: >-
-    Restores the always-on homelab Tapo plugs if one is switched off. The Gaming
-    PC plug is deliberately not locked — that box gets powered down normally.
+    Restores the always-on homelab Tapo plugs if one is switched off. The office
+    plugs (Gaming PC, MacBook) are deliberately not locked.
   mode: parallel
   max: 10
   trigger:
     - platform: state
       entity_id:
-        - switch.gpu_psu
+        - switch.threadripper
         - switch.nas_psu
-        - switch.truenas_server
+        - switch.truenas
         - switch.hp_sff
-        - switch.shed_lab
+        - switch.hp_elite
       from: "on"
       to: "off"
   action:

--- a/my-apps/home/home-assistant/configuration.yaml
+++ b/my-apps/home/home-assistant/configuration.yaml
@@ -40,34 +40,26 @@ recorder:
       - sensor.*_rssi
       - sensor.*_lqi
 
-# Metered homelab + workstation plugs. Household plugs and the garage fridge are
-# deliberately excluded. Entity prefixes are frozen to preserve history: gpu_psu is
-# the Threadripper host, basement_homelab_* is the garage fridge.
+# Only the metered plugs and the derived totals are exported. Household plugs stay out.
 prometheus:
   requires_auth: false
   filter:
     include_entity_globs:
-      - sensor.gpu_psu_*
+      - sensor.threadripper_*
       - sensor.nas_psu_*
-      - sensor.truenas_server_*
+      - sensor.truenas_*
       - sensor.hp_sff_*
-      - sensor.shed_lab_*
+      - sensor.hp_elite_*
       - sensor.gaming_pc_*
-      - sensor.hp_elite_estimated_*
-      - sensor.homelab_total_*
-      - sensor.homelab_grid_*
-      - sensor.homelab_cost_*
+      - sensor.macbook_*
+      - sensor.homelab_*
+      - sensor.office_*
+      - sensor.combined_*
       - sensor.current_electricity_rate
       - sensor.electricity_tariff_period
       # StuckAtPrototype AirCube Zigbee air-quality monitor (temp/humidity/eCO2/
       # tVOC + rssi/lqi). Feeds the aircube-dashboard.json Grafana dashboard.
       - sensor.stuckatprototype_aircube_*
-    exclude_entity_globs:
-      - sensor.basement_homelab_* # garage fridge — plug was renamed, entity_ids were not
-      - sensor.dryer_smart_plug_*
-      - sensor.office_smart_plug_*
-      - sensor.office2_smart_plug_*
-      - sensor.tv_smart_plug_*
 
 # Energy dashboard is configured in the UI: add each sensor.<dev>_energy sensor as Individual devices.
 energy:
@@ -134,24 +126,17 @@ input_number:
     unit_of_measurement: "%"
     icon: mdi:percent
     initial: 6.0
-  hp_elite_estimated_watts:
-    name: "HP Elite (estimated) — Assumed Draw"
-    min: 0
-    max: 400
-    step: 1
-    mode: box
-    unit_of_measurement: "W"
-    icon: mdi:help-circle-outline
-    initial: 30
 
 # Cost integrates a live USD/h cost-rate (power * current TOU rate), not a fixed tariff.
 # Every integral starts at 0 when first created; totals only fill in as data accumulates.
+# Each `name:` slug MUST equal the entity prefix: HA derives the entity_id from `name`, and a
+# mismatch makes every template/dashboard reference silently read nothing.
 sensor:
-  # --- per-device energy (kWh) ---
+  # --- energy (kWh): one integral per plug, one per group ---
   - platform: integration
-    source: sensor.gpu_psu_current_consumption
-    name: "GPU PSU Energy"
-    unique_id: gpu_psu_energy
+    source: sensor.threadripper_current_consumption
+    name: "Threadripper Energy"
+    unique_id: threadripper_energy
     unit_prefix: k
     round: 3
     method: left
@@ -163,9 +148,9 @@ sensor:
     round: 3
     method: left
   - platform: integration
-    source: sensor.truenas_server_current_consumption
-    name: "TrueNAS Server Energy"
-    unique_id: truenas_server_energy
+    source: sensor.truenas_current_consumption
+    name: "TrueNAS Energy"
+    unique_id: truenas_energy
     unit_prefix: k
     round: 3
     method: left
@@ -177,9 +162,9 @@ sensor:
     round: 3
     method: left
   - platform: integration
-    source: sensor.shed_lab_current_consumption
-    name: "Shed Lab Energy"
-    unique_id: shed_lab_energy
+    source: sensor.hp_elite_current_consumption
+    name: "HP Elite Energy"
+    unique_id: hp_elite_energy
     unit_prefix: k
     round: 3
     method: left
@@ -191,14 +176,12 @@ sensor:
     round: 3
     method: left
   - platform: integration
-    source: sensor.hp_elite_estimated_current_consumption
-    name: "HP Elite Estimated Energy"
-    unique_id: hp_elite_estimated_energy
+    source: sensor.macbook_current_consumption
+    name: "MacBook Energy"
+    unique_id: macbook_energy
     unit_prefix: k
     round: 3
     method: left
-
-  # --- homelab total energy (kWh) — feeds weekly/monthly/yearly meters ---
   - platform: integration
     source: sensor.homelab_total_power
     name: "Homelab Total Energy"
@@ -206,12 +189,26 @@ sensor:
     unit_prefix: k
     round: 3
     method: left
-
-  # --- per-device cumulative cost (USD) — integrates the USD/h cost-rate ---
   - platform: integration
-    source: sensor.gpu_psu_cost_rate
-    name: "GPU PSU Cost"
-    unique_id: gpu_psu_cost
+    source: sensor.office_total_power
+    name: "Office Total Energy"
+    unique_id: office_total_energy
+    unit_prefix: k
+    round: 3
+    method: left
+  - platform: integration
+    source: sensor.combined_total_power
+    name: "Combined Total Energy"
+    unique_id: combined_total_energy
+    unit_prefix: k
+    round: 3
+    method: left
+
+  # --- cost (USD): integrates the USD/h cost-rate ---
+  - platform: integration
+    source: sensor.threadripper_cost_rate
+    name: "Threadripper Cost"
+    unique_id: threadripper_cost
     unit_time: h
     round: 4
     method: left
@@ -223,9 +220,9 @@ sensor:
     round: 4
     method: left
   - platform: integration
-    source: sensor.truenas_server_cost_rate
-    name: "TrueNAS Server Cost"
-    unique_id: truenas_server_cost
+    source: sensor.truenas_cost_rate
+    name: "TrueNAS Cost"
+    unique_id: truenas_cost
     unit_time: h
     round: 4
     method: left
@@ -237,9 +234,9 @@ sensor:
     round: 4
     method: left
   - platform: integration
-    source: sensor.shed_lab_cost_rate
-    name: "Shed Lab Cost"
-    unique_id: shed_lab_cost
+    source: sensor.hp_elite_cost_rate
+    name: "HP Elite Cost"
+    unique_id: hp_elite_cost
     unit_time: h
     round: 4
     method: left
@@ -251,14 +248,12 @@ sensor:
     round: 4
     method: left
   - platform: integration
-    source: sensor.hp_elite_estimated_cost_rate
-    name: "HP Elite Estimated Cost"
-    unique_id: hp_elite_estimated_cost
+    source: sensor.macbook_cost_rate
+    name: "MacBook Cost"
+    unique_id: macbook_cost
     unit_time: h
     round: 4
     method: left
-
-  # --- homelab total cumulative cost (USD) ---
   - platform: integration
     source: sensor.homelab_cost_rate
     name: "Homelab Cost"
@@ -266,27 +261,39 @@ sensor:
     unit_time: h
     round: 4
     method: left
+  - platform: integration
+    source: sensor.office_cost_rate
+    name: "Office Cost"
+    unique_id: office_cost
+    unit_time: h
+    round: 4
+    method: left
+  - platform: integration
+    source: sensor.combined_cost_rate
+    name: "Combined Cost"
+    unique_id: combined_cost
+    unit_time: h
+    round: 4
+    method: left
 
-# Each `name:` slug MUST equal its config key: HA derives the entity_id from `name`, and a
-# mismatch makes the template/dashboard references silently read nothing.
 utility_meter:
   # ===== ENERGY (kWh) =====
   # Threadripper Host
-  gpu_psu_energy_daily:
-    name: "GPU PSU Energy Daily"
-    source: sensor.gpu_psu_energy
+  threadripper_energy_daily:
+    name: "Threadripper Energy Daily"
+    source: sensor.threadripper_energy
     cycle: daily
-  gpu_psu_energy_weekly:
-    name: "GPU PSU Energy Weekly"
-    source: sensor.gpu_psu_energy
+  threadripper_energy_weekly:
+    name: "Threadripper Energy Weekly"
+    source: sensor.threadripper_energy
     cycle: weekly
-  gpu_psu_energy_monthly:
-    name: "GPU PSU Energy Monthly"
-    source: sensor.gpu_psu_energy
+  threadripper_energy_monthly:
+    name: "Threadripper Energy Monthly"
+    source: sensor.threadripper_energy
     cycle: monthly
-  gpu_psu_energy_yearly:
-    name: "GPU PSU Energy Yearly"
-    source: sensor.gpu_psu_energy
+  threadripper_energy_yearly:
+    name: "Threadripper Energy Yearly"
+    source: sensor.threadripper_energy
     cycle: yearly
   # NAS Drive PSU
   nas_psu_energy_daily:
@@ -306,21 +313,21 @@ utility_meter:
     source: sensor.nas_psu_energy
     cycle: yearly
   # TrueNAS (DL360)
-  truenas_server_energy_daily:
-    name: "TrueNAS Server Energy Daily"
-    source: sensor.truenas_server_energy
+  truenas_energy_daily:
+    name: "TrueNAS Energy Daily"
+    source: sensor.truenas_energy
     cycle: daily
-  truenas_server_energy_weekly:
-    name: "TrueNAS Server Energy Weekly"
-    source: sensor.truenas_server_energy
+  truenas_energy_weekly:
+    name: "TrueNAS Energy Weekly"
+    source: sensor.truenas_energy
     cycle: weekly
-  truenas_server_energy_monthly:
-    name: "TrueNAS Server Energy Monthly"
-    source: sensor.truenas_server_energy
+  truenas_energy_monthly:
+    name: "TrueNAS Energy Monthly"
+    source: sensor.truenas_energy
     cycle: monthly
-  truenas_server_energy_yearly:
-    name: "TrueNAS Server Energy Yearly"
-    source: sensor.truenas_server_energy
+  truenas_energy_yearly:
+    name: "TrueNAS Energy Yearly"
+    source: sensor.truenas_energy
     cycle: yearly
   # HP SFF + Optiplex
   hp_sff_energy_daily:
@@ -339,24 +346,24 @@ utility_meter:
     name: "HP SFF Energy Yearly"
     source: sensor.hp_sff_energy
     cycle: yearly
-  # Shed (HP micro, solar)
-  shed_lab_energy_daily:
-    name: "Shed Lab Energy Daily"
-    source: sensor.shed_lab_energy
+  # HP Elite Mini G9
+  hp_elite_energy_daily:
+    name: "HP Elite Energy Daily"
+    source: sensor.hp_elite_energy
     cycle: daily
-  shed_lab_energy_weekly:
-    name: "Shed Lab Energy Weekly"
-    source: sensor.shed_lab_energy
+  hp_elite_energy_weekly:
+    name: "HP Elite Energy Weekly"
+    source: sensor.hp_elite_energy
     cycle: weekly
-  shed_lab_energy_monthly:
-    name: "Shed Lab Energy Monthly"
-    source: sensor.shed_lab_energy
+  hp_elite_energy_monthly:
+    name: "HP Elite Energy Monthly"
+    source: sensor.hp_elite_energy
     cycle: monthly
-  shed_lab_energy_yearly:
-    name: "Shed Lab Energy Yearly"
-    source: sensor.shed_lab_energy
+  hp_elite_energy_yearly:
+    name: "HP Elite Energy Yearly"
+    source: sensor.hp_elite_energy
     cycle: yearly
-  # Gaming PC (7800X3D + 3090)
+  # Gaming PC
   gaming_pc_energy_daily:
     name: "Gaming PC Energy Daily"
     source: sensor.gaming_pc_energy
@@ -373,24 +380,28 @@ utility_meter:
     name: "Gaming PC Energy Yearly"
     source: sensor.gaming_pc_energy
     cycle: yearly
-  # HP Elite (estimated)
-  hp_elite_estimated_energy_daily:
-    name: "HP Elite Estimated Energy Daily"
-    source: sensor.hp_elite_estimated_energy
+  # MacBook + Monitor
+  macbook_energy_daily:
+    name: "MacBook Energy Daily"
+    source: sensor.macbook_energy
     cycle: daily
-  hp_elite_estimated_energy_weekly:
-    name: "HP Elite Estimated Energy Weekly"
-    source: sensor.hp_elite_estimated_energy
+  macbook_energy_weekly:
+    name: "MacBook Energy Weekly"
+    source: sensor.macbook_energy
     cycle: weekly
-  hp_elite_estimated_energy_monthly:
-    name: "HP Elite Estimated Energy Monthly"
-    source: sensor.hp_elite_estimated_energy
+  macbook_energy_monthly:
+    name: "MacBook Energy Monthly"
+    source: sensor.macbook_energy
     cycle: monthly
-  hp_elite_estimated_energy_yearly:
-    name: "HP Elite Estimated Energy Yearly"
-    source: sensor.hp_elite_estimated_energy
+  macbook_energy_yearly:
+    name: "MacBook Energy Yearly"
+    source: sensor.macbook_energy
     cycle: yearly
-  # Homelab total energy
+  # Homelab total
+  homelab_total_energy_daily:
+    name: "Homelab Total Energy Daily"
+    source: sensor.homelab_total_energy
+    cycle: daily
   homelab_total_energy_weekly:
     name: "Homelab Total Energy Weekly"
     source: sensor.homelab_total_energy
@@ -403,24 +414,58 @@ utility_meter:
     name: "Homelab Total Energy Yearly"
     source: sensor.homelab_total_energy
     cycle: yearly
+  # Office total
+  office_total_energy_daily:
+    name: "Office Total Energy Daily"
+    source: sensor.office_total_energy
+    cycle: daily
+  office_total_energy_weekly:
+    name: "Office Total Energy Weekly"
+    source: sensor.office_total_energy
+    cycle: weekly
+  office_total_energy_monthly:
+    name: "Office Total Energy Monthly"
+    source: sensor.office_total_energy
+    cycle: monthly
+  office_total_energy_yearly:
+    name: "Office Total Energy Yearly"
+    source: sensor.office_total_energy
+    cycle: yearly
+  # Combined total
+  combined_total_energy_daily:
+    name: "Combined Total Energy Daily"
+    source: sensor.combined_total_energy
+    cycle: daily
+  combined_total_energy_weekly:
+    name: "Combined Total Energy Weekly"
+    source: sensor.combined_total_energy
+    cycle: weekly
+  combined_total_energy_monthly:
+    name: "Combined Total Energy Monthly"
+    source: sensor.combined_total_energy
+    cycle: monthly
+  combined_total_energy_yearly:
+    name: "Combined Total Energy Yearly"
+    source: sensor.combined_total_energy
+    cycle: yearly
 
   # ===== COST (USD) =====
   # Threadripper Host
-  gpu_psu_cost_daily:
-    name: "GPU PSU Cost Daily"
-    source: sensor.gpu_psu_cost
+  threadripper_cost_daily:
+    name: "Threadripper Cost Daily"
+    source: sensor.threadripper_cost
     cycle: daily
-  gpu_psu_cost_weekly:
-    name: "GPU PSU Cost Weekly"
-    source: sensor.gpu_psu_cost
+  threadripper_cost_weekly:
+    name: "Threadripper Cost Weekly"
+    source: sensor.threadripper_cost
     cycle: weekly
-  gpu_psu_cost_monthly:
-    name: "GPU PSU Cost Monthly"
-    source: sensor.gpu_psu_cost
+  threadripper_cost_monthly:
+    name: "Threadripper Cost Monthly"
+    source: sensor.threadripper_cost
     cycle: monthly
-  gpu_psu_cost_yearly:
-    name: "GPU PSU Cost Yearly"
-    source: sensor.gpu_psu_cost
+  threadripper_cost_yearly:
+    name: "Threadripper Cost Yearly"
+    source: sensor.threadripper_cost
     cycle: yearly
   # NAS Drive PSU
   nas_psu_cost_daily:
@@ -440,21 +485,21 @@ utility_meter:
     source: sensor.nas_psu_cost
     cycle: yearly
   # TrueNAS (DL360)
-  truenas_server_cost_daily:
-    name: "TrueNAS Server Cost Daily"
-    source: sensor.truenas_server_cost
+  truenas_cost_daily:
+    name: "TrueNAS Cost Daily"
+    source: sensor.truenas_cost
     cycle: daily
-  truenas_server_cost_weekly:
-    name: "TrueNAS Server Cost Weekly"
-    source: sensor.truenas_server_cost
+  truenas_cost_weekly:
+    name: "TrueNAS Cost Weekly"
+    source: sensor.truenas_cost
     cycle: weekly
-  truenas_server_cost_monthly:
-    name: "TrueNAS Server Cost Monthly"
-    source: sensor.truenas_server_cost
+  truenas_cost_monthly:
+    name: "TrueNAS Cost Monthly"
+    source: sensor.truenas_cost
     cycle: monthly
-  truenas_server_cost_yearly:
-    name: "TrueNAS Server Cost Yearly"
-    source: sensor.truenas_server_cost
+  truenas_cost_yearly:
+    name: "TrueNAS Cost Yearly"
+    source: sensor.truenas_cost
     cycle: yearly
   # HP SFF + Optiplex
   hp_sff_cost_daily:
@@ -473,24 +518,24 @@ utility_meter:
     name: "HP SFF Cost Yearly"
     source: sensor.hp_sff_cost
     cycle: yearly
-  # Shed (HP micro, solar)
-  shed_lab_cost_daily:
-    name: "Shed Lab Cost Daily"
-    source: sensor.shed_lab_cost
+  # HP Elite Mini G9
+  hp_elite_cost_daily:
+    name: "HP Elite Cost Daily"
+    source: sensor.hp_elite_cost
     cycle: daily
-  shed_lab_cost_weekly:
-    name: "Shed Lab Cost Weekly"
-    source: sensor.shed_lab_cost
+  hp_elite_cost_weekly:
+    name: "HP Elite Cost Weekly"
+    source: sensor.hp_elite_cost
     cycle: weekly
-  shed_lab_cost_monthly:
-    name: "Shed Lab Cost Monthly"
-    source: sensor.shed_lab_cost
+  hp_elite_cost_monthly:
+    name: "HP Elite Cost Monthly"
+    source: sensor.hp_elite_cost
     cycle: monthly
-  shed_lab_cost_yearly:
-    name: "Shed Lab Cost Yearly"
-    source: sensor.shed_lab_cost
+  hp_elite_cost_yearly:
+    name: "HP Elite Cost Yearly"
+    source: sensor.hp_elite_cost
     cycle: yearly
-  # Gaming PC (7800X3D + 3090)
+  # Gaming PC
   gaming_pc_cost_daily:
     name: "Gaming PC Cost Daily"
     source: sensor.gaming_pc_cost
@@ -507,24 +552,24 @@ utility_meter:
     name: "Gaming PC Cost Yearly"
     source: sensor.gaming_pc_cost
     cycle: yearly
-  # HP Elite (estimated)
-  hp_elite_estimated_cost_daily:
-    name: "HP Elite Estimated Cost Daily"
-    source: sensor.hp_elite_estimated_cost
+  # MacBook + Monitor
+  macbook_cost_daily:
+    name: "MacBook Cost Daily"
+    source: sensor.macbook_cost
     cycle: daily
-  hp_elite_estimated_cost_weekly:
-    name: "HP Elite Estimated Cost Weekly"
-    source: sensor.hp_elite_estimated_cost
+  macbook_cost_weekly:
+    name: "MacBook Cost Weekly"
+    source: sensor.macbook_cost
     cycle: weekly
-  hp_elite_estimated_cost_monthly:
-    name: "HP Elite Estimated Cost Monthly"
-    source: sensor.hp_elite_estimated_cost
+  macbook_cost_monthly:
+    name: "MacBook Cost Monthly"
+    source: sensor.macbook_cost
     cycle: monthly
-  hp_elite_estimated_cost_yearly:
-    name: "HP Elite Estimated Cost Yearly"
-    source: sensor.hp_elite_estimated_cost
+  macbook_cost_yearly:
+    name: "MacBook Cost Yearly"
+    source: sensor.macbook_cost
     cycle: yearly
-  # Homelab total cost
+  # Homelab total
   homelab_cost_daily:
     name: "Homelab Cost Daily"
     source: sensor.homelab_cost
@@ -541,8 +586,42 @@ utility_meter:
     name: "Homelab Cost Yearly"
     source: sensor.homelab_cost
     cycle: yearly
+  # Office total
+  office_cost_daily:
+    name: "Office Cost Daily"
+    source: sensor.office_cost
+    cycle: daily
+  office_cost_weekly:
+    name: "Office Cost Weekly"
+    source: sensor.office_cost
+    cycle: weekly
+  office_cost_monthly:
+    name: "Office Cost Monthly"
+    source: sensor.office_cost
+    cycle: monthly
+  office_cost_yearly:
+    name: "Office Cost Yearly"
+    source: sensor.office_cost
+    cycle: yearly
+  # Combined total
+  combined_cost_daily:
+    name: "Combined Cost Daily"
+    source: sensor.combined_cost
+    cycle: daily
+  combined_cost_weekly:
+    name: "Combined Cost Weekly"
+    source: sensor.combined_cost
+    cycle: weekly
+  combined_cost_monthly:
+    name: "Combined Cost Monthly"
+    source: sensor.combined_cost
+    cycle: monthly
+  combined_cost_yearly:
+    name: "Combined Cost Yearly"
+    source: sensor.combined_cost
+    cycle: yearly
 
-# Template sensors: live all-in rate, tariff window, totals, per-device cost-rate and share.
+# Template sensors: live all-in rate, tariff window, group totals, per-device cost-rate and share.
 template:
   - sensor:
       # now()-based templates re-render every minute; float(<bill default>) keeps this right
@@ -579,67 +658,58 @@ template:
           {% elif summer %}Summer Off-Peak
           {% else %}Non-Summer{% endif %}
 
-      # No smart plug on this host yet, so its draw is the assumed figure above rather
-      # than a measurement. Point this at the plug's sensor the day one is fitted.
-      - name: "HP Elite Estimated Current Consumption"
-        unique_id: hp_elite_estimated_current_consumption
-        unit_of_measurement: "W"
-        device_class: power
-        state_class: measurement
-        state: >
-          {{ states('input_number.hp_elite_estimated_watts') | float(30) }}
-
-      # Totals cover every metered device plus the estimated one; the homelab_total_*
-      # entity_ids are kept so the long-term statistics stay continuous.
+      # ----- group totals (W). homelab = always-on servers, office = workstations, combined = both -----
       - name: "Homelab Total Power"
         unique_id: homelab_total_power
         unit_of_measurement: "W"
         device_class: power
         state_class: measurement
         availability: >
-          {{ states('sensor.gpu_psu_current_consumption') not in ['unknown','unavailable']
+          {{ states('sensor.threadripper_current_consumption') not in ['unknown','unavailable']
              or states('sensor.nas_psu_current_consumption') not in ['unknown','unavailable']
-             or states('sensor.truenas_server_current_consumption') not in ['unknown','unavailable']
+             or states('sensor.truenas_current_consumption') not in ['unknown','unavailable']
              or states('sensor.hp_sff_current_consumption') not in ['unknown','unavailable']
-             or states('sensor.shed_lab_current_consumption') not in ['unknown','unavailable']
-             or states('sensor.gaming_pc_current_consumption') not in ['unknown','unavailable'] }}
+             or states('sensor.hp_elite_current_consumption') not in ['unknown','unavailable'] }}
         state: >
-          {{ (states('sensor.gpu_psu_current_consumption') | float(0)
+          {{ (states('sensor.threadripper_current_consumption') | float(0)
             + states('sensor.nas_psu_current_consumption') | float(0)
-            + states('sensor.truenas_server_current_consumption') | float(0)
+            + states('sensor.truenas_current_consumption') | float(0)
             + states('sensor.hp_sff_current_consumption') | float(0)
-            + states('sensor.shed_lab_current_consumption') | float(0)
-            + states('sensor.gaming_pc_current_consumption') | float(0)
-            + states('sensor.hp_elite_estimated_current_consumption') | float(0)) | round(1) }}
+            + states('sensor.hp_elite_current_consumption') | float(0)) | round(1) }}
 
-      # Billable draw: everything except the solar-fed Shed (HP micro, solar).
-      # Cost is priced off THIS, never off homelab_total_power.
-      - name: "Homelab Grid Power"
-        unique_id: homelab_grid_power
+      - name: "Office Total Power"
+        unique_id: office_total_power
         unit_of_measurement: "W"
         device_class: power
         state_class: measurement
+        availability: >
+          {{ states('sensor.gaming_pc_current_consumption') not in ['unknown','unavailable']
+             or states('sensor.macbook_current_consumption') not in ['unknown','unavailable'] }}
         state: >
-          {{ (states('sensor.gpu_psu_current_consumption') | float(0)
-            + states('sensor.nas_psu_current_consumption') | float(0)
-            + states('sensor.truenas_server_current_consumption') | float(0)
-            + states('sensor.hp_sff_current_consumption') | float(0)
-            + states('sensor.gaming_pc_current_consumption') | float(0)
-            + states('sensor.hp_elite_estimated_current_consumption') | float(0)) | round(1) }}
+          {{ (states('sensor.gaming_pc_current_consumption') | float(0)
+            + states('sensor.macbook_current_consumption') | float(0)) | round(1) }}
 
-      - name: "Homelab Total Energy Today"
-        unique_id: homelab_total_energy_today
-        unit_of_measurement: "kWh"
-        device_class: energy
-        state_class: total_increasing
+      - name: "Combined Total Power"
+        unique_id: combined_total_power
+        unit_of_measurement: "W"
+        device_class: power
+        state_class: measurement
+        availability: >
+          {{ states('sensor.threadripper_current_consumption') not in ['unknown','unavailable']
+             or states('sensor.nas_psu_current_consumption') not in ['unknown','unavailable']
+             or states('sensor.truenas_current_consumption') not in ['unknown','unavailable']
+             or states('sensor.hp_sff_current_consumption') not in ['unknown','unavailable']
+             or states('sensor.hp_elite_current_consumption') not in ['unknown','unavailable']
+             or states('sensor.gaming_pc_current_consumption') not in ['unknown','unavailable']
+             or states('sensor.macbook_current_consumption') not in ['unknown','unavailable'] }}
         state: >
-          {{ (states('sensor.gpu_psu_energy_daily') | float(0)
-            + states('sensor.nas_psu_energy_daily') | float(0)
-            + states('sensor.truenas_server_energy_daily') | float(0)
-            + states('sensor.hp_sff_energy_daily') | float(0)
-            + states('sensor.shed_lab_energy_daily') | float(0)
-            + states('sensor.gaming_pc_energy_daily') | float(0)
-            + states('sensor.hp_elite_estimated_energy_daily') | float(0)) | round(3) }}
+          {{ (states('sensor.threadripper_current_consumption') | float(0)
+            + states('sensor.nas_psu_current_consumption') | float(0)
+            + states('sensor.truenas_current_consumption') | float(0)
+            + states('sensor.hp_sff_current_consumption') | float(0)
+            + states('sensor.hp_elite_current_consumption') | float(0)
+            + states('sensor.gaming_pc_current_consumption') | float(0)
+            + states('sensor.macbook_current_consumption') | float(0)) | round(1) }}
 
       # ----- live USD/h cost-rate (power_kW * current all-in rate) -----
       - name: "Homelab Cost Rate"
@@ -648,191 +718,104 @@ template:
         state_class: measurement
         icon: mdi:cash-fast
         state: >
-          {{ (states('sensor.homelab_grid_power') | float(0) / 1000
+          {{ (states('sensor.homelab_total_power') | float(0) / 1000
             * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
-      - name: "GPU PSU Cost Rate"
-        unique_id: gpu_psu_cost_rate
+      - name: "Office Cost Rate"
+        unique_id: office_cost_rate
         unit_of_measurement: "USD/h"
         state_class: measurement
+        icon: mdi:cash-fast
         state: >
-          {{ (states('sensor.gpu_psu_current_consumption') | float(0) / 1000
+          {{ (states('sensor.office_total_power') | float(0) / 1000
+            * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
+
+      - name: "Combined Cost Rate"
+        unique_id: combined_cost_rate
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        icon: mdi:cash-fast
+        state: >
+          {{ (states('sensor.combined_total_power') | float(0) / 1000
+            * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
+
+      - name: "Threadripper Cost Rate"
+        unique_id: threadripper_cost_rate
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        icon: mdi:cash-fast
+        state: >
+          {{ (states('sensor.threadripper_current_consumption') | float(0) / 1000
             * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
       - name: "NAS PSU Cost Rate"
         unique_id: nas_psu_cost_rate
         unit_of_measurement: "USD/h"
         state_class: measurement
+        icon: mdi:cash-fast
         state: >
           {{ (states('sensor.nas_psu_current_consumption') | float(0) / 1000
             * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
-      - name: "TrueNAS Server Cost Rate"
-        unique_id: truenas_server_cost_rate
+      - name: "TrueNAS Cost Rate"
+        unique_id: truenas_cost_rate
         unit_of_measurement: "USD/h"
         state_class: measurement
+        icon: mdi:cash-fast
         state: >
-          {{ (states('sensor.truenas_server_current_consumption') | float(0) / 1000
+          {{ (states('sensor.truenas_current_consumption') | float(0) / 1000
             * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
       - name: "HP SFF Cost Rate"
         unique_id: hp_sff_cost_rate
         unit_of_measurement: "USD/h"
         state_class: measurement
+        icon: mdi:cash-fast
         state: >
           {{ (states('sensor.hp_sff_current_consumption') | float(0) / 1000
             * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
-      # Shed (HP micro, solar) runs off its own solar + battery bank, so it costs nothing on the grid
-      # bill. Kept as a real sensor so its cost meters and dashboard rows stay uniform.
-      - name: "Shed Lab Cost Rate"
-        unique_id: shed_lab_cost_rate
+      - name: "HP Elite Cost Rate"
+        unique_id: hp_elite_cost_rate
         unit_of_measurement: "USD/h"
         state_class: measurement
-        state: "0"
+        icon: mdi:cash-fast
+        state: >
+          {{ (states('sensor.hp_elite_current_consumption') | float(0) / 1000
+            * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
       - name: "Gaming PC Cost Rate"
         unique_id: gaming_pc_cost_rate
         unit_of_measurement: "USD/h"
         state_class: measurement
+        icon: mdi:cash-fast
         state: >
           {{ (states('sensor.gaming_pc_current_consumption') | float(0) / 1000
             * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
-      - name: "HP Elite Estimated Cost Rate"
-        unique_id: hp_elite_estimated_cost_rate
+      - name: "MacBook Cost Rate"
+        unique_id: macbook_cost_rate
         unit_of_measurement: "USD/h"
         state_class: measurement
+        icon: mdi:cash-fast
         state: >
-          {{ (states('sensor.hp_elite_estimated_current_consumption') | float(0) / 1000
+          {{ (states('sensor.macbook_current_consumption') | float(0) / 1000
             * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
 
-      # ----- last completed month (utility_meter last_period) -----
-      - name: "GPU PSU Cost Last Month"
-        unique_id: gpu_psu_cost_last_month
-        unit_of_measurement: "USD"
-        state_class: total
-        icon: mdi:calendar-check
-        state: >
-          {{ state_attr('sensor.gpu_psu_cost_monthly', 'last_period') | float(0) | round(4) }}
-
-      - name: "NAS PSU Cost Last Month"
-        unique_id: nas_psu_cost_last_month
-        unit_of_measurement: "USD"
-        state_class: total
-        icon: mdi:calendar-check
-        state: >
-          {{ state_attr('sensor.nas_psu_cost_monthly', 'last_period') | float(0) | round(4) }}
-
-      - name: "TrueNAS Server Cost Last Month"
-        unique_id: truenas_server_cost_last_month
-        unit_of_measurement: "USD"
-        state_class: total
-        icon: mdi:calendar-check
-        state: >
-          {{ state_attr('sensor.truenas_server_cost_monthly', 'last_period') | float(0) | round(4) }}
-
-      - name: "HP SFF Cost Last Month"
-        unique_id: hp_sff_cost_last_month
-        unit_of_measurement: "USD"
-        state_class: total
-        icon: mdi:calendar-check
-        state: >
-          {{ state_attr('sensor.hp_sff_cost_monthly', 'last_period') | float(0) | round(4) }}
-
-      - name: "Shed Lab Cost Last Month"
-        unique_id: shed_lab_cost_last_month
-        unit_of_measurement: "USD"
-        state_class: total
-        icon: mdi:calendar-check
-        state: >
-          {{ state_attr('sensor.shed_lab_cost_monthly', 'last_period') | float(0) | round(4) }}
-
-      - name: "Gaming PC Cost Last Month"
-        unique_id: gaming_pc_cost_last_month
-        unit_of_measurement: "USD"
-        state_class: total
-        icon: mdi:calendar-check
-        state: >
-          {{ state_attr('sensor.gaming_pc_cost_monthly', 'last_period') | float(0) | round(4) }}
-
-      - name: "HP Elite Estimated Cost Last Month"
-        unique_id: hp_elite_estimated_cost_last_month
-        unit_of_measurement: "USD"
-        state_class: total
-        icon: mdi:calendar-check
-        state: >
-          {{ state_attr('sensor.hp_elite_estimated_cost_monthly', 'last_period') | float(0) | round(4) }}
-
-      - name: "GPU PSU Energy Last Month"
-        unique_id: gpu_psu_energy_last_month
-        unit_of_measurement: "kWh"
-        device_class: energy
-        state_class: total
-        state: >
-          {{ state_attr('sensor.gpu_psu_energy_monthly', 'last_period') | float(0) | round(3) }}
-
-      - name: "NAS PSU Energy Last Month"
-        unique_id: nas_psu_energy_last_month
-        unit_of_measurement: "kWh"
-        device_class: energy
-        state_class: total
-        state: >
-          {{ state_attr('sensor.nas_psu_energy_monthly', 'last_period') | float(0) | round(3) }}
-
-      - name: "TrueNAS Server Energy Last Month"
-        unique_id: truenas_server_energy_last_month
-        unit_of_measurement: "kWh"
-        device_class: energy
-        state_class: total
-        state: >
-          {{ state_attr('sensor.truenas_server_energy_monthly', 'last_period') | float(0) | round(3) }}
-
-      - name: "HP SFF Energy Last Month"
-        unique_id: hp_sff_energy_last_month
-        unit_of_measurement: "kWh"
-        device_class: energy
-        state_class: total
-        state: >
-          {{ state_attr('sensor.hp_sff_energy_monthly', 'last_period') | float(0) | round(3) }}
-
-      - name: "Shed Lab Energy Last Month"
-        unique_id: shed_lab_energy_last_month
-        unit_of_measurement: "kWh"
-        device_class: energy
-        state_class: total
-        state: >
-          {{ state_attr('sensor.shed_lab_energy_monthly', 'last_period') | float(0) | round(3) }}
-
-      - name: "Gaming PC Energy Last Month"
-        unique_id: gaming_pc_energy_last_month
-        unit_of_measurement: "kWh"
-        device_class: energy
-        state_class: total
-        state: >
-          {{ state_attr('sensor.gaming_pc_energy_monthly', 'last_period') | float(0) | round(3) }}
-
-      - name: "HP Elite Estimated Energy Last Month"
-        unique_id: hp_elite_estimated_energy_last_month
-        unit_of_measurement: "kWh"
-        device_class: energy
-        state_class: total
-        state: >
-          {{ state_attr('sensor.hp_elite_estimated_energy_monthly', 'last_period') | float(0) | round(3) }}
-
+      # ----- finished periods (utility_meter last_period): comparable against a bill -----
       - name: "Homelab Cost Last Month"
         unique_id: homelab_cost_last_month
         unit_of_measurement: "USD"
-        state_class: total
         icon: mdi:calendar-check
+        state_class: total
         state: >
           {{ state_attr('sensor.homelab_cost_monthly', 'last_period') | float(0) | round(4) }}
 
       - name: "Homelab Cost Yesterday"
         unique_id: homelab_cost_yesterday
         unit_of_measurement: "USD"
-        state_class: total
         icon: mdi:calendar-arrow-left
+        state_class: total
         state: >
           {{ state_attr('sensor.homelab_cost_daily', 'last_period') | float(0) | round(4) }}
 
@@ -844,16 +827,176 @@ template:
         state: >
           {{ state_attr('sensor.homelab_total_energy_monthly', 'last_period') | float(0) | round(3) }}
 
-      # ----- live % of total draw (entity slug == *_power_share) -----
-      - name: "GPU PSU Power Share"
-        unique_id: gpu_psu_power_share
+      - name: "Office Cost Last Month"
+        unique_id: office_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.office_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "Office Cost Yesterday"
+        unique_id: office_cost_yesterday
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-arrow-left
+        state_class: total
+        state: >
+          {{ state_attr('sensor.office_cost_daily', 'last_period') | float(0) | round(4) }}
+
+      - name: "Office Total Energy Last Month"
+        unique_id: office_total_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.office_total_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "Combined Cost Last Month"
+        unique_id: combined_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.combined_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "Combined Cost Yesterday"
+        unique_id: combined_cost_yesterday
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-arrow-left
+        state_class: total
+        state: >
+          {{ state_attr('sensor.combined_cost_daily', 'last_period') | float(0) | round(4) }}
+
+      - name: "Combined Total Energy Last Month"
+        unique_id: combined_total_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.combined_total_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "Threadripper Cost Last Month"
+        unique_id: threadripper_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.threadripper_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "Threadripper Energy Last Month"
+        unique_id: threadripper_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.threadripper_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "NAS PSU Cost Last Month"
+        unique_id: nas_psu_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.nas_psu_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "NAS PSU Energy Last Month"
+        unique_id: nas_psu_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.nas_psu_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "TrueNAS Cost Last Month"
+        unique_id: truenas_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.truenas_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "TrueNAS Energy Last Month"
+        unique_id: truenas_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.truenas_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "HP SFF Cost Last Month"
+        unique_id: hp_sff_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.hp_sff_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "HP SFF Energy Last Month"
+        unique_id: hp_sff_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.hp_sff_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "HP Elite Cost Last Month"
+        unique_id: hp_elite_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.hp_elite_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "HP Elite Energy Last Month"
+        unique_id: hp_elite_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.hp_elite_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "Gaming PC Cost Last Month"
+        unique_id: gaming_pc_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.gaming_pc_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "Gaming PC Energy Last Month"
+        unique_id: gaming_pc_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.gaming_pc_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "MacBook Cost Last Month"
+        unique_id: macbook_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.macbook_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "MacBook Energy Last Month"
+        unique_id: macbook_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.macbook_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      # ----- live % of combined draw -----
+      - name: "Threadripper Power Share"
+        unique_id: threadripper_power_share
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:chart-pie
         state: >
-          {% set total = states('sensor.homelab_total_power') | float(0) %}
+          {% set total = states('sensor.combined_total_power') | float(0) %}
           {% if total > 0 %}
-            {{ (states('sensor.gpu_psu_current_consumption') | float(0) / total * 100) | round(1) }}
+            {{ (states('sensor.threadripper_current_consumption') | float(0) / total * 100) | round(1) }}
           {% else %}0{% endif %}
 
       - name: "NAS PSU Power Share"
@@ -862,20 +1005,20 @@ template:
         state_class: measurement
         icon: mdi:chart-pie
         state: >
-          {% set total = states('sensor.homelab_total_power') | float(0) %}
+          {% set total = states('sensor.combined_total_power') | float(0) %}
           {% if total > 0 %}
             {{ (states('sensor.nas_psu_current_consumption') | float(0) / total * 100) | round(1) }}
           {% else %}0{% endif %}
 
-      - name: "TrueNAS Server Power Share"
-        unique_id: truenas_server_power_share
+      - name: "TrueNAS Power Share"
+        unique_id: truenas_power_share
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:chart-pie
         state: >
-          {% set total = states('sensor.homelab_total_power') | float(0) %}
+          {% set total = states('sensor.combined_total_power') | float(0) %}
           {% if total > 0 %}
-            {{ (states('sensor.truenas_server_current_consumption') | float(0) / total * 100) | round(1) }}
+            {{ (states('sensor.truenas_current_consumption') | float(0) / total * 100) | round(1) }}
           {% else %}0{% endif %}
 
       - name: "HP SFF Power Share"
@@ -884,20 +1027,20 @@ template:
         state_class: measurement
         icon: mdi:chart-pie
         state: >
-          {% set total = states('sensor.homelab_total_power') | float(0) %}
+          {% set total = states('sensor.combined_total_power') | float(0) %}
           {% if total > 0 %}
             {{ (states('sensor.hp_sff_current_consumption') | float(0) / total * 100) | round(1) }}
           {% else %}0{% endif %}
 
-      - name: "Shed Lab Power Share"
-        unique_id: shed_lab_power_share
+      - name: "HP Elite Power Share"
+        unique_id: hp_elite_power_share
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:chart-pie
         state: >
-          {% set total = states('sensor.homelab_total_power') | float(0) %}
+          {% set total = states('sensor.combined_total_power') | float(0) %}
           {% if total > 0 %}
-            {{ (states('sensor.shed_lab_current_consumption') | float(0) / total * 100) | round(1) }}
+            {{ (states('sensor.hp_elite_current_consumption') | float(0) / total * 100) | round(1) }}
           {% else %}0{% endif %}
 
       - name: "Gaming PC Power Share"
@@ -906,96 +1049,18 @@ template:
         state_class: measurement
         icon: mdi:chart-pie
         state: >
-          {% set total = states('sensor.homelab_total_power') | float(0) %}
+          {% set total = states('sensor.combined_total_power') | float(0) %}
           {% if total > 0 %}
             {{ (states('sensor.gaming_pc_current_consumption') | float(0) / total * 100) | round(1) }}
           {% else %}0{% endif %}
 
-      - name: "HP Elite Estimated Power Share"
-        unique_id: hp_elite_estimated_power_share
+      - name: "MacBook Power Share"
+        unique_id: macbook_power_share
         unit_of_measurement: "%"
         state_class: measurement
         icon: mdi:chart-pie
         state: >
-          {% set total = states('sensor.homelab_total_power') | float(0) %}
+          {% set total = states('sensor.combined_total_power') | float(0) %}
           {% if total > 0 %}
-            {{ (states('sensor.hp_elite_estimated_current_consumption') | float(0) / total * 100) | round(1) }}
-          {% else %}0{% endif %}
-
-      # ----- share of today's energy (entity slug == *_energy_share_today) -----
-      - name: "GPU PSU Energy Share Today"
-        unique_id: gpu_psu_energy_share_today
-        unit_of_measurement: "%"
-        state_class: measurement
-        icon: mdi:chart-donut
-        state: >
-          {% set total = states('sensor.homelab_total_energy_today') | float(0) %}
-          {% if total > 0 %}
-            {{ (states('sensor.gpu_psu_energy_daily') | float(0) / total * 100) | round(1) }}
-          {% else %}0{% endif %}
-
-      - name: "NAS PSU Energy Share Today"
-        unique_id: nas_psu_energy_share_today
-        unit_of_measurement: "%"
-        state_class: measurement
-        icon: mdi:chart-donut
-        state: >
-          {% set total = states('sensor.homelab_total_energy_today') | float(0) %}
-          {% if total > 0 %}
-            {{ (states('sensor.nas_psu_energy_daily') | float(0) / total * 100) | round(1) }}
-          {% else %}0{% endif %}
-
-      - name: "TrueNAS Server Energy Share Today"
-        unique_id: truenas_server_energy_share_today
-        unit_of_measurement: "%"
-        state_class: measurement
-        icon: mdi:chart-donut
-        state: >
-          {% set total = states('sensor.homelab_total_energy_today') | float(0) %}
-          {% if total > 0 %}
-            {{ (states('sensor.truenas_server_energy_daily') | float(0) / total * 100) | round(1) }}
-          {% else %}0{% endif %}
-
-      - name: "HP SFF Energy Share Today"
-        unique_id: hp_sff_energy_share_today
-        unit_of_measurement: "%"
-        state_class: measurement
-        icon: mdi:chart-donut
-        state: >
-          {% set total = states('sensor.homelab_total_energy_today') | float(0) %}
-          {% if total > 0 %}
-            {{ (states('sensor.hp_sff_energy_daily') | float(0) / total * 100) | round(1) }}
-          {% else %}0{% endif %}
-
-      - name: "Shed Lab Energy Share Today"
-        unique_id: shed_lab_energy_share_today
-        unit_of_measurement: "%"
-        state_class: measurement
-        icon: mdi:chart-donut
-        state: >
-          {% set total = states('sensor.homelab_total_energy_today') | float(0) %}
-          {% if total > 0 %}
-            {{ (states('sensor.shed_lab_energy_daily') | float(0) / total * 100) | round(1) }}
-          {% else %}0{% endif %}
-
-      - name: "Gaming PC Energy Share Today"
-        unique_id: gaming_pc_energy_share_today
-        unit_of_measurement: "%"
-        state_class: measurement
-        icon: mdi:chart-donut
-        state: >
-          {% set total = states('sensor.homelab_total_energy_today') | float(0) %}
-          {% if total > 0 %}
-            {{ (states('sensor.gaming_pc_energy_daily') | float(0) / total * 100) | round(1) }}
-          {% else %}0{% endif %}
-
-      - name: "HP Elite Estimated Energy Share Today"
-        unique_id: hp_elite_estimated_energy_share_today
-        unit_of_measurement: "%"
-        state_class: measurement
-        icon: mdi:chart-donut
-        state: >
-          {% set total = states('sensor.homelab_total_energy_today') | float(0) %}
-          {% if total > 0 %}
-            {{ (states('sensor.hp_elite_estimated_energy_daily') | float(0) / total * 100) | round(1) }}
+            {{ (states('sensor.macbook_current_consumption') | float(0) / total * 100) | round(1) }}
           {% else %}0{% endif %}

--- a/my-apps/home/home-assistant/customize.yaml
+++ b/my-apps/home/home-assistant/customize.yaml
@@ -1,47 +1,52 @@
-# `hidden: true` only removes a switch from the default view; the power-off lockout automation
-# in automations.yaml is the real enforcement. Entity prefixes are frozen to keep history, so
-# friendly_name is the only place the real hardware is named.
+# friendly_name is what Grafana shows: it must read '<Device> <Metric...>' so the dashboards can
+# strip the metric words. `hidden: true` is cosmetic; the lockout automation is the real enforcement.
 
-# ---------- Threadripper Host (entity prefix gpu_psu_*) ----------
-sensor.gpu_psu_current_consumption:
+# ---------- Threadripper Host (threadripper_*) ----------
+sensor.threadripper_current_consumption:
   friendly_name: Threadripper Host Power
-sensor.gpu_psu_energy:
-  friendly_name: Threadripper Host Energy
-sensor.gpu_psu_cost:
-  friendly_name: Threadripper Host Cost
-sensor.gpu_psu_cost_rate:
-  friendly_name: Threadripper Host Cost Rate
-sensor.gpu_psu_power_share:
-  friendly_name: Threadripper Host Power Share
-sensor.gpu_psu_energy_share_today:
-  friendly_name: Threadripper Host Energy Share Today
-sensor.gpu_psu_voltage:
+sensor.threadripper_voltage:
   friendly_name: Threadripper Host Voltage
-sensor.gpu_psu_current:
+sensor.threadripper_current:
   friendly_name: Threadripper Host Current
-sensor.gpu_psu_energy_daily:
+sensor.threadripper_energy:
+  friendly_name: Threadripper Host Energy
+sensor.threadripper_cost:
+  friendly_name: Threadripper Host Cost
+sensor.threadripper_cost_rate:
+  friendly_name: Threadripper Host Cost Rate
+sensor.threadripper_power_share:
+  friendly_name: Threadripper Host Power Share
+sensor.threadripper_cost_last_month:
+  friendly_name: Threadripper Host Cost Last Month
+sensor.threadripper_energy_last_month:
+  friendly_name: Threadripper Host Energy Last Month
+sensor.threadripper_energy_daily:
   friendly_name: Threadripper Host Energy Daily
-sensor.gpu_psu_energy_weekly:
+sensor.threadripper_energy_weekly:
   friendly_name: Threadripper Host Energy Weekly
-sensor.gpu_psu_energy_monthly:
+sensor.threadripper_energy_monthly:
   friendly_name: Threadripper Host Energy Monthly
-sensor.gpu_psu_energy_yearly:
+sensor.threadripper_energy_yearly:
   friendly_name: Threadripper Host Energy Yearly
-sensor.gpu_psu_cost_daily:
+sensor.threadripper_cost_daily:
   friendly_name: Threadripper Host Cost Daily
-sensor.gpu_psu_cost_weekly:
+sensor.threadripper_cost_weekly:
   friendly_name: Threadripper Host Cost Weekly
-sensor.gpu_psu_cost_monthly:
+sensor.threadripper_cost_monthly:
   friendly_name: Threadripper Host Cost Monthly
-sensor.gpu_psu_cost_yearly:
+sensor.threadripper_cost_yearly:
   friendly_name: Threadripper Host Cost Yearly
-switch.gpu_psu:
+switch.threadripper:
   friendly_name: Threadripper Host (read-only)
   hidden: true
 
-# ---------- NAS Drive PSU (entity prefix nas_psu_*) ----------
+# ---------- NAS Drive PSU (nas_psu_*) ----------
 sensor.nas_psu_current_consumption:
   friendly_name: NAS Drive PSU Power
+sensor.nas_psu_voltage:
+  friendly_name: NAS Drive PSU Voltage
+sensor.nas_psu_current:
+  friendly_name: NAS Drive PSU Current
 sensor.nas_psu_energy:
   friendly_name: NAS Drive PSU Energy
 sensor.nas_psu_cost:
@@ -50,12 +55,10 @@ sensor.nas_psu_cost_rate:
   friendly_name: NAS Drive PSU Cost Rate
 sensor.nas_psu_power_share:
   friendly_name: NAS Drive PSU Power Share
-sensor.nas_psu_energy_share_today:
-  friendly_name: NAS Drive PSU Energy Share Today
-sensor.nas_psu_voltage:
-  friendly_name: NAS Drive PSU Voltage
-sensor.nas_psu_current:
-  friendly_name: NAS Drive PSU Current
+sensor.nas_psu_cost_last_month:
+  friendly_name: NAS Drive PSU Cost Last Month
+sensor.nas_psu_energy_last_month:
+  friendly_name: NAS Drive PSU Energy Last Month
 sensor.nas_psu_energy_daily:
   friendly_name: NAS Drive PSU Energy Daily
 sensor.nas_psu_energy_weekly:
@@ -76,46 +79,52 @@ switch.nas_psu:
   friendly_name: NAS Drive PSU (read-only)
   hidden: true
 
-# ---------- TrueNAS (DL360) (entity prefix truenas_server_*) ----------
-sensor.truenas_server_current_consumption:
+# ---------- TrueNAS (DL360) (truenas_*) ----------
+sensor.truenas_current_consumption:
   friendly_name: TrueNAS (DL360) Power
-sensor.truenas_server_energy:
-  friendly_name: TrueNAS (DL360) Energy
-sensor.truenas_server_cost:
-  friendly_name: TrueNAS (DL360) Cost
-sensor.truenas_server_cost_rate:
-  friendly_name: TrueNAS (DL360) Cost Rate
-sensor.truenas_server_power_share:
-  friendly_name: TrueNAS (DL360) Power Share
-sensor.truenas_server_energy_share_today:
-  friendly_name: TrueNAS (DL360) Energy Share Today
-sensor.truenas_server_voltage:
+sensor.truenas_voltage:
   friendly_name: TrueNAS (DL360) Voltage
-sensor.truenas_server_current:
+sensor.truenas_current:
   friendly_name: TrueNAS (DL360) Current
-sensor.truenas_server_energy_daily:
+sensor.truenas_energy:
+  friendly_name: TrueNAS (DL360) Energy
+sensor.truenas_cost:
+  friendly_name: TrueNAS (DL360) Cost
+sensor.truenas_cost_rate:
+  friendly_name: TrueNAS (DL360) Cost Rate
+sensor.truenas_power_share:
+  friendly_name: TrueNAS (DL360) Power Share
+sensor.truenas_cost_last_month:
+  friendly_name: TrueNAS (DL360) Cost Last Month
+sensor.truenas_energy_last_month:
+  friendly_name: TrueNAS (DL360) Energy Last Month
+sensor.truenas_energy_daily:
   friendly_name: TrueNAS (DL360) Energy Daily
-sensor.truenas_server_energy_weekly:
+sensor.truenas_energy_weekly:
   friendly_name: TrueNAS (DL360) Energy Weekly
-sensor.truenas_server_energy_monthly:
+sensor.truenas_energy_monthly:
   friendly_name: TrueNAS (DL360) Energy Monthly
-sensor.truenas_server_energy_yearly:
+sensor.truenas_energy_yearly:
   friendly_name: TrueNAS (DL360) Energy Yearly
-sensor.truenas_server_cost_daily:
+sensor.truenas_cost_daily:
   friendly_name: TrueNAS (DL360) Cost Daily
-sensor.truenas_server_cost_weekly:
+sensor.truenas_cost_weekly:
   friendly_name: TrueNAS (DL360) Cost Weekly
-sensor.truenas_server_cost_monthly:
+sensor.truenas_cost_monthly:
   friendly_name: TrueNAS (DL360) Cost Monthly
-sensor.truenas_server_cost_yearly:
+sensor.truenas_cost_yearly:
   friendly_name: TrueNAS (DL360) Cost Yearly
-switch.truenas_server:
+switch.truenas:
   friendly_name: TrueNAS (DL360) (read-only)
   hidden: true
 
-# ---------- HP SFF + Optiplex (entity prefix hp_sff_*) ----------
+# ---------- HP SFF + Optiplex (hp_sff_*) ----------
 sensor.hp_sff_current_consumption:
   friendly_name: HP SFF + Optiplex Power
+sensor.hp_sff_voltage:
+  friendly_name: HP SFF + Optiplex Voltage
+sensor.hp_sff_current:
+  friendly_name: HP SFF + Optiplex Current
 sensor.hp_sff_energy:
   friendly_name: HP SFF + Optiplex Energy
 sensor.hp_sff_cost:
@@ -124,12 +133,10 @@ sensor.hp_sff_cost_rate:
   friendly_name: HP SFF + Optiplex Cost Rate
 sensor.hp_sff_power_share:
   friendly_name: HP SFF + Optiplex Power Share
-sensor.hp_sff_energy_share_today:
-  friendly_name: HP SFF + Optiplex Energy Share Today
-sensor.hp_sff_voltage:
-  friendly_name: HP SFF + Optiplex Voltage
-sensor.hp_sff_current:
-  friendly_name: HP SFF + Optiplex Current
+sensor.hp_sff_cost_last_month:
+  friendly_name: HP SFF + Optiplex Cost Last Month
+sensor.hp_sff_energy_last_month:
+  friendly_name: HP SFF + Optiplex Energy Last Month
 sensor.hp_sff_energy_daily:
   friendly_name: HP SFF + Optiplex Energy Daily
 sensor.hp_sff_energy_weekly:
@@ -150,135 +157,113 @@ switch.hp_sff:
   friendly_name: HP SFF + Optiplex (read-only)
   hidden: true
 
-# ---------- Shed (HP micro, solar) (entity prefix shed_lab_*) ----------
-sensor.shed_lab_current_consumption:
-  friendly_name: Shed (HP micro, solar) Power
-sensor.shed_lab_energy:
-  friendly_name: Shed (HP micro, solar) Energy
-sensor.shed_lab_cost:
-  friendly_name: Shed (HP micro, solar) Cost
-sensor.shed_lab_cost_rate:
-  friendly_name: Shed (HP micro, solar) Cost Rate
-sensor.shed_lab_power_share:
-  friendly_name: Shed (HP micro, solar) Power Share
-sensor.shed_lab_energy_share_today:
-  friendly_name: Shed (HP micro, solar) Energy Share Today
-sensor.shed_lab_voltage:
-  friendly_name: Shed (HP micro, solar) Voltage
-sensor.shed_lab_current:
-  friendly_name: Shed (HP micro, solar) Current
-sensor.shed_lab_energy_daily:
-  friendly_name: Shed (HP micro, solar) Energy Daily
-sensor.shed_lab_energy_weekly:
-  friendly_name: Shed (HP micro, solar) Energy Weekly
-sensor.shed_lab_energy_monthly:
-  friendly_name: Shed (HP micro, solar) Energy Monthly
-sensor.shed_lab_energy_yearly:
-  friendly_name: Shed (HP micro, solar) Energy Yearly
-sensor.shed_lab_cost_daily:
-  friendly_name: Shed (HP micro, solar) Cost Daily
-sensor.shed_lab_cost_weekly:
-  friendly_name: Shed (HP micro, solar) Cost Weekly
-sensor.shed_lab_cost_monthly:
-  friendly_name: Shed (HP micro, solar) Cost Monthly
-sensor.shed_lab_cost_yearly:
-  friendly_name: Shed (HP micro, solar) Cost Yearly
-switch.shed_lab:
-  friendly_name: Shed (HP micro, solar) (read-only)
+# ---------- HP Elite Mini G9 (hp_elite_*) ----------
+sensor.hp_elite_current_consumption:
+  friendly_name: HP Elite Mini G9 Power
+sensor.hp_elite_voltage:
+  friendly_name: HP Elite Mini G9 Voltage
+sensor.hp_elite_current:
+  friendly_name: HP Elite Mini G9 Current
+sensor.hp_elite_energy:
+  friendly_name: HP Elite Mini G9 Energy
+sensor.hp_elite_cost:
+  friendly_name: HP Elite Mini G9 Cost
+sensor.hp_elite_cost_rate:
+  friendly_name: HP Elite Mini G9 Cost Rate
+sensor.hp_elite_power_share:
+  friendly_name: HP Elite Mini G9 Power Share
+sensor.hp_elite_cost_last_month:
+  friendly_name: HP Elite Mini G9 Cost Last Month
+sensor.hp_elite_energy_last_month:
+  friendly_name: HP Elite Mini G9 Energy Last Month
+sensor.hp_elite_energy_daily:
+  friendly_name: HP Elite Mini G9 Energy Daily
+sensor.hp_elite_energy_weekly:
+  friendly_name: HP Elite Mini G9 Energy Weekly
+sensor.hp_elite_energy_monthly:
+  friendly_name: HP Elite Mini G9 Energy Monthly
+sensor.hp_elite_energy_yearly:
+  friendly_name: HP Elite Mini G9 Energy Yearly
+sensor.hp_elite_cost_daily:
+  friendly_name: HP Elite Mini G9 Cost Daily
+sensor.hp_elite_cost_weekly:
+  friendly_name: HP Elite Mini G9 Cost Weekly
+sensor.hp_elite_cost_monthly:
+  friendly_name: HP Elite Mini G9 Cost Monthly
+sensor.hp_elite_cost_yearly:
+  friendly_name: HP Elite Mini G9 Cost Yearly
+switch.hp_elite:
+  friendly_name: HP Elite Mini G9 (read-only)
   hidden: true
 
-# ---------- Gaming PC (7800X3D + 3090) (entity prefix gaming_pc_*) ----------
+# ---------- Gaming PC (gaming_pc_*) ----------
 sensor.gaming_pc_current_consumption:
-  friendly_name: Gaming PC (7800X3D + 3090) Power
-sensor.gaming_pc_energy:
-  friendly_name: Gaming PC (7800X3D + 3090) Energy
-sensor.gaming_pc_cost:
-  friendly_name: Gaming PC (7800X3D + 3090) Cost
-sensor.gaming_pc_cost_rate:
-  friendly_name: Gaming PC (7800X3D + 3090) Cost Rate
-sensor.gaming_pc_power_share:
-  friendly_name: Gaming PC (7800X3D + 3090) Power Share
-sensor.gaming_pc_energy_share_today:
-  friendly_name: Gaming PC (7800X3D + 3090) Energy Share Today
+  friendly_name: Gaming PC Power
 sensor.gaming_pc_voltage:
-  friendly_name: Gaming PC (7800X3D + 3090) Voltage
+  friendly_name: Gaming PC Voltage
 sensor.gaming_pc_current:
-  friendly_name: Gaming PC (7800X3D + 3090) Current
+  friendly_name: Gaming PC Current
+sensor.gaming_pc_energy:
+  friendly_name: Gaming PC Energy
+sensor.gaming_pc_cost:
+  friendly_name: Gaming PC Cost
+sensor.gaming_pc_cost_rate:
+  friendly_name: Gaming PC Cost Rate
+sensor.gaming_pc_power_share:
+  friendly_name: Gaming PC Power Share
+sensor.gaming_pc_cost_last_month:
+  friendly_name: Gaming PC Cost Last Month
+sensor.gaming_pc_energy_last_month:
+  friendly_name: Gaming PC Energy Last Month
 sensor.gaming_pc_energy_daily:
-  friendly_name: Gaming PC (7800X3D + 3090) Energy Daily
+  friendly_name: Gaming PC Energy Daily
 sensor.gaming_pc_energy_weekly:
-  friendly_name: Gaming PC (7800X3D + 3090) Energy Weekly
+  friendly_name: Gaming PC Energy Weekly
 sensor.gaming_pc_energy_monthly:
-  friendly_name: Gaming PC (7800X3D + 3090) Energy Monthly
+  friendly_name: Gaming PC Energy Monthly
 sensor.gaming_pc_energy_yearly:
-  friendly_name: Gaming PC (7800X3D + 3090) Energy Yearly
+  friendly_name: Gaming PC Energy Yearly
 sensor.gaming_pc_cost_daily:
-  friendly_name: Gaming PC (7800X3D + 3090) Cost Daily
+  friendly_name: Gaming PC Cost Daily
 sensor.gaming_pc_cost_weekly:
-  friendly_name: Gaming PC (7800X3D + 3090) Cost Weekly
+  friendly_name: Gaming PC Cost Weekly
 sensor.gaming_pc_cost_monthly:
-  friendly_name: Gaming PC (7800X3D + 3090) Cost Monthly
+  friendly_name: Gaming PC Cost Monthly
 sensor.gaming_pc_cost_yearly:
-  friendly_name: Gaming PC (7800X3D + 3090) Cost Yearly
-switch.gaming_pc:
-  friendly_name: Gaming PC (7800X3D + 3090)
+  friendly_name: Gaming PC Cost Yearly
 
-# ---------- HP Elite (estimated) (entity prefix hp_elite_estimated_*) ----------
-sensor.hp_elite_estimated_current_consumption:
-  friendly_name: HP Elite (estimated) Power
-sensor.hp_elite_estimated_energy:
-  friendly_name: HP Elite (estimated) Energy
-sensor.hp_elite_estimated_cost:
-  friendly_name: HP Elite (estimated) Cost
-sensor.hp_elite_estimated_cost_rate:
-  friendly_name: HP Elite (estimated) Cost Rate
-sensor.hp_elite_estimated_power_share:
-  friendly_name: HP Elite (estimated) Power Share
-sensor.hp_elite_estimated_energy_share_today:
-  friendly_name: HP Elite (estimated) Energy Share Today
-sensor.hp_elite_estimated_energy_daily:
-  friendly_name: HP Elite (estimated) Energy Daily
-sensor.hp_elite_estimated_energy_weekly:
-  friendly_name: HP Elite (estimated) Energy Weekly
-sensor.hp_elite_estimated_energy_monthly:
-  friendly_name: HP Elite (estimated) Energy Monthly
-sensor.hp_elite_estimated_energy_yearly:
-  friendly_name: HP Elite (estimated) Energy Yearly
-sensor.hp_elite_estimated_cost_daily:
-  friendly_name: HP Elite (estimated) Cost Daily
-sensor.hp_elite_estimated_cost_weekly:
-  friendly_name: HP Elite (estimated) Cost Weekly
-sensor.hp_elite_estimated_cost_monthly:
-  friendly_name: HP Elite (estimated) Cost Monthly
-sensor.hp_elite_estimated_cost_yearly:
-  friendly_name: HP Elite (estimated) Cost Yearly
-
-# ---------- StuckAtPrototype AirCube (Zigbee air-quality, ZHA quirk) ----------
-# Display-only: Grafana matches on the `entity` label, not friendly_name, so renames can't break aircube-dashboard.yaml.
-sensor.stuckatprototype_aircube_temperature:
-  friendly_name: AirCube Temperature
-sensor.stuckatprototype_aircube_humidity:
-  friendly_name: AirCube Humidity
-sensor.stuckatprototype_aircube_equivalent_co2:
-  friendly_name: AirCube eCO2
-sensor.stuckatprototype_aircube_volatile_organic_compounds_parts:
-  friendly_name: AirCube tVOC
-sensor.stuckatprototype_aircube_voc_level:
-  friendly_name: AirCube VOC Level
-number.stuckatprototype_aircube_brightness:
-  friendly_name: AirCube Brightness
-
-# Hidden: rssi/lqi are link diagnostics, `number.stuckatprototype_aircube` is ZHA's raw duplicate
-# of the brightness slider, and identify is a commissioning aid.
-sensor.stuckatprototype_aircube_rssi:
-  friendly_name: AirCube RSSI
-  hidden: true
-sensor.stuckatprototype_aircube_lqi:
-  friendly_name: AirCube LQI
-  hidden: true
-number.stuckatprototype_aircube:
-  friendly_name: AirCube Brightness (duplicate — use AirCube Brightness)
-  hidden: true
-button.stuckatprototype_aircube_identify:
-  friendly_name: AirCube Identify
-  hidden: true
+# ---------- MacBook + Monitor (macbook_*) ----------
+sensor.macbook_current_consumption:
+  friendly_name: MacBook + Monitor Power
+sensor.macbook_voltage:
+  friendly_name: MacBook + Monitor Voltage
+sensor.macbook_current:
+  friendly_name: MacBook + Monitor Current
+sensor.macbook_energy:
+  friendly_name: MacBook + Monitor Energy
+sensor.macbook_cost:
+  friendly_name: MacBook + Monitor Cost
+sensor.macbook_cost_rate:
+  friendly_name: MacBook + Monitor Cost Rate
+sensor.macbook_power_share:
+  friendly_name: MacBook + Monitor Power Share
+sensor.macbook_cost_last_month:
+  friendly_name: MacBook + Monitor Cost Last Month
+sensor.macbook_energy_last_month:
+  friendly_name: MacBook + Monitor Energy Last Month
+sensor.macbook_energy_daily:
+  friendly_name: MacBook + Monitor Energy Daily
+sensor.macbook_energy_weekly:
+  friendly_name: MacBook + Monitor Energy Weekly
+sensor.macbook_energy_monthly:
+  friendly_name: MacBook + Monitor Energy Monthly
+sensor.macbook_energy_yearly:
+  friendly_name: MacBook + Monitor Energy Yearly
+sensor.macbook_cost_daily:
+  friendly_name: MacBook + Monitor Cost Daily
+sensor.macbook_cost_weekly:
+  friendly_name: MacBook + Monitor Cost Weekly
+sensor.macbook_cost_monthly:
+  friendly_name: MacBook + Monitor Cost Monthly
+sensor.macbook_cost_yearly:
+  friendly_name: MacBook + Monitor Cost Yearly

--- a/my-apps/home/home-assistant/lovelace-homelab-power.yaml
+++ b/my-apps/home/home-assistant/lovelace-homelab-power.yaml
@@ -9,29 +9,26 @@ views:
       - type: markdown
         content: |
           # Homelab Power & Cost
-          Live draw, per-device share and time-of-use cost across the cluster
-          hosts, the NAS and the office workstation. Cost uses the **all-in
-          marginal rate** (energy + delivery riders + tax), which varies by
-          season and peak/off-peak window.
+          Every box sits behind a Tapo P115 plug. **Homelab** is the five always-on
+          servers, **Office** is the Gaming PC and the MacBook, **Combined** is both.
+          Cost uses the **all-in marginal rate** (energy + delivery riders + tax),
+          which varies by season and peak/off-peak window.
 
-          Two figures are not measurements. **HP Elite** has no plug — its draw
-          is the assumed number set below. **The shed runs on solar**, so it
-          contributes watts but no cost, and *billable draw* is the total minus
-          the shed.
-
-          The **HP SFF** plug feeds the HP SFF *and* the Dell Optiplex on one
-          outlet. Switches are locked read-only except the Gaming PC — see the
-          `Homelab plug power-off lockout` automation.
+          The **HP SFF** plug feeds two hosts (HP 8500 + Optiplex 8500), so its draw
+          cannot be split. Homelab switches are locked read-only by the
+          `Homelab plug power-off lockout` automation; the office plugs are not.
 
       - type: entities
-        title: Rate & assumptions
+        title: Rate
         entities:
           - entity: sensor.current_electricity_rate
             name: Effective rate
           - entity: sensor.electricity_tariff_period
             name: Tariff window
           - entity: sensor.homelab_cost_rate
-            name: Burn rate (USD/h)
+            name: Homelab burn rate (USD/h)
+          - entity: sensor.office_cost_rate
+            name: Office burn rate (USD/h)
           - type: section
             label: Inputs (temporary — git is source of truth)
           - entity: input_number.rate_summer_onpeak
@@ -44,8 +41,6 @@ views:
             name: Delivery riders
           - entity: input_number.rate_sales_tax_pct
             name: Sales tax
-          - entity: input_number.hp_elite_estimated_watts
-            name: HP Elite (estimated) assumed draw
 
       - type: glance
         title: Live draw
@@ -53,26 +48,28 @@ views:
         columns: 4
         entities:
           - entity: sensor.homelab_total_power
-            name: TOTAL
-          - entity: sensor.homelab_grid_power
-            name: Billable
-          - entity: sensor.gpu_psu_current_consumption
+            name: HOMELAB
+          - entity: sensor.office_total_power
+            name: OFFICE
+          - entity: sensor.combined_total_power
+            name: COMBINED
+          - entity: sensor.threadripper_current_consumption
             name: Threadripper Host
           - entity: sensor.nas_psu_current_consumption
             name: NAS Drive PSU
-          - entity: sensor.truenas_server_current_consumption
+          - entity: sensor.truenas_current_consumption
             name: TrueNAS (DL360)
           - entity: sensor.hp_sff_current_consumption
             name: HP SFF + Optiplex
-          - entity: sensor.shed_lab_current_consumption
-            name: Shed (HP micro, solar)
+          - entity: sensor.hp_elite_current_consumption
+            name: HP Elite Mini G9
           - entity: sensor.gaming_pc_current_consumption
-            name: Gaming PC (7800X3D + 3090)
-          - entity: sensor.hp_elite_estimated_current_consumption
-            name: HP Elite (estimated)
+            name: Gaming PC
+          - entity: sensor.macbook_current_consumption
+            name: MacBook + Monitor
 
       - type: glance
-        title: Cost so far
+        title: Homelab cost so far
         show_state: true
         columns: 4
         entities:
@@ -86,7 +83,35 @@ views:
             name: This Year
 
       - type: glance
-        title: Last completed month
+        title: Office cost so far
+        show_state: true
+        columns: 4
+        entities:
+          - entity: sensor.office_cost_daily
+            name: Today
+          - entity: sensor.office_cost_weekly
+            name: This Week
+          - entity: sensor.office_cost_monthly
+            name: This Month
+          - entity: sensor.office_cost_yearly
+            name: This Year
+
+      - type: glance
+        title: Combined cost so far
+        show_state: true
+        columns: 4
+        entities:
+          - entity: sensor.combined_cost_daily
+            name: Today
+          - entity: sensor.combined_cost_weekly
+            name: This Week
+          - entity: sensor.combined_cost_monthly
+            name: This Month
+          - entity: sensor.combined_cost_yearly
+            name: This Year
+
+      - type: glance
+        title: Last completed month (homelab)
         show_state: true
         columns: 3
         entities:
@@ -97,49 +122,61 @@ views:
           - entity: sensor.homelab_cost_yesterday
             name: Cost yesterday
 
+      - type: glance
+        title: Last completed month (office)
+        show_state: true
+        columns: 3
+        entities:
+          - entity: sensor.office_cost_last_month
+            name: Cost last month
+          - entity: sensor.office_total_energy_last_month
+            name: Energy last month
+          - entity: sensor.office_cost_yesterday
+            name: Cost yesterday
+
       - type: entities
         title: Cost last month — per device
         entities:
-          - entity: sensor.gpu_psu_cost_last_month
+          - entity: sensor.threadripper_cost_last_month
             name: Threadripper Host
           - entity: sensor.nas_psu_cost_last_month
             name: NAS Drive PSU
-          - entity: sensor.truenas_server_cost_last_month
+          - entity: sensor.truenas_cost_last_month
             name: TrueNAS (DL360)
           - entity: sensor.hp_sff_cost_last_month
             name: HP SFF + Optiplex
-          - entity: sensor.shed_lab_cost_last_month
-            name: Shed (HP micro, solar)
+          - entity: sensor.hp_elite_cost_last_month
+            name: HP Elite Mini G9
           - entity: sensor.gaming_pc_cost_last_month
-            name: Gaming PC (7800X3D + 3090)
-          - entity: sensor.hp_elite_estimated_cost_last_month
-            name: HP Elite (estimated)
+            name: Gaming PC
+          - entity: sensor.macbook_cost_last_month
+            name: MacBook + Monitor
 
       - type: entities
         title: Energy last month — per device
         entities:
-          - entity: sensor.gpu_psu_energy_last_month
+          - entity: sensor.threadripper_energy_last_month
             name: Threadripper Host
           - entity: sensor.nas_psu_energy_last_month
             name: NAS Drive PSU
-          - entity: sensor.truenas_server_energy_last_month
+          - entity: sensor.truenas_energy_last_month
             name: TrueNAS (DL360)
           - entity: sensor.hp_sff_energy_last_month
             name: HP SFF + Optiplex
-          - entity: sensor.shed_lab_energy_last_month
-            name: Shed (HP micro, solar)
+          - entity: sensor.hp_elite_energy_last_month
+            name: HP Elite Mini G9
           - entity: sensor.gaming_pc_energy_last_month
-            name: Gaming PC (7800X3D + 3090)
-          - entity: sensor.hp_elite_estimated_energy_last_month
-            name: HP Elite (estimated)
+            name: Gaming PC
+          - entity: sensor.macbook_energy_last_month
+            name: MacBook + Monitor
 
       - type: grid
-        title: Share of total draw
-        columns: 3
+        title: Share of combined draw
+        columns: 4
         square: false
         cards:
           - type: gauge
-            entity: sensor.gpu_psu_power_share
+            entity: sensor.threadripper_power_share
             name: Threadripper Host
             unit: "%"
             min: 0
@@ -153,7 +190,7 @@ views:
             max: 100
             needle: true
           - type: gauge
-            entity: sensor.truenas_server_power_share
+            entity: sensor.truenas_power_share
             name: TrueNAS (DL360)
             unit: "%"
             min: 0
@@ -167,22 +204,22 @@ views:
             max: 100
             needle: true
           - type: gauge
-            entity: sensor.shed_lab_power_share
-            name: Shed (HP micro, solar)
+            entity: sensor.hp_elite_power_share
+            name: HP Elite Mini G9
             unit: "%"
             min: 0
             max: 100
             needle: true
           - type: gauge
             entity: sensor.gaming_pc_power_share
-            name: Gaming PC (7800X3D + 3090)
+            name: Gaming PC
             unit: "%"
             min: 0
             max: 100
             needle: true
           - type: gauge
-            entity: sensor.hp_elite_estimated_power_share
-            name: HP Elite (estimated)
+            entity: sensor.macbook_power_share
+            name: MacBook + Monitor
             unit: "%"
             min: 0
             max: 100
@@ -191,60 +228,62 @@ views:
       - type: entities
         title: Cost today
         entities:
-          - entity: sensor.gpu_psu_cost_daily
+          - entity: sensor.threadripper_cost_daily
             name: Threadripper Host
           - entity: sensor.nas_psu_cost_daily
             name: NAS Drive PSU
-          - entity: sensor.truenas_server_cost_daily
+          - entity: sensor.truenas_cost_daily
             name: TrueNAS (DL360)
           - entity: sensor.hp_sff_cost_daily
             name: HP SFF + Optiplex
-          - entity: sensor.shed_lab_cost_daily
-            name: Shed (HP micro, solar)
+          - entity: sensor.hp_elite_cost_daily
+            name: HP Elite Mini G9
           - entity: sensor.gaming_pc_cost_daily
-            name: Gaming PC (7800X3D + 3090)
-          - entity: sensor.hp_elite_estimated_cost_daily
-            name: HP Elite (estimated)
+            name: Gaming PC
+          - entity: sensor.macbook_cost_daily
+            name: MacBook + Monitor
 
       - type: entities
         title: Cost this month
         entities:
-          - entity: sensor.gpu_psu_cost_monthly
+          - entity: sensor.threadripper_cost_monthly
             name: Threadripper Host
           - entity: sensor.nas_psu_cost_monthly
             name: NAS Drive PSU
-          - entity: sensor.truenas_server_cost_monthly
+          - entity: sensor.truenas_cost_monthly
             name: TrueNAS (DL360)
           - entity: sensor.hp_sff_cost_monthly
             name: HP SFF + Optiplex
-          - entity: sensor.shed_lab_cost_monthly
-            name: Shed (HP micro, solar)
+          - entity: sensor.hp_elite_cost_monthly
+            name: HP Elite Mini G9
           - entity: sensor.gaming_pc_cost_monthly
-            name: Gaming PC (7800X3D + 3090)
-          - entity: sensor.hp_elite_estimated_cost_monthly
-            name: HP Elite (estimated)
+            name: Gaming PC
+          - entity: sensor.macbook_cost_monthly
+            name: MacBook + Monitor
 
       - type: history-graph
         title: Power draw (24h)
         hours_to_show: 24
         refresh_interval: 30
         entities:
-          - entity: sensor.gpu_psu_current_consumption
+          - entity: sensor.threadripper_current_consumption
             name: Threadripper Host
           - entity: sensor.nas_psu_current_consumption
             name: NAS Drive PSU
-          - entity: sensor.truenas_server_current_consumption
+          - entity: sensor.truenas_current_consumption
             name: TrueNAS (DL360)
           - entity: sensor.hp_sff_current_consumption
             name: HP SFF + Optiplex
-          - entity: sensor.shed_lab_current_consumption
-            name: Shed (HP micro, solar)
+          - entity: sensor.hp_elite_current_consumption
+            name: HP Elite Mini G9
           - entity: sensor.gaming_pc_current_consumption
-            name: Gaming PC (7800X3D + 3090)
-          - entity: sensor.hp_elite_estimated_current_consumption
-            name: HP Elite (estimated)
+            name: Gaming PC
+          - entity: sensor.macbook_current_consumption
+            name: MacBook + Monitor
           - entity: sensor.homelab_total_power
-            name: TOTAL
+            name: HOMELAB
+          - entity: sensor.office_total_power
+            name: OFFICE
 
       - type: statistics-graph
         title: Energy by day (30d)
@@ -254,13 +293,13 @@ views:
         stat_types:
           - change
         entities:
-          - sensor.gpu_psu_energy
+          - sensor.threadripper_energy
           - sensor.nas_psu_energy
-          - sensor.truenas_server_energy
+          - sensor.truenas_energy
           - sensor.hp_sff_energy
-          - sensor.shed_lab_energy
+          - sensor.hp_elite_energy
           - sensor.gaming_pc_energy
-          - sensor.hp_elite_estimated_energy
+          - sensor.macbook_energy
 
       - type: statistics-graph
         title: Cost by month (12 months)
@@ -270,16 +309,16 @@ views:
         stat_types:
           - change
         entities:
-          - sensor.gpu_psu_cost
+          - sensor.threadripper_cost
           - sensor.nas_psu_cost
-          - sensor.truenas_server_cost
+          - sensor.truenas_cost
           - sensor.hp_sff_cost
-          - sensor.shed_lab_cost
+          - sensor.hp_elite_cost
           - sensor.gaming_pc_cost
-          - sensor.hp_elite_estimated_cost
+          - sensor.macbook_cost
 
       - type: statistics-graph
-        title: Total cost by month
+        title: Homelab vs office cost by month
         chart_type: bar
         period: month
         days_to_show: 365
@@ -287,32 +326,33 @@ views:
           - change
         entities:
           - sensor.homelab_cost
+          - sensor.office_cost
 
       - type: entities
         title: Per-device detail
         entities:
           - type: section
             label: Threadripper Host
-          - entity: sensor.gpu_psu_current_consumption
+          - entity: sensor.threadripper_current_consumption
             name: Power now
-          - entity: sensor.gpu_psu_power_share
-            name: Share of total
-          - entity: sensor.gpu_psu_energy_daily
+          - entity: sensor.threadripper_power_share
+            name: Share of combined
+          - entity: sensor.threadripper_energy_daily
             name: Energy today
-          - entity: sensor.gpu_psu_cost_daily
+          - entity: sensor.threadripper_cost_daily
             name: Cost today
-          - entity: sensor.gpu_psu_cost_monthly
+          - entity: sensor.threadripper_cost_monthly
             name: Cost this month
-          - entity: sensor.gpu_psu_voltage
+          - entity: sensor.threadripper_voltage
             name: Voltage
-          - entity: sensor.gpu_psu_current
+          - entity: sensor.threadripper_current
             name: Current
           - type: section
             label: NAS Drive PSU
           - entity: sensor.nas_psu_current_consumption
             name: Power now
           - entity: sensor.nas_psu_power_share
-            name: Share of total
+            name: Share of combined
           - entity: sensor.nas_psu_energy_daily
             name: Energy today
           - entity: sensor.nas_psu_cost_daily
@@ -325,26 +365,26 @@ views:
             name: Current
           - type: section
             label: TrueNAS (DL360)
-          - entity: sensor.truenas_server_current_consumption
+          - entity: sensor.truenas_current_consumption
             name: Power now
-          - entity: sensor.truenas_server_power_share
-            name: Share of total
-          - entity: sensor.truenas_server_energy_daily
+          - entity: sensor.truenas_power_share
+            name: Share of combined
+          - entity: sensor.truenas_energy_daily
             name: Energy today
-          - entity: sensor.truenas_server_cost_daily
+          - entity: sensor.truenas_cost_daily
             name: Cost today
-          - entity: sensor.truenas_server_cost_monthly
+          - entity: sensor.truenas_cost_monthly
             name: Cost this month
-          - entity: sensor.truenas_server_voltage
+          - entity: sensor.truenas_voltage
             name: Voltage
-          - entity: sensor.truenas_server_current
+          - entity: sensor.truenas_current
             name: Current
           - type: section
             label: HP SFF + Optiplex
           - entity: sensor.hp_sff_current_consumption
             name: Power now
           - entity: sensor.hp_sff_power_share
-            name: Share of total
+            name: Share of combined
           - entity: sensor.hp_sff_energy_daily
             name: Energy today
           - entity: sensor.hp_sff_cost_daily
@@ -356,27 +396,27 @@ views:
           - entity: sensor.hp_sff_current
             name: Current
           - type: section
-            label: Shed (HP micro, solar)
-          - entity: sensor.shed_lab_current_consumption
+            label: HP Elite Mini G9
+          - entity: sensor.hp_elite_current_consumption
             name: Power now
-          - entity: sensor.shed_lab_power_share
-            name: Share of total
-          - entity: sensor.shed_lab_energy_daily
+          - entity: sensor.hp_elite_power_share
+            name: Share of combined
+          - entity: sensor.hp_elite_energy_daily
             name: Energy today
-          - entity: sensor.shed_lab_cost_daily
+          - entity: sensor.hp_elite_cost_daily
             name: Cost today
-          - entity: sensor.shed_lab_cost_monthly
+          - entity: sensor.hp_elite_cost_monthly
             name: Cost this month
-          - entity: sensor.shed_lab_voltage
+          - entity: sensor.hp_elite_voltage
             name: Voltage
-          - entity: sensor.shed_lab_current
+          - entity: sensor.hp_elite_current
             name: Current
           - type: section
-            label: Gaming PC (7800X3D + 3090)
+            label: Gaming PC
           - entity: sensor.gaming_pc_current_consumption
             name: Power now
           - entity: sensor.gaming_pc_power_share
-            name: Share of total
+            name: Share of combined
           - entity: sensor.gaming_pc_energy_daily
             name: Energy today
           - entity: sensor.gaming_pc_cost_daily
@@ -388,14 +428,18 @@ views:
           - entity: sensor.gaming_pc_current
             name: Current
           - type: section
-            label: HP Elite (estimated)
-          - entity: sensor.hp_elite_estimated_current_consumption
+            label: MacBook + Monitor
+          - entity: sensor.macbook_current_consumption
             name: Power now
-          - entity: sensor.hp_elite_estimated_power_share
-            name: Share of total
-          - entity: sensor.hp_elite_estimated_energy_daily
+          - entity: sensor.macbook_power_share
+            name: Share of combined
+          - entity: sensor.macbook_energy_daily
             name: Energy today
-          - entity: sensor.hp_elite_estimated_cost_daily
+          - entity: sensor.macbook_cost_daily
             name: Cost today
-          - entity: sensor.hp_elite_estimated_cost_monthly
+          - entity: sensor.macbook_cost_monthly
             name: Cost this month
+          - entity: sensor.macbook_voltage
+            name: Voltage
+          - entity: sensor.macbook_current
+            name: Current


### PR DESCRIPTION
## Summary
- Rebuild the Home Assistant power config around the seven Tapo plugs that actually exist: shed plug removed, HP Elite Mini gets its real plug (30 W estimate retired), MacBook + Monitor added. HP SFF stays a two-host plug.
- Entity prefixes renamed to match hardware (`threadripper`, `truenas`, `hp_elite`, `macbook`); history is being reset on purpose.
- Three groups: `homelab_*` (five servers, the bill number), `office_*` (Gaming PC + MacBook), `combined_*`, each with power/energy/cost, four meter cycles, last-month and yesterday sensors.
- Lockout automation covers the five homelab switches; office plugs are free.
- Both Grafana dashboards regenerated; plug names derive from `friendly_name` via one regex `label_replace`.
- `docs/domains/power/metering.md` rewritten, with a section on resetting history.

## Validation
- HA `check_config` passes against the new files inside the running pod.
- Every entity referenced by Lovelace and both dashboards resolves to a defined sensor.
- `kustomize build` renders for `my-apps/home/home-assistant` and `monitoring/prometheus-stack`.

## After merge (manual, one-off)
Rollout-restart HA, then inside the pod: rename the raw Tapo entities to the new prefixes, drop orphaned old registry entries, rename devices, rewrite the Energy dashboard device list, delete the recorder DB (+2.7 GB corrupt copies) and `core.restore_state`, kill the HA process so old totals are not written back. Old Prometheus series age out in 15 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKVvajhmCcNMv4DoK8s8Ln