### PR TITLE
Fix Argo missing app updates and shared config changes

### DIFF
--- a/.github/workflows/argocd-cache-contract.yml
+++ b/.github/workflows/argocd-cache-contract.yml
@@ -1,0 +1,38 @@
+name: Argo Cache Contract
+on:
+  pull_request:
+    paths:
+      - 'infrastructure/controllers/argocd/**'
+      - 'my-apps/common/**'
+      - 'scripts/validate-argocd-cache-paths.py'
+      - 'scripts/tests/test_argocd_cache_paths.py'
+      - '.github/workflows/argocd-cache-contract.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/controllers/argocd/**'
+      - 'my-apps/common/**'
+      - 'scripts/validate-argocd-cache-paths.py'
+      - 'scripts/tests/test_argocd_cache_paths.py'
+      - '.github/workflows/argocd-cache-contract.yml'
+permissions:
+  contents: read
+jobs:
+  cache-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install PyYAML==6.0.3
+      - uses: imranismail/setup-kustomize@v2
+        with:
+          kustomize-version: '5.8.1'
+      - name: Test path semantics
+        run: python -m unittest discover -s scripts/tests -p test_argocd_cache_paths.py -v
+      - name: Validate the rendered registry and bootstrap seed
+        run: |
+          set -euo pipefail
+          kustomize build infrastructure/controllers/argocd/apps > /tmp/argocd-entrypoints.yaml
+          python scripts/validate-argocd-cache-paths.py /tmp/argocd-entrypoints.yaml infrastructure/controllers/argocd/root.yaml

--- a/docs/domains/argocd/manifest-cache-contract.md
+++ b/docs/domains/argocd/manifest-cache-contract.md
@@ -1,0 +1,47 @@
+# Manifest cache dependency contract
+
+Argo resolves relative `manifest-generate-paths` entries against an Application's
+`source.path`. Repeating the repository path without a leading slash therefore
+creates a doubled, nonmatching path. An unrelated commit may reuse the cache;
+a change to an input must not.
+
+The root registry's Kustomize patches own the effective hints for its children:
+
+- standalone Applications and ordinary ApplicationSets: `.`;
+- the `my-apps` ApplicationSet: `.;/my-apps/common`;
+- the separately seeded root Application: `.` in `root.yaml`.
+
+The raw entrypoint files can still contain historical hints; the rendered registry
+is authoritative. This central patch keeps all entrypoints consistent without
+renaming Applications, changing their sources, changing sync waves, or changing
+prune behavior. New shared directories must be added to the consuming template's
+hint and tests before use. This is a cache-dependency declaration, not an
+application discovery filter.
+
+## Verification
+
+```sh
+python -m unittest discover -s scripts/tests -p test_argocd_cache_paths.py -v
+kustomize build infrastructure/controllers/argocd/apps > /tmp/argocd-entrypoints.yaml
+python scripts/validate-argocd-cache-paths.py /tmp/argocd-entrypoints.yaml infrastructure/controllers/argocd/root.yaml
+```
+
+The manually seeded root is not self-managed. After merging, reapply the root
+seed with the normal bootstrap ownership convention (no workload edits):
+
+```sh
+kubectl apply -f infrastructure/controllers/argocd/root.yaml
+kubectl -n argocd annotate application root argocd.argoproj.io/refresh=hard --overwrite
+```
+
+Verify the rendered child annotations and live Application annotations agree.
+Use a disposable application's ConfigMap to verify an app-local edit propagates.
+Then verify a shared Component edit changes every affected desired render. An
+unrelated application's edit must not count as a dependency. Compare actual
+manifest content, not only `status.sync.revision`.
+
+This fixes a concrete dependency declaration error; it does not prove the cause
+of every historical stale-cache incident. Existing hard-refresh/cache-expiry
+settings are unchanged. Rollback is reverting this PR; do not delete Applications.
+
+Upstream semantics: https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#manifest-paths-annotation

--- a/infrastructure/controllers/argocd/apps/kustomization.yaml
+++ b/infrastructure/controllers/argocd/apps/kustomization.yaml
@@ -36,3 +36,28 @@ resources:
   - appsets/database-appset.yaml
   - appsets/monitoring-appset.yaml
   - appsets/my-apps-appset.yaml
