### PR TITLE
power: pull whole-house usage from Consumers Energy into HA and Grafana

### DIFF
--- a/docs/domains/power/metering.md
+++ b/docs/domains/power/metering.md
@@ -52,9 +52,9 @@ energy component steps between three windows:
 
 | Window | When | All-in rate |
 |---|---|---|
-| Summer on-peak | June–August, weekdays 14:00–19:00 | ~$0.289 |
-| Summer off-peak | June–August, all other hours | ~$0.238 |
-| Non-summer | September–May | ~$0.216 |
+| Summer on-peak | June–August, weekdays 14:00–19:00 | ~$0.285 |
+| Summer off-peak | June–August, all other hours | ~$0.235 |
+| Non-summer | September–May | ~$0.213 |
 
 Rates live in `my-apps/home/home-assistant/configuration.yaml` under
 `input_number:`. **Git is the source of truth**: the `initial:` values reset the
@@ -115,6 +115,46 @@ estimate.
 
 **The HP SFF plug cannot be attributed.** It feeds two hosts. Split the outlet
 before concluding which of the two to retire.
+
+## House-level data from Consumers Energy
+
+The plugs only see the homelab. The whole-house number comes from the utility:
+a daily CronJob (`my-apps/home/consumers-energy-sync/`) drives a headless
+Chromium through the Consumers Energy portal, downloads the *Share data → CSV*
+export (one row per day, trailing 30 days, with CE's own cost), and pushes it
+into Home Assistant. Source and image: `github.com/mitchross/consumers-energy-sync`.
+
+| What lands | Where it shows |
+|---|---|
+| `consumers_energy:grid_kwh`, `consumers_energy:grid_cost` (long-term statistics) | HA Energy dashboard grid source with cost; `statistics-graph` cards |
+| `sensor.consumers_energy_kwh_yesterday`, `_kwh_7d`, `_kwh_month`, `_kwh_last_month` and the `_cost_*` twins | Homelab Power dashboard, Grafana via the Prometheus exporter |
+| `sensor.homelab_share_of_house`, `sensor.combined_share_of_house` | Homelab kWh yesterday as a share of the house |
+| `sensor.consumers_energy_effective_rate` | CE cost / kWh yesterday, next to the modelled rate |
+
+The live sensors are set through the REST API, so they vanish on an HA restart
+until the next 06:17 run. The statistics persist.
+
+**Running it elsewhere.** The same image runs anywhere with the same env vars
+(`CE_PORTAL_USERNAME`, `CE_PORTAL_PASSWORD`, `HASS_URL`, `HASS_TOKEN`):
+
+```bash
+# local checkout: node --env-file=.env index.mjs [--download-only|--import-only|--dry-run]
+docker run --rm --user 1001:1001 --env-file .env -v ce-data:/data \
+  ghcr.io/mitchross/consumers-energy-sync:v0.1.1
+```
+
+`/data` holds the Playwright cookie jar (a credential) and the CSVs; keep it
+private. The first run logs in with the password; later runs reuse the cookie
+jar. A failed run leaves a full-page screenshot in `/data`.
+
+**Cumulative sums.** Each import bases its running total on what HA already
+holds just before the export window, so overlapping trailing windows stay
+consistent. Importing data *older* than what HA has breaks that: clear both
+statistics first (`recorder.clear_statistics`) and import oldest-first.
+
+**Releasing a new image.** Tag the sync repo (`git tag v0.x.y && git push --tags`);
+the workflow publishes to GHCR. Bump the tag and digest in `cronjob.yaml`.
+The base image version must equal the `playwright` version in `package.json`.
 
 ## Safety: the power-off lockout
 

--- a/monitoring/prometheus-stack/dashboards/homelab-power.json
+++ b/monitoring/prometheus-stack/dashboards/homelab-power.json
@@ -2813,7 +2813,7 @@
     },
     {
       "type": "row",
-      "title": "Reading this dashboard",
+      "title": "House — Consumers Energy (daily CSV via consumers-energy-sync)",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -2822,6 +2822,727 @@
         "y": 96
       },
       "id": 47,
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "House kWh Yesterday",
+      "description": "Whole-house grid import from the CE export.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "kwatth",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "orange",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.consumers_energy_kwh_yesterday\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 97
+      },
+      "id": 48
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Homelab Share of House",
+      "description": "Homelab kWh yesterday / house kWh yesterday.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25
+              },
+              {
+                "color": "orange",
+                "value": 35
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_percent{entity=\"sensor.homelab_share_of_house\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 97
+      },
+      "id": 49
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Homelab + Office Share",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 35
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 65
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_percent{entity=\"sensor.combined_share_of_house\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 97
+      },
+      "id": 50
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "CE Cost Yesterday",
+      "description": "Consumers Energy's own cost figure for the day.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.consumers_energy_cost_yesterday\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 97
+      },
+      "id": 51
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "House kWh This Month",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "kwatth",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.consumers_energy_kwh_month\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 103
+      },
+      "id": 52
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "CE Cost This Month",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.consumers_energy_cost_month\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 103
+      },
+      "id": 53
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "CE Cost Last Month",
+      "description": "Finished month from the CE daily costs. Bill-period totals differ: bills run mid-month to mid-month.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.consumers_energy_cost_last_month\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 103
+      },
+      "id": 54
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "CE Effective Rate vs Model",
+      "description": "CE cost / kWh yesterday next to the modelled all-in rate now. A steady gap means the rate inputs need adjusting.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "currencyUSD",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd_per_kwh{entity=\"sensor.consumers_energy_effective_rate\"})",
+          "legendFormat": "CE yesterday",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd_per_kwh{entity=\"sensor.current_electricity_rate\"})",
+          "legendFormat": "model now",
+          "refId": "B",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 103
+      },
+      "id": 55
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "timeseries",
+      "title": "House vs Homelab — kWh per day",
+      "description": "Each point is the previous day's total; steps once a day.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "kwatth",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.consumers_energy_kwh_yesterday\"})",
+          "legendFormat": "house (CE)",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.homelab_total_energy_yesterday\"})",
+          "legendFormat": "homelab",
+          "refId": "B",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.combined_total_energy_yesterday\"})",
+          "legendFormat": "homelab + office",
+          "refId": "C",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 108
+      },
+      "id": 56
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "timeseries",
+      "title": "Effective Rate — CE vs Model",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 4
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd_per_kwh{entity=\"sensor.consumers_energy_effective_rate\"})",
+          "legendFormat": "CE yesterday",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd_per_kwh{entity=\"sensor.current_electricity_rate\"})",
+          "legendFormat": "model now",
+          "refId": "B",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 108
+      },
+      "id": 57
+    },
+    {
+      "type": "row",
+      "title": "Reading this dashboard",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 116
+      },
+      "id": 58,
       "panels": []
     },
     {
@@ -2836,9 +3557,9 @@
         "h": 14,
         "w": 24,
         "x": 0,
-        "y": 97
+        "y": 117
       },
