### PR TITLE
feat(longhorn): drain by eviction, freeze fs for snapshots, drop autoscaler flag

### DIFF
--- a/infrastructure/storage/longhorn/node-failure-settings.yaml
+++ b/infrastructure/storage/longhorn/node-failure-settings.yaml
@@ -11,7 +11,7 @@ metadata:
 value: "delete-both-statefulset-and-deployment-pod"
 
 ---
-# Without this, PVCs whose replicas are all lost stick in Terminating.
+# Reaps replica directories and engine/replica processes that lost their CRs (node offline during a delete).
 apiVersion: longhorn.io/v1beta2
 kind: Setting
 metadata:
@@ -20,12 +20,14 @@ metadata:
 value: "replica-data;instance"
 
 ---
+# Evict a last replica to another node, then let the drain proceed; single-replica volumes no longer wedge Talos upgrades.
+# Volumes pinned by diskSelector (longhorn-flash) still block on their node — nowhere to evict to.
 apiVersion: longhorn.io/v1beta2
 kind: Setting
 metadata:
   name: node-drain-policy
   namespace: longhorn-system
-value: "block-if-contains-last-replica"
+value: "block-for-eviction-if-contains-last-replica"
 
 ---
 # INTENTIONALLY 1: a mass-restore bootstrap overloads any engine on this hardware and faults
@@ -42,16 +44,6 @@ apiVersion: longhorn.io/v1beta2
 kind: Setting
 metadata:
   name: disable-scheduling-on-cordoned-node
-  namespace: longhorn-system
-value: "true"
-
----
-# Automatically detach volumes on node failure after timeout
-# This allows volumes to be reattached to healthy nodes
-apiVersion: longhorn.io/v1beta2
-kind: Setting
-metadata:
-  name: kubernetes-cluster-autoscaler-enabled
   namespace: longhorn-system
 value: "true"
 

--- a/infrastructure/storage/longhorn/storageclass-wired-ha.yaml
+++ b/infrastructure/storage/longhorn/storageclass-wired-ha.yaml
@@ -17,7 +17,7 @@ parameters:
   dataEngine: "v1"
   nodeSelector: "wired-storage"
   dataLocality: "best-effort"
-  replicaAutoBalance: "best-effort"
+  replicaAutoBalance: "least-effort" # rebalance only when redundancy is missing; best-effort chases a rebooting node
   replicaSoftAntiAffinity: "disabled"
   replicaZoneSoftAntiAffinity: "disabled"
   replicaDiskSoftAntiAffinity: "disabled"

--- a/infrastructure/storage/longhorn/values.yaml
+++ b/infrastructure/storage/longhorn/values.yaml
@@ -36,9 +36,10 @@ defaultSettings:
   autoCleanupSystemGeneratedSnapshot: "true"
   # Allow Longhorn to auto-upgrade volume engines after manager upgrades
   concurrentAutomaticEngineUpgradePerNodeLimit: "3"
-  # Allow detached volumes to rebuild replicas (fixes VolSync clone volumes
-  # stuck in VolumeCloneCopyCompleteAwaitingHealthy with replica count > 1)
+  # Detached multi-replica volumes still rebuild; otherwise a clone waits for an attach that never comes.
   offlineReplicaRebuilding: "true"
+  # ext4 fsfreeze before each snapshot instead of a best-effort sync (needs kernel >= 5.17; Talos is 6.x).
+  freezeFilesystemForSnapshot: "true"
 # -- Disables the pre-upgrade check job. This is recommended for GitOps tools
 # like ArgoCD to prevent sync failures.
 preUpgradeChecker:


### PR DESCRIPTION
## What

Four setting changes from a re-review of `infrastructure/storage/longhorn/` against the Longhorn 1.12.1 docs and the 2026-09-03 Temporal Postgres incident.

| Setting | Before | After | Why |
|---|---|---|---|
| `node-drain-policy` | `block-if-contains-last-replica` | `block-for-eviction-if-contains-last-replica` | Talos upgrade drains blocked on every 1-replica volume. Longhorn now evicts the last replica to another node first. `longhorn-flash` volumes (diskSelector, gpu node only) still block there. |
| `freeze-filesystem-for-snapshot` | `false` (default) | `true` | ext4 fsfreeze before each snapshot instead of best-effort sync. Docs require kernel ≥ 5.17; Talos runs 6.18. |
| `longhorn-wired-ha` `replicaAutoBalance` | `best-effort` | `least-effort` | best-effort keeps migrating the second replica back onto a node that just rebooted. least-effort only acts when redundancy is missing (Longhorn best-practice recommendation). SC carries `Replace=true` so the immutable parameter applies. |
| `kubernetes-cluster-autoscaler-enabled` | `true` | removed (default `false`) | No autoscaler in this cluster. The in-file comment ("detach volumes on node failure") described a behavior the setting does not have. Argo prunes the CR; Longhorn recreates it at default. |

Plus two stale comments fixed (orphan cleanup wording, VolSync reference).

## Reviewed and left alone

Replica count 1 default, over-provisioning 200 %, rebuild limit 1, instance-manager CPU 8 %, revision counter disabled, soft anti-affinity off, orphan auto-deletion on. No drift between the Helm ConfigMap and Setting CRs.

## Not in this PR

Migrating the single-replica databases (keep, gitea, immich, paperless, intercept, surfsense, nomad mysql, hindsight, home-assistant, karakeep, n8n) to `longhorn-wired-ha` via `docs/domains/storage/pvc-storageclass-migration.md`, one volume at a time.

## Validation

`kustomize build --enable-helm` renders all four values; `validate-argocd-apps.sh` PASSED; `validate-no-inline-scripts.sh` clean.

## Post-merge checks

```
kubectl -n longhorn-system get settings.longhorn.io node-drain-policy freeze-filesystem-for-snapshot kubernetes-cluster-autoscaler-enabled -o custom-columns='NAME:.metadata.name,VALUE:.value'
kubectl get sc longhorn-wired-ha -o jsonpath='{.parameters.replicaAutoBalance}'
```

Rollback: revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ei1yKFfDcm9j9Nt7P6cPS7
