### PR TITLE
feat(temporal): move Temporal Postgres to longhorn-wired-ha

### DIFF
--- a/docs/domains/storage/pvc-storageclass-migration.md
+++ b/docs/domains/storage/pvc-storageclass-migration.md
@@ -1,0 +1,171 @@
+# Move a kopiur-backed PVC to another StorageClass
+
+**Purpose:** change the StorageClass of an existing PVC (for example `longhorn` →
+`longhorn-wired-ha`) without losing data.
+**Status:** runbook, current truth.
+**Scope:** one PVC and its `Restore` CR. Nothing else in the Application changes.
+Kubernetes treats `spec.storageClassName` as immutable, so the only path is the
+same restore-before-bind flow the cluster already uses for disaster recovery:
+snapshot → delete PVC + `Restore` → let Argo CD recreate both → kopiur hydrates
+the new volume from the snapshot.
+
+## Prerequisites
+
+- The target class provisions and places replicas the way you expect. Prove it
+  with a disposable PVC first (see "Canary" below).
+- The PVC is on the `kopiur-backup` component: `SnapshotPolicy`, `SnapshotSchedule`,
+  `Restore`, and a `dataSourceRef` pointing at the `Restore`.
+- The last scheduled `Snapshot` is `Succeeded` and the Longhorn volume is `healthy`.
+- The workload is a single writer you can pause (a Postgres Deployment qualifies).
+- A merged Git change that sets the new `storageClassName` on the PVC. Until the
+  PVC is recreated, Argo CD reports that resource as failing to sync
+  ("field is immutable"). That is expected; run the cutover right after merge.
+
+## Canary
+
+```sh
+kubectl create ns sc-canary
+kubectl -n sc-canary apply -f - <<'YAML'
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: { name: canary }
+spec: { accessModes: [ReadWriteOnce], storageClassName: <new-class>, resources: { requests: { storage: 2Gi } } }
+YAML
+kubectl -n sc-canary run writer --image=busybox:1.37 --restart=Never --overrides='{"spec":{"containers":[{"name":"w","image":"busybox:1.37","command":["sh","-c","head -c 64M /dev/urandom >/data/blob; sha256sum /data/blob >/data/blob.sha; sync; sleep 3600"],"volumeMounts":[{"name":"d","mountPath":"/data"}]}],"volumes":[{"name":"d","persistentVolumeClaim":{"claimName":"canary"}}]}}'
+PV=$(kubectl -n sc-canary get pvc canary -o jsonpath='{.spec.volumeName}')
+kubectl -n longhorn-system get replicas.longhorn.io -l longhornvolume=$PV -o custom-columns='NAME:.metadata.name,NODE:.spec.nodeID,STATE:.status.currentState'
+```
+
+Expected: one replica per distinct node. Then delete one replica CR and confirm
+Longhorn rebuilds it and the data still verifies:
+
+```sh
+kubectl -n longhorn-system delete replicas.longhorn.io <one-replica-name>
+kubectl -n longhorn-system get volumes.longhorn.io $PV -o jsonpath='{.status.robustness}'   # healthy again within ~1 min
+kubectl -n sc-canary exec writer -- sh -c 'cd /data && sha256sum -c blob.sha'                 # blob: OK
+kubectl delete ns sc-canary
+```
+
+## Cutover (worked example: `temporal/temporal-postgres-data`)
+
+Replace names for another PVC. `<ns>` is `temporal`, `<pvc>` is
+`temporal-postgres-data`, `<restore>` is `temporal-postgres-data-restore`.
+
+1. **Keep the old volume as a fallback.** Nothing is deleted until step 8.
+
+   ```sh
+   OLD_PV=$(kubectl -n <ns> get pvc <pvc> -o jsonpath='{.spec.volumeName}')
+   kubectl patch pv $OLD_PV -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+   ```
+
+2. **Stop writers without touching the pod.** A temporary NetworkPolicy blocks
+   every client; terminating open sessions forces reconnects into the block.
+   Argo CD does not manage this object, so it will not remove it for you.
+
+   ```sh
+   kubectl -n <ns> apply -f - <<'YAML'
+   apiVersion: networking.k8s.io/v1
+   kind: NetworkPolicy
+   metadata: { name: cutover-quiesce }
+   spec:
+     podSelector: { matchLabels: { app: temporal-postgres } }
+     policyTypes: [Ingress]
+   YAML
+   kubectl -n <ns> exec deploy/temporal-postgres -c postgres -- psql -U temporal -d temporal -c \
+     "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE backend_type='client backend' AND pid<>pg_backend_pid();"
+   kubectl -n <ns> exec deploy/temporal-postgres -c postgres -- psql -U temporal -d temporal -c \
+     "SELECT count(*) FROM pg_stat_activity WHERE backend_type='client backend' AND pid<>pg_backend_pid();"
+   ```
+
+   Expected: the count is `0` and stays `0` on a second run. Temporal services
+   log persistence errors while blocked; that is the point.
+
+3. **Take the cutover snapshot.** Manual `Snapshot` CRs reuse the policy (hooks,
+   identity, mover uid). `Retain` keeps the kopia snapshot if the CR is later
+   deleted; `pin` exempts it from retention.
+
+   ```sh
+   kubectl -n <ns> apply -f - <<'YAML'
+   apiVersion: kopiur.home-operations.com/v1alpha1
+   kind: Snapshot
+   metadata: { name: <pvc>-cutover }
+   spec:
+     policyRef: { name: <pvc> }
+     deletionPolicy: Retain
+     pin: true
+   YAML
+   kubectl -n <ns> get snapshot <pvc>-cutover -o jsonpath='{.status.phase} {.status.snapshot.kopiaSnapshotID}{"\n"}'
+   ```
+
+   Expected: `Succeeded <kopia-id>` within a few minutes. Write the id down.
+
+4. **Recreate the claim.** Delete the `Restore` first: it pins its snapshot at
+   admission and never re-resolves, so a leftover `Restore` would hydrate an old
+   snapshot. The pod must go too, or PVC protection keeps the claim alive.
+
+   ```sh
+   kubectl -n <ns> delete restore <restore>
+   kubectl -n <ns> delete pvc <pvc> --wait=false
+   kubectl -n <ns> delete pod -l app=temporal-postgres
+   kubectl -n <ns> get pvc <pvc>          # NotFound within ~1 min
+   kubectl get pv $OLD_PV                 # Released
+   kubectl -n argocd annotate application <app> argocd.argoproj.io/refresh=normal --overwrite
+   ```
+
+5. **Check the pin before the bytes.**
+
+   ```sh
+   kubectl -n <ns> get restore <restore> -o jsonpath='{.status.resolved.pinnedAt} {.status.resolved.kopiaSnapshotID}{"\n"}'
+   kubectl -n <ns> get pvc <pvc> -o jsonpath='{.status.phase} {.spec.storageClassName}{"\n"}'
+   ```
+
+   Expected: the kopia id from step 3, a `pinnedAt` newer than it, and the PVC
+   moving `Pending → Bound` on the new class. A PVC that binds instantly never
+   ran the populator; stop and inspect the `Restore` conditions.
+
+6. **Verify the volume and the database.**
+
+   ```sh
+   NEW_PV=$(kubectl -n <ns> get pvc <pvc> -o jsonpath='{.spec.volumeName}')
+   kubectl -n longhorn-system get replicas.longhorn.io -l longhornvolume=$NEW_PV -o custom-columns='NODE:.spec.nodeID,STATE:.status.currentState'
+   kubectl -n <ns> logs deploy/temporal-postgres -c postgres | grep -E "redo done|ready to accept"
+   kubectl -n <ns> exec deploy/temporal-postgres -c postgres -- psql -U temporal -d temporal -tc "SELECT pg_is_in_recovery();"
+   ```
+
+   Expected: replicas on distinct nodes, `redo done` then `ready to accept
+   connections`, and `f`.
+
+7. **Release the writers.**
+
+   ```sh
+   kubectl -n <ns> delete networkpolicy cutover-quiesce
+   kubectl -n <ns> exec deploy/temporal-admintools -- temporal operator cluster health   # SERVING
+   kubectl -n <ns> exec deploy/temporal-admintools -- temporal schedule list --namespace default
+   kubectl -n <ns> exec deploy/temporal-admintools -- tdbg dlq list                     # count unchanged
+   ```
+
+8. **Retire the old volume** only after the next scheduled `Snapshot` on the new
+   volume is `Succeeded`.
+
+   ```sh
+   kubectl -n <ns> get snapshot --sort-by=.metadata.creationTimestamp | tail -2
+   kubectl delete pv $OLD_PV
+   ```
+
+## Failure path
+
+- **PVC stuck `Pending`, `Restore` shows `Stalled`:** the repository is
+  unreachable or the mover cannot read. Fix the cause; kopiur retries. Nothing
+  binds empty (restore-before-bind fails closed).
+- **Wrong snapshot pinned:** delete the `Restore` and the PVC again; the next
+  admission pins the newest snapshot.
+- **Roll back the class:** revert the Git change, then repeat step 4. The
+  cutover snapshot restores equally well onto the old class.
+- **Last resort:** the Retained old PV still holds the pre-cutover bytes until
+  step 8. Bind it with a PVC that sets `volumeName` and no `dataSourceRef`.
+
+## Source of truth
+
+- StorageClass contract: [storage-tiers.md](storage-tiers.md)
+- Backup/restore mechanics and the `Restore` pin: [kopiur-backup-architecture.md](kopiur-backup-architecture.md), [../../disaster-recovery.md](../../disaster-recovery.md)
+- Worked example manifests: `my-apps/development/temporal/postgres/pvc.yaml`, `my-apps/development/temporal/kopiur/temporal-postgres-data.yaml`