+
+# Cache hints are relative to each Application's source.path, not the repo root.
+patches:
+  - target:
+      group: argoproj.io
+      kind: Application
+    patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1manifest-generate-paths
+        value: .
+  - target:
+      group: argoproj.io
+      kind: ApplicationSet
+    patch: |-
+      - op: add
+        path: /spec/template/metadata/annotations/argocd.argoproj.io~1manifest-generate-paths
+        value: .
+  - target:
+      group: argoproj.io
+      kind: ApplicationSet
+      name: my-apps
+    patch: |-
+      - op: add
+        path: /spec/template/metadata/annotations/argocd.argoproj.io~1manifest-generate-paths
+        value: .;/my-apps/common

--- a/infrastructure/controllers/argocd/root.yaml
+++ b/infrastructure/controllers/argocd/root.yaml
@@ -7,7 +7,7 @@ metadata:
     # Manifest-generate-paths cache hint: only invalidate root's manifest cache
     # when files under apps/ change. Without this, any commit anywhere in the
     # repo forces the repo-server to re-render the root app-of-apps tree.
-    argocd.argoproj.io/manifest-generate-paths: infrastructure/controllers/argocd/apps
+    argocd.argoproj.io/manifest-generate-paths: .
     # Force CLIENT-side diff for the app-of-apps. The global
     # controller.diff.server.side: "true" (argocd-cmd-params-cm) does a dry-run
     # server-side apply of every managed resource against the API server. For

