### PR TITLE
Fix Longhorn sync failures by undoing an unsupported setting change

### DIFF
--- a/infrastructure/storage/longhorn/storageclass-wired-ha.yaml
+++ b/infrastructure/storage/longhorn/storageclass-wired-ha.yaml
@@ -17,7 +17,8 @@ parameters:
   dataEngine: "v1"
   nodeSelector: "wired-storage"
   dataLocality: "best-effort"
-  replicaAutoBalance: "least-effort" # rebalance only when redundancy is missing; best-effort chases a rebooting node
+  # Immutable once created (Replace=true still fails); change replicaAutoBalance per volume, not here.
+  replicaAutoBalance: "best-effort"
   replicaSoftAntiAffinity: "disabled"
   replicaZoneSoftAntiAffinity: "disabled"
   replicaDiskSoftAntiAffinity: "disabled"


### PR DESCRIPTION
## What was wrong?

A change in #2223 asked Kubernetes to alter a storage setting that cannot be changed on an existing StorageClass. Kubernetes rejects it, so Argo keeps retrying and Longhorn stays out of sync.

## What does this fix?

Put `longhorn-wired-ha`'s `replicaAutoBalance` setting back to `best-effort` instead of `least-effort`. This undoes only that setting change from #2223.

It does not delete or recreate any storage class, volume, or PVC. It does not move data or change the number of storage copies. The other changes from #2223 are left alone.

## Checks and next step

GitHub's Cluster CI passed for commit `f66fde0`. The live cluster still needs checking after merge:

```sh
kubectl -n argocd get application longhorn
```

Longhorn should return to `Synced` once Argo applies the correction. That check confirms the sync problem is resolved; it is not a disk-health or backup test.

<details>
<summary>Original implementation session</summary>

Generated with [Claude Code](https://claude.com/claude-code).

https://claude.ai/code/session_01Ei1yKFfDcm9j9Nt7P6cPS7

</details>