--- a/docs/domains/storage/storage-tiers.md
+++ b/docs/domains/storage/storage-tiers.md
@@ -26,7 +26,8 @@ distinct classes, and you choose per volume:
 
 `longhorn-wired-ha` is opt-in and fails closed until at least two healthy,
 distinct-zone Longhorn nodes have the `wired-storage` node tag. Adding the class
-does not migrate existing PVCs; use a new or restore-before-bind PVC for adoption.
+does not migrate existing PVCs; use a new or restore-before-bind PVC for adoption
+(runbook: [pvc-storageclass-migration.md](pvc-storageclass-migration.md)).
 
 The tag comes from the Omni cluster template: the `hp-sff`, `hp-elite`, and `dell`
 worker blocks set the `node.longhorn.io/default-node-tags` node annotation, which

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ Backups are **kopiur** (Kopia-native operator).
 - **GitOps / ArgoCD**: [argocd](domains/argocd/argocd.md) · [entrypoints & waves](domains/argocd/entrypoints.md)
 - **Enterprise multi-cluster planning**: [roadmap](domains/multicluster/enterprise-gitops-roadmap.md) · [concrete fleet PRD](domains/multicluster/prd.md)
 - **Networking**: [topology](domains/networking/topology.md) · [Dell Proxmox Talos worker](domains/networking/dell-proxmox-talos-worker.md) · [policy](domains/networking/policy.md) · [Technitium `vanillax.me` migration](domains/networking/technitium-vanillax-me-migration.md)
