### PR TITLE
Catch broken backup restore settings before they reach the cluster

### DIFF
--- a/.github/workflows/backup-contract-tests.yml
+++ b/.github/workflows/backup-contract-tests.yml
@@ -1,0 +1,27 @@
+name: Backup Contract Tests
+on:
+  pull_request:
+    paths:
+      - 'scripts/validate-kopiur-coverage.py'
+      - 'scripts/tests/test_kopiur_coverage.py'
+      - 'my-apps/common/kopiur-backup/**'
+      - '.github/workflows/backup-contract-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/validate-kopiur-coverage.py'
+      - 'scripts/tests/test_kopiur_coverage.py'
+      - 'my-apps/common/kopiur-backup/**'
+      - '.github/workflows/backup-contract-tests.yml'
+permissions:
+  contents: read
+jobs:
+  regressions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install PyYAML==6.0.3
+      - run: python -m unittest discover -s scripts/tests -p test_kopiur_coverage.py -v

--- a/docs/domains/storage/backup-validation-contract.md
+++ b/docs/domains/storage/backup-validation-contract.md
@@ -1,0 +1,39 @@
+# Backup validation: references are a graph, not a kind check
+
+`scripts/validate-kopiur-coverage.py` checks the aggregate rendered manifests in
+Cluster CI. The offline tests live in `scripts/tests/test_kopiur_coverage.py`.
+
+For a protected, Git-owned PVC, validation follows:
+
+```
+SnapshotPolicy source PVC -> PVC dataSourceRef -> same-namespace named Restore
+                         -> target.populator -> source.fromPolicy back to that policy
+```
+
+Missing Restore objects, cross-namespace pointers, non-populator targets, and
+wrong policy names are hard failures. An exempt or unprotected application PVC
+cannot hide a dangling Kopiur Restore reference either. Operator-owned direct
+`target.pvc` restores and the existing explicitly annotated manual-recovery
+exception retain their behavior.
+
+Coverage warnings now include every non-system storage class, including flash,
+wired HA, static shares, and future local CSI classes. A retired CNPG label is
+not a backup guarantee. Intentional disposable or externally protected volumes
+should carry `backup-exempt: "true"` and a qualified reason explaining who owns
+recovery. This change does not force all data onto Kopiur or change the existing
+warning-only policy for previously uncovered PVCs.
+
+A passing validation means no checked restore link is broken. It does not prove
+backup freshness, permissions at runtime, snapshot readability, database
+consistency, or recovery time. Warnings remain open decisions. Keep running the
+canary and application-level recovery drills.
+
+Run locally:
+
+```sh
+python -m unittest discover -s scripts/tests -p test_kopiur_coverage.py -v
+python scripts/validate-kopiur-coverage.py /tmp/all-manifests.yaml
+```
+
+No cluster changes, PVC migrations, retention changes, or destructive tests are
+part of this validation improvement. Rollback is a Git revert of this PR.