--- a/scripts/tests/test_argocd_cache_paths.py
+++ b/scripts/tests/test_argocd_cache_paths.py
@@ -1,0 +1,47 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+spec = importlib.util.spec_from_file_location("cache_paths", Path(__file__).parents[1] / "validate-argocd-cache-paths.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def app(hint, source="my-apps/ai/example"):
+    return {"kind": "Application", "metadata": {"name": "example", "annotations": {module.ANNOTATION: hint}}, "spec": {"source": {"path": source}}}
+
+
+def appset(hint):
+    template = app(hint, "{{ .path.path }}")
+    return {"kind": "ApplicationSet", "metadata": {"name": "my-apps"}, "spec": {"template": template}}
+
+
+class CachePathsTest(unittest.TestCase):
+    def test_app_local_change_is_covered(self):
+        self.assertFalse(module.validate([app(".")]))
+
+    def test_old_double_prefixed_path_fails(self):
+        self.assertTrue(module.validate([app("my-apps/ai/example")]))
+
+    def test_absolute_paths_are_repo_relative(self):
+        self.assertFalse(module.validate([app("/my-apps/ai/example")]))
+
+    def test_shared_component_is_required(self):
+        self.assertTrue(module.validate([appset(".")]))
+        self.assertFalse(module.validate([appset(".;/my-apps/common")]))
+
+    def test_unrelated_app_does_not_match(self):
+        paths = module.resolve_paths("my-apps/ai/example", ".;/my-apps/common")
+        self.assertFalse(any(module.covers(p, "my-apps/home/unrelated/deployment.yaml") for p in paths))
+        self.assertTrue(any(module.covers(p, "my-apps/common/kopiur-backup/kustomization.yaml") for p in paths))
+
+    def test_prefix_is_not_directory_match(self):
+        self.assertFalse(module.covers("my-apps/ai/example", "my-apps/ai/example-other/file.yaml"))
+
+    def test_seed_root_and_empty_input(self):
+        self.assertFalse(module.validate([app(".", "infrastructure/controllers/argocd/apps")]))
+        self.assertTrue(module.validate([]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-argocd-cache-paths.py
+++ b/scripts/validate-argocd-cache-paths.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Validate rendered Argo cache hints, including the manually seeded root."""
+import argparse
+import posixpath
+from pathlib import Path
+
+import yaml
+
+ANNOTATION = "argocd.argoproj.io/manifest-generate-paths"
+
+
+def resolve_paths(source: str, annotation: str) -> list[str]:
+    """Resolve directory hints using Argo's source-relative/repo-absolute rules."""
+    return [
+        posixpath.normpath(p.lstrip("/") if p.startswith("/") else posixpath.join(source, p))
+        for p in annotation.split(";") if p
+    ]
+
+
+def covers(directory: str, dependency: str) -> bool:
+    return directory == "." or dependency == directory or dependency.startswith(directory + "/")
+
+
+def validate(documents: list[dict]) -> list[str]:
+    errors = []
+    checked = 0
+    for obj in documents:
+        kind = obj.get("kind")
+        if kind not in ("Application", "ApplicationSet"):
+            continue
+        checked += 1
+        name = obj["metadata"]["name"]
+        app = obj["spec"]["template"] if kind == "ApplicationSet" else obj
+        source = app.get("spec", {}).get("source", {}).get("path")
+        if not source:
+            # Chart-only Applications have no local Kustomize dependency graph.
+            continue
+        hint = app.get("metadata", {}).get("annotations", {}).get(ANNOTATION, "")
+        if not hint:
+            errors.append(f"{name}: missing cache hint")
+            continue
+        if "{{" in source:
+            source = "my-apps/ai/example" if name == "my-apps" else f"{name}/example"
+            hint = hint.replace("{{ .path.path }}", source)
+        paths = resolve_paths(source, hint)
+        if not any(covers(path, source) for path in paths):
+            errors.append(f"{name}: {hint!r} does not cover source {source!r}; resolves to {paths}")
+        if name == "my-apps" and not any(covers(path, "my-apps/common") for path in paths):
+            errors.append(f"{name}: shared Components are outside cache hints {paths}")
+        if any(path == ".." or path.startswith("../") for path in paths):
+            errors.append(f"{name}: hint escapes the repository")
+    if not checked:
+        errors.append("No Application or ApplicationSet objects supplied")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifests", nargs="+", type=Path)
+    args = parser.parse_args()
+    try:
+        docs = [doc for path in args.manifests for doc in yaml.safe_load_all(path.read_text()) if doc]
+        errors = validate(docs)
+    except (OSError, yaml.YAMLError, KeyError, TypeError, AttributeError) as exc:
+        print(f"ERROR: cannot validate manifests: {exc}")
+        return 1
+    for error in errors:
+        print(f"ERROR: {error}")
+    if not errors:
+        print("Argo cache hints cover application roots and shared Components.")
+    return bool(errors)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What was wrong?

Argo was checking the wrong folders when deciding whether it could reuse an older copy of an app's configuration. That means a Git change could be missed even while Argo showed the app as synced.

The folder names were effectively repeated twice. Shared settings under `my-apps/common` were also missing from the folders Argo checks.

## What does this fix?

Correct those paths for the apps and for Argo's root Application. Include the shared folder so changes there are picked up by the apps that use it. Add seven tests and a GitHub check to catch this mistake in future changes.

The fix is applied in the existing root Kustomization, so the final generated settings are what matters; some original files still contain the old paths.

## What changes on the cluster?

This changes Argo's settings, not app names, storage, replica counts, or deletion rules. The existing refresh timers stay the same.

**Argo may now apply Git changes it previously missed.** Review the pending changes before refreshing. This is not a promise that every app will stay untouched.

## Has it been tested?

GitHub's Argo Cache Contract, Cluster CI, and docs workflows passed for commit `1b998a0`. The new check tests the paths and the configuration generated by Kustomize.

It has not been tested on the live cluster. This fixes a real path mistake, but does not prove it caused every previous stale-config incident. The PR remains a draft for review.

## What do I need to do after merging?

Update your local checkout, then reapply the root Application and ask Argo to refresh it. The root is installed manually, so merging alone does not update that object:

```sh
kubectl apply -f infrastructure/controllers/argocd/root.yaml
kubectl -n argocd annotate application root argocd.argoproj.io/refresh=hard --overwrite
```

Do not delete the root Application or any child apps. Check that an app-local change and a shared-config change actually update the expected configuration; a green status alone is not enough.

To undo this change, revert the PR and reapply the reverted root file as well.

<details>
<summary>Technical reference</summary>

The corrected annotation is `.` for ordinary apps and `.;/my-apps/common` for generated user apps.

[Argo's path rules](https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#manifest-paths-annotation)

The rollout instructions are also in `docs/domains/argocd/manifest-cache-contract.md`.

</details>