-- **Storage**: [kopia maintenance](domains/storage/kopia-maintenance-plan.md) · [RWO/RWX model & sizing](domains/storage/storage-model-rwo-rwx-and-sizing.md) · [RustFS credentials](domains/rustfs/credential-runbook.md) · [future: tiered storage](domains/storage/architecture-future.md)
+- **Storage**: [move a PVC to another StorageClass](domains/storage/pvc-storageclass-migration.md) · [kopia maintenance](domains/storage/kopia-maintenance-plan.md) · [RWO/RWX model & sizing](domains/storage/storage-model-rwo-rwx-and-sizing.md) · [RustFS credentials](domains/rustfs/credential-runbook.md) · [future: tiered storage](domains/storage/architecture-future.md)
 - **Observability**: [radar-ng](domains/observability/radar-ng.md)
 - **Scheduling**: [VPA policy ownership and topology](domains/scheduling/vpa-and-topology.md)
 - **Power**: [wall-plug metering, cost model and the power-off lockout](domains/power/metering.md)

--- a/my-apps/development/temporal/README.md
+++ b/my-apps/development/temporal/README.md
@@ -144,8 +144,12 @@ server:
 `postgres/deployment.yaml` serves two databases: workflow history and
 searchable visibility. Its RWO Deployment uses `Recreate`, and
 `kopiur/temporal-postgres-data.yaml` provides restore-before-bind backups.
-This is one database instance, not database HA. Longhorn handles a disk or
-node loss; kopiur is the independent restore path.
+The PVC is on `longhorn-wired-ha`: two synchronous replicas on distinct
+wired-storage nodes, and the pod is pinned to wired nodes as well. This is one
+database instance, not database HA. Longhorn survives one node or disk loss
+with a full copy intact; kopiur is the independent restore path. Changing the
+StorageClass again is a restore-before-bind recreation, see
+[pvc-storageclass-migration.md](../../../docs/domains/storage/pvc-storageclass-migration.md).
 
 > 💡 **`numHistoryShards: 1`** is set in our values.yaml. This is
 > **permanent for this Temporal database** — changing it requires a new