-      "id": 48
+      "id": 59
     }
   ],
   "refresh": "30s",

--- a/my-apps/home/consumers-energy-sync/cronjob.yaml
+++ b/my-apps/home/consumers-energy-sync/cronjob.yaml
@@ -1,0 +1,64 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: consumers-energy-sync
+  namespace: consumers-energy-sync
+spec:
+  # CE posts the previous day overnight; 06:17 local catches it with margin.
+  schedule: "17 6 * * *"
+  timeZone: America/New_York
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 900
+      template:
+        spec:
+          restartPolicy: Never
+          # pwuser in the Playwright image; fsGroup makes the PVC writable for it.
+          securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: sync
+              image: ghcr.io/mitchross/consumers-energy-sync:v0.1.1@sha256:81cff10b88945d15ecee92679658c48723fd19c51c363524f1288cb7e854fe12
+              envFrom:
+                - secretRef:
+                    name: consumers-energy-sync
+              env:
+                - name: HASS_URL
+                  value: http://home-assistant.home-assistant.svc.cluster.local:8123
+                - name: ENERGY_CSV_DIR
+                  value: /data
+                - name: TIMEZONE
+                  value: America/Detroit
+                - name: HOME
+                  value: /tmp
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                - name: tmp
+                  mountPath: /tmp
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+                limits:
+                  memory: 2Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: consumers-energy-sync-data
+            - name: tmp
+              emptyDir:
+                sizeLimit: 1Gi

--- a/my-apps/home/consumers-energy-sync/externalsecret.yaml
+++ b/my-apps/home/consumers-energy-sync/externalsecret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: consumers-energy-sync
+  namespace: consumers-energy-sync
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: consumers-energy-sync
+    creationPolicy: Owner
+  data:
+    - secretKey: CE_PORTAL_USERNAME
+      remoteRef:
+        key: consumers-energy
+        property: username
+    - secretKey: CE_PORTAL_PASSWORD
+      remoteRef:
+        key: consumers-energy
+        property: password
+    # Same long-lived token the rest of the lab uses for the HA API.
+    - secretKey: HASS_TOKEN
+      remoteRef:
+        key: home-assistant
+        property: ha-longlived-token

