### PR TITLE
fix(longhorn): declare kubernetes-cluster-autoscaler-enabled=false instead of deleting it

### DIFF
--- a/infrastructure/storage/longhorn/node-failure-settings.yaml
+++ b/infrastructure/storage/longhorn/node-failure-settings.yaml
@@ -58,6 +58,15 @@ metadata:
 value: "true"
 
 ---
+# No autoscaler here. Longhorn's webhook forbids deleting this Setting, so it must stay declared as false.
+apiVersion: longhorn.io/v1beta2
+kind: Setting
+metadata:
+  name: kubernetes-cluster-autoscaler-enabled
+  namespace: longhorn-system
+value: "false"
+
+---
 # V2 (SPDK) reactor cores; inert on V1 but the 2-core default wedges a rebuild under restore churn.
 # Name must be the consolidated `data-engine-cpu-mask` — the legacy `v2-data-engine-cpu-mask` is rejected.
 apiVersion: longhorn.io/v1beta2


### PR DESCRIPTION
## What

#2223 removed the `kubernetes-cluster-autoscaler-enabled` Setting CR. Longhorn's validator webhook refuses that: `setting kubernetes-cluster-autoscaler-enabled can be modified but not deleted`, so Argo's prune fails and the `longhorn` app retries in a loop. This re-declares the Setting with value `false` (the intended state, also Longhorn's default).

Post-merge check:
```
kubectl -n longhorn-system get settings.longhorn.io kubernetes-cluster-autoscaler-enabled -o jsonpath='{.value}'   # false
kubectl -n argocd get application longhorn -o custom-columns='SYNC:.status.sync.status,OP:.status.operationState.phase'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ei1yKFfDcm9j9Nt7P6cPS7