--- a/my-apps/development/temporal/postgres/deployment.yaml
+++ b/my-apps/development/temporal/postgres/deployment.yaml
@@ -23,6 +23,15 @@ spec:
     spec:
       # SIGINT = Postgres fast shutdown; 60s covers a busy checkpoint before SIGKILL.
       terminationGracePeriodSeconds: 60
+      # Replicas live on wired-storage nodes; keep the engine there too so a wifi/house node never fronts the DB.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.vanillax.dev/link
+                    operator: In
+                    values: ["wired"]
       securityContext:
         fsGroup: 999 # postgres uid:gid in the official image
       containers:

--- a/my-apps/development/temporal/postgres/pvc.yaml
+++ b/my-apps/development/temporal/postgres/pvc.yaml
@@ -15,7 +15,8 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: longhorn # needs CSI VolumeSnapshot for kopiur
+  # Immutable: changing the class means restore-before-bind recreation (docs/domains/storage/pvc-storageclass-migration.md).
+  storageClassName: longhorn-wired-ha # two replicas on distinct wired nodes; Longhorn CSI snapshots for kopiur
   dataSourceRef:
     apiGroup: kopiur.home-operations.com
     kind: Restore


### PR DESCRIPTION
## What

Moves `temporal/temporal-postgres-data` from `longhorn` (1 replica) to `longhorn-wired-ha` (2 synchronous replicas on distinct `wired-storage` nodes) and pins the Postgres pod to wired nodes. Adds the generic runbook for changing a kopiur-backed PVC's StorageClass: `docs/domains/storage/pvc-storageclass-migration.md`.

## Why

2026-09-03 16:18Z: the hp-elite Proxmox host hard-reset (I219-LM e1000e unit hangs, see Mink `hp-elite-proxmox-hard-reset-and-e1000e-incident-2026-09-02`). Temporal Postgres and its **only** Longhorn replica were on that node. The WAL tail was lost; Longhorn salvaged the replica and rebuilt a local copy from it on the gpu node; Postgres refused to start (`could not locate a valid checkpoint record`) for 22h. Alerts fired into Keep but nothing paged. Restored 2026-09-04 15:06Z from kopiur `temporal-postgres-data-hourly-20260903160600` (kopia `5772eeec…`, 11 min of history lost). DLQ still 5 messages, radar schedules firing again.

Interim guard already applied live: the restored volume `pvc-38ea2308…` was patched to `numberOfReplicas: 2` (second replica healthy on hp-sff). The corrupt PV `pvc-fcfecb3b…` is `Released`/`Retain` for forensics; delete it once nobody needs it.

## Canary (gate 3 of #2192) — passed 2026-09-04

Disposable PVC on `longhorn-wired-ha`: replicas landed on hp-sff + hp-elite, deleting one replica CR rebuilt in ~34s, 64 MiB sha256 verified intact. Namespace removed.

## Merge = start of cutover

`storageClassName` is immutable. After merge Argo reports the PVC as failing to sync ("field is immutable") until the claim is recreated. Run the runbook's **Cutover** section right after merging: quiesce via NetworkPolicy → manual pinned `Snapshot` → delete `Restore` + PVC + pod → verify the pin equals the cutover snapshot → verify two replicas on distinct nodes → remove the NetworkPolicy → retire the old PV after the next hourly snapshot succeeds.

## Validation

- `kustomize build --enable-helm` renders `storageClassName: longhorn-wired-ha` and the wired nodeAffinity.
- `validate-argocd-apps.sh` PASSED, `validate-no-inline-scripts.sh` clean, `validate-kopiur-coverage.py` OK. `validate-vpa-policies.py` output identical to `main` for this app.

## Follow-ups (not in this PR)

- `keep/keep-postgres-data` has the same exposure (single replica, currently on hp-elite).
- Page on `severity=critical` (Alertmanager push receiver) and port the Postgres-down rules from #2192 to the shared Temporal.
- Unblocks #2192: gate 1 (tags live) and gate 3 (canary) are done; gate 2 (1Password `radar_temporal_db_password`) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ei1yKFfDcm9j9Nt7P6cPS7