--- a/my-apps/home/consumers-energy-sync/kustomization.yaml
+++ b/my-apps/home/consumers-energy-sync/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: consumers-energy-sync
+
+# Daily CronJob: headless Chromium downloads the Consumers Energy usage CSV and
+# pushes it into Home Assistant as long-term statistics. Source + image:
+# github.com/mitchross/consumers-energy-sync (private repo, public GHCR package).
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - pvc.yaml
+  - cronjob.yaml

--- a/my-apps/home/consumers-energy-sync/namespace.yaml
+++ b/my-apps/home/consumers-energy-sync/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: consumers-energy-sync

--- a/my-apps/home/consumers-energy-sync/pvc.yaml
+++ b/my-apps/home/consumers-energy-sync/pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: consumers-energy-sync-data
+  namespace: consumers-energy-sync
+  labels:
+    backup-exempt: "true"
+  annotations:
+    storage.vanillax.dev/backup-exempt-reason: "Playwright cookie jar plus re-downloadable CSVs; the data of record is Home Assistant's statistics"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 1Gi

--- a/my-apps/home/home-assistant/configuration.yaml
+++ b/my-apps/home/home-assistant/configuration.yaml
@@ -57,6 +57,8 @@ prometheus:
       - sensor.combined_*
       - sensor.current_electricity_rate
       - sensor.electricity_tariff_period
+      # House-level data pushed by the consumers-energy-sync CronJob.
+      - sensor.consumers_energy_*
       # StuckAtPrototype AirCube Zigbee air-quality monitor (temp/humidity/eCO2/
       # tVOC + rssi/lqi). Feeds the aircube-dashboard.json Grafana dashboard.
       - sensor.stuckatprototype_aircube_*
@@ -116,7 +118,7 @@ input_number:
     mode: box
     unit_of_measurement: "USD/kWh"
     icon: mdi:transmission-tower
-    initial: 0.120887
+    initial: 0.122077
   rate_sales_tax_pct:
     name: "Rate — Sales Tax"
     min: 0
@@ -125,7 +127,7 @@ input_number:
     mode: box
     unit_of_measurement: "%"
     icon: mdi:percent
-    initial: 6.0
+    initial: 4.0
 
 # Cost integrates a live USD/h cost-rate (power * current TOU rate), not a fixed tariff.
 # Every integral starts at 0 when first created; totals only fill in as data accumulates.
@@ -643,8 +645,8 @@ template:
           {% else %}
             {% set e = states('input_number.rate_nonsummer') | float(0.082996) %}
           {% endif %}
-          {% set r = states('input_number.rate_delivery_riders') | float(0.120887) %}
-          {% set t = states('input_number.rate_sales_tax_pct') | float(6) %}
+          {% set r = states('input_number.rate_delivery_riders') | float(0.122077) %}
+          {% set t = states('input_number.rate_sales_tax_pct') | float(4) %}
           {{ ((e + r) * (1 + t / 100)) | round(5) }}
 
       - name: "Electricity Tariff Period"