--- a/scripts/tests/test_kopiur_coverage.py
+++ b/scripts/tests/test_kopiur_coverage.py
@@ -1,0 +1,107 @@
+"""Offline regression cases; these fixtures are not deployable applications."""
+from copy import deepcopy
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+SCRIPT = Path(__file__).parents[1] / "validate-kopiur-coverage.py"
+GROUP = "kopiur.home-operations.com"
+NS = {"apiVersion": "v1", "kind": "Namespace", "metadata": {"name": "test", "labels": {f"{GROUP}/repo": "cluster-kopia"}}}
+PVC = {"apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": {"namespace": "test", "name": "data"}, "spec": {"storageClassName": "longhorn", "dataSourceRef": {"apiGroup": GROUP, "kind": "Restore", "name": "data-restore"}}}
+POLICY = {"apiVersion": f"{GROUP}/v1alpha1", "kind": "SnapshotPolicy", "metadata": {"namespace": "test", "name": "data-policy"}, "spec": {"sources": [{"pvc": {"name": "data"}}], "mover": {"securityContext": {"runAsUser": 999}}}}
+RESTORE = {"apiVersion": f"{GROUP}/v1alpha1", "kind": "Restore", "metadata": {"namespace": "test", "name": "data-restore"}, "spec": {"source": {"fromPolicy": {"name": "data-policy"}}, "target": {"populator": {}}, "mover": {"securityContext": {"runAsUser": 999}}}}
+
+
+def run(*docs):
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "rendered.yaml"
+        path.write_text(yaml.safe_dump_all(docs))
+        return subprocess.run([sys.executable, str(SCRIPT), str(path)], capture_output=True, text=True)
+
+
+class KopiurCoverageTest(unittest.TestCase):
+    def test_correct_populator(self):
+        self.assertEqual(run(NS, PVC, POLICY, RESTORE).returncode, 0)
+
+    def test_absent_named_restore(self):
+        result = run(NS, PVC, POLICY)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("named Restore", result.stdout)
+
+    def test_wrong_policy(self):
+        restore = deepcopy(RESTORE)
+        restore["spec"]["source"]["fromPolicy"]["name"] = "wrong"
+        self.assertEqual(run(NS, PVC, POLICY, restore).returncode, 1)
+
+    def test_wrong_restore_namespace(self):
+        restore = deepcopy(RESTORE)
+        restore["metadata"]["namespace"] = "other"
+        self.assertEqual(run(NS, PVC, POLICY, restore).returncode, 1)
+
+    def test_cross_namespace_pointer(self):
+        pvc = deepcopy(PVC)
+        pvc["spec"]["dataSourceRef"]["namespace"] = "other"
+        self.assertEqual(run(NS, pvc, POLICY, RESTORE).returncode, 1)
+
+    def test_not_a_populator(self):
+        restore = deepcopy(RESTORE)
+        restore["spec"]["target"] = {"pvc": {"name": "other"}}
+        self.assertEqual(run(NS, PVC, POLICY, restore).returncode, 1)
+
+    def test_missing_pointer_still_fails(self):
+        pvc = deepcopy(PVC)
+        del pvc["spec"]["dataSourceRef"]
+        self.assertEqual(run(NS, pvc, POLICY, RESTORE).returncode, 1)
+
+    def test_all_storage_classes_receive_coverage_review(self):
+        for storage in ("longhorn", "longhorn-flash", "longhorn-wired-ha", "truenas-nfs", "custom-local"):
+            with self.subTest(storage=storage):
+                pvc = deepcopy(PVC)
+                pvc["spec"] = {"storageClassName": storage}
+                result = run(NS, pvc)
+                self.assertEqual(result.returncode, 0)
+                self.assertIn("[gap]", result.stdout)
+                self.assertIn(storage, result.stdout)
+
+    def test_reasoned_exemption(self):
+        pvc = deepcopy(PVC)
+        pvc["spec"] = {"storageClassName": "longhorn-flash"}
+        pvc["metadata"].update(labels={"backup-exempt": "true"}, annotations={"storage.vanillax.dev/backup-exempt-reason": "Regenerable cache"})
+        result = run(NS, pvc)
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn("WARN", result.stdout)
+
+    def test_exemption_cannot_hide_dangling_restore(self):
+        pvc = deepcopy(PVC)
+        pvc["metadata"]["labels"] = {"backup-exempt": "true"}
+        self.assertEqual(run(NS, pvc).returncode, 1)
+
+    def test_direct_operator_restore_keeps_working(self):
+        restore = deepcopy(RESTORE)
+        restore["spec"]["target"] = {"pvc": {"name": "data"}}
+        self.assertEqual(run(NS, POLICY, restore).returncode, 0)
+        restore["spec"]["source"]["fromPolicy"]["name"] = "wrong"
+        self.assertEqual(run(NS, POLICY, restore).returncode, 1)
+
+    def test_explicit_manual_operator_recovery_keeps_working(self):
+        policy = deepcopy(POLICY)
+        policy["metadata"]["annotations"] = {"storage.vanillax.dev/operator-owned-pvc": "true", "storage.vanillax.dev/no-restore-before-bind-reason": "Manual operator recovery is documented"}
+        result = run(NS, policy)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("manual step", result.stdout)
+
+    def test_aggregate_duplicate_objects_do_not_create_false_errors(self):
+        self.assertEqual(run(NS, PVC, POLICY, RESTORE, NS, PVC, POLICY, RESTORE).returncode, 0)
+
+    def test_missing_namespace_label_still_fails(self):
+        ns = deepcopy(NS)
+        ns["metadata"]["labels"] = {}
+        self.assertEqual(run(ns, PVC, POLICY, RESTORE).returncode, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-kopiur-coverage.py
+++ b/scripts/validate-kopiur-coverage.py
@@ -24,7 +24,7 @@ WARNINGS (printed, exit 0):
   [mover]   A SnapshotPolicy/Restore with no spec.mover security context (neither
             securityContext nor inheritSecurityContextFrom) → likely PermissionDenied
             (the #1 kopiur gotcha — see docs/domains/storage/kopiur-mover-permissions.md).
-  [gap]     A longhorn PVC that is neither backed up nor backup-exempt → review.
+  [gap]     Any non-system PVC neither backed up nor backup-exempt → review.
   [exempt]  A backup-exempt PVC missing the fully-qualified reason annotation
             (kept for grep-ability now that pvc-plumber no longer enforces it).
 """
@@ -76,6 +76,29 @@ def has_mover_sc(d):
     return bool(mover.get("securityContext") or mover.get("inheritSecurityContextFrom"))
 
 
+def restore_link_errors(pvc, restores_by_name, expected_policy=None):
+    """Check the named restore, not just the API group/kind of the pointer."""
+    ns, name = meta(pvc, "namespace"), meta(pvc, "name")
+    ref = (pvc.get("spec") or {}).get("dataSourceRef") or {}
+    target_ns = ref.get("namespace") or ns
+    if target_ns != ns:
+        return [f"[dsr]     PVC {ns}/{name}: cross-namespace Restore is outside this repository's restore contract"]
+    restore = restores_by_name.get((target_ns, ref.get("name")))
+    if restore is None:
+        return [f"[dsr]     PVC {ns}/{name}: named Restore {target_ns}/{ref.get('name')} was not rendered"]
+    spec = restore.get("spec") or {}
+    errors = []
+    if "populator" not in (spec.get("target") or {}):
+        errors.append(f"[dsr]     PVC {ns}/{name}: Restore {ref.get('name')} is not a populator target")
+    policy_ref = (spec.get("source") or {}).get("fromPolicy") or {}
+    if expected_policy is not None and (
+        policy_ref.get("name") != expected_policy
+        or (policy_ref.get("namespace") or ns) != ns
+    ):
+        errors.append(f"[dsr]     PVC {ns}/{name}: Restore {ref.get('name')} must use source.fromPolicy {ns}/{expected_policy}, got {policy_ref}")
+    return errors
+
+
 def main():
     if len(sys.argv) != 2:
         sys.stderr.write("usage: validate-kopiur-coverage.py <rendered-manifests.yaml>\n")
@@ -109,6 +132,7 @@ def main():
     # workload operator adopts it (Kafka/Strimzi). Index only restores whose
     # source policy matches the PVC's SnapshotPolicy; a same-name target alone
     # must not accidentally satisfy the DR contract.
+    restores_by_name = {(meta(r, "namespace"), meta(r, "name")): r for r in restores}
     direct_restore_pvcs = {}
     for r in restores:
         spec = r.get("spec") or {}
@@ -157,6 +181,8 @@ def main():
             dsr = (pvc.get("spec") or {}).get("dataSourceRef") or {}
             if dsr.get("apiGroup") != KOPIUR_GROUP or dsr.get("kind") != "Restore":
                 fails.append(f"[dsr]     PVC {pns}/{pvcname} is backed up but dataSourceRef is not a kopiur Restore → recreates EMPTY in DR (got: {dsr or 'none'})")
+                continue
+            fails.extend(restore_link_errors(pvc, restores_by_name, pname))
 
     for r in restores:
         if not has_mover_sc(r):
@@ -172,18 +198,18 @@ def main():
     for (pns, pname), pvc in sorted(pvcs.items(), key=lambda kv: (kv[0][0] or "", kv[0][1] or "")):
         if pns in SYSTEM_NS:
             continue
-        if (pvc.get("spec") or {}).get("storageClassName") != "longhorn":
-            continue
+        storage_class = (pvc.get("spec") or {}).get("storageClassName", "<default>")
         lbls = labels_of(pvc)
-        if any(k.startswith("cnpg.io/") for k in lbls):  # CNPG = Barman, not kopiur
-            continue
         if (pns, pname) in backed_pvcs:
             continue
+        dsr = (pvc.get("spec") or {}).get("dataSourceRef") or {}
+        if dsr.get("apiGroup") == KOPIUR_GROUP and dsr.get("kind") == "Restore":
+            fails.extend(restore_link_errors(pvc, restores_by_name))
         if lbls.get(EXEMPT_LABEL) == "true":
             if not anns_of(pvc).get(EXEMPT_REASON):
                 warns.append(f"[exempt]  PVC {pns}/{pname} is backup-exempt but missing {EXEMPT_REASON} annotation")
             continue
-        warns.append(f"[gap]     PVC {pns}/{pname} (longhorn) is neither backed up nor backup-exempt → review")
+        warns.append(f"[gap]     PVC {pns}/{pname} ({storage_class}) is neither backed up nor backup-exempt → review")
 
     print("== kopiur backup coverage ==")
     print(f"  policies={len(policies)} restores={len(restores)} pvcs={len(pvcs)} backed-namespaces={len(backed_namespaces)}")
@@ -194,7 +220,7 @@ def main():
     if fails:
         print(f"\n{len(fails)} hard failure(s): a backup would silently fail or a PVC would recreate empty in DR.")
         return 1
-    print(f"\nOK — coverage intact ({len(warns)} warning(s), 0 failures).")
+    print(f"\nValidation passed ({len(warns)} warning(s), 0 broken restore links). Warnings are unresolved coverage decisions, not proof of recovery.")
     return 0
 
 


### PR DESCRIPTION
## What was wrong?

The backup check could pass even when an app pointed to a restore that did not exist or used the wrong backup. It also skipped unprotected storage unless the storage class was named exactly `longhorn`.

A passing check could therefore give us confidence we had not earned.

## What does this fix?

Check that each protected app volume points to a real Restore in the same namespace, that the Restore can fill the new volume, and that it uses the correct backup policy. Also check for broken restore references on volumes marked disposable.

Review application volumes across storage classes, including flash, replicated Longhorn, and NAS storage. Missing backup coverage still produces a warning rather than forcing backups onto disposable caches. Existing special handling for operator-created volumes is preserved.

The success message is clearer: passing these checks is not proof that a backup can actually be restored.

## Does merging touch my data?

No. This changes the validation script and its tests. It does not change volumes, storage classes, replicas, backup schedules, retention, or live restore settings.

## Tests and remaining work

The implementation notes report 14 local tests passing. Review the full Cluster CI result before merging; it checks the configuration generated from the repository. Newly reported gaps on other storage classes are expected and need a decision, not automatic backups.

No live backup or restore was tested. The PR remains a draft. Reverting it restores the old validator without changing cluster data.