@@ -1063,4 +1065,58 @@ template:
           {% set total = states('sensor.combined_total_power') | float(0) %}
           {% if total > 0 %}
             {{ (states('sensor.macbook_current_consumption') | float(0) / total * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      # ----- house vs homelab (sensor.consumers_energy_* are pushed daily by consumers-energy-sync) -----
+      - name: "Homelab Total Energy Yesterday"
+        unique_id: homelab_total_energy_yesterday
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.homelab_total_energy_daily', 'last_period') | float(0) | round(3) }}
+
+      - name: "Combined Total Energy Yesterday"
+        unique_id: combined_total_energy_yesterday
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.combined_total_energy_daily', 'last_period') | float(0) | round(3) }}
+
+      - name: "Homelab Share Of House"
+        unique_id: homelab_share_of_house
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:home-percent
+        availability: "{{ states('sensor.consumers_energy_kwh_yesterday') | is_number }}"
+        state: >
+          {% set house = states('sensor.consumers_energy_kwh_yesterday') | float(0) %}
+          {% if house > 0 %}
+            {{ (states('sensor.homelab_total_energy_yesterday') | float(0) / house * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      - name: "Combined Share Of House"
+        unique_id: combined_share_of_house
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:home-percent
+        availability: "{{ states('sensor.consumers_energy_kwh_yesterday') | is_number }}"
+        state: >
+          {% set house = states('sensor.consumers_energy_kwh_yesterday') | float(0) %}
+          {% if house > 0 %}
+            {{ (states('sensor.combined_total_energy_yesterday') | float(0) / house * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      # What CE actually charged per kWh yesterday, to check the modelled rate against.
+      - name: "Consumers Energy Effective Rate"
+        unique_id: consumers_energy_effective_rate
+        unit_of_measurement: "USD/kWh"
+        state_class: measurement
+        icon: mdi:cash-check
+        availability: "{{ states('sensor.consumers_energy_kwh_yesterday') | is_number and states('sensor.consumers_energy_cost_yesterday') | is_number }}"
+        state: >
+          {% set kwh = states('sensor.consumers_energy_kwh_yesterday') | float(0) %}
+          {% if kwh > 0 %}
+            {{ (states('sensor.consumers_energy_cost_yesterday') | float(0) / kwh) | round(5) }}
           {% else %}0{% endif %}

--- a/my-apps/home/home-assistant/lovelace-homelab-power.yaml
+++ b/my-apps/home/home-assistant/lovelace-homelab-power.yaml
@@ -42,6 +42,48 @@ views:
           - entity: input_number.rate_sales_tax_pct
             name: Sales tax
 
+      - type: entities
+        title: House (Consumers Energy)
+        entities:
+          - entity: sensor.consumers_energy_kwh_yesterday
+            name: House yesterday
+          - entity: sensor.homelab_total_energy_yesterday
+            name: Homelab yesterday
+          - entity: sensor.homelab_share_of_house
+            name: Homelab share of house
+          - entity: sensor.combined_share_of_house
+            name: Homelab + office share of house
+          - entity: sensor.consumers_energy_cost_yesterday
+            name: CE cost yesterday
+          - entity: sensor.consumers_energy_effective_rate
+            name: CE effective rate
+          - entity: sensor.current_electricity_rate
+            name: Modelled rate now
+          - type: section
+            label: Month to date and last month
+          - entity: sensor.consumers_energy_kwh_month
+            name: House this month
+          - entity: sensor.consumers_energy_cost_month
+            name: CE cost this month
+          - entity: sensor.consumers_energy_kwh_last_month
+            name: House last month
+          - entity: sensor.consumers_energy_cost_last_month
+            name: CE cost last month
+          - entity: sensor.consumers_energy_last_reading
+            name: Last CE reading
+
+      - type: statistics-graph
+        title: House vs homelab by day (30d)
+        chart_type: bar
+        period: day
+        days_to_show: 30
+        stat_types:
+          - change
+        entities:
+          - consumers_energy:grid_kwh
+          - sensor.homelab_total_energy
+          - sensor.office_total_energy
+
       - type: glance
         title: Live draw
         state_color: false


### PR DESCRIPTION
## Summary
- New app `my-apps/home/consumers-energy-sync/`: daily CronJob (06:17 ET) running `ghcr.io/mitchross/consumers-energy-sync:v0.1.1` (pinned digest). Headless Chromium logs into the CE portal (Okta, password only), downloads the daily usage CSV (trailing 30 days with CE's cost) and pushes it into Home Assistant via `recorder/import_statistics`.
- HA: `consumers_energy:grid_kwh` / `grid_cost` statistics are the Energy dashboard grid source (already saved live). New sensors exported to Prometheus, plus `homelab_share_of_house`, `combined_share_of_house`, `consumers_energy_effective_rate`. House card + 30-day house-vs-homelab chart on the power dashboard.
- Grafana: "House — Consumers Energy" row on Homelab Power & Cost.
- Rate corrections from the July bill: sales tax 6% → 4%, riders 0.120887 → 0.122077.
- Docs: `docs/domains/power/metering.md` section on the utility data, local/docker/cluster runs, backfill caveat, release procedure.

## Secrets
- New 1Password item `consumers-energy` (homelab-prod) with the portal login; HA token reused from `home-assistant/ha-longlived-token` (rotated today, old one was dead).
- PVC is backup-exempt (cookie jar + re-downloadable CSVs).

## Validation
- Ran end to end from the desktop and from the container: 30 days imported, idempotent on re-run, sensors correct in HA.
- HA `check_config` passes on the new config inside the running pod; kustomize builds for the new app, home-assistant and prometheus-stack.
- Every dashboard/Lovelace entity resolves to a defined or pushed sensor.
- Image verified to contain only code; GHCR package is public and pulls anonymously.

## After merge
HA needs a restart for the new template sensors and Prometheus filter (`kubectl rollout restart deployment/home-assistant -n home-assistant`). The first CronJob run at 06:17 seeds the cookie jar by logging in with the password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKVvajhmCcNMv4DoK8s8Ln