### PR TITLE
Warn when log and trace collectors stop working

### DIFF
--- a/.github/workflows/telemetry-rule-tests.yml
+++ b/.github/workflows/telemetry-rule-tests.yml
@@ -1,0 +1,38 @@
+name: Telemetry Rule Tests
+on:
+  pull_request:
+    paths:
+      - 'infrastructure/controllers/opentelemetry-operator-observability/**'
+      - '.github/workflows/telemetry-rule-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/controllers/opentelemetry-operator-observability/**'
+      - '.github/workflows/telemetry-rule-tests.yml'
+permissions:
+  contents: read
+jobs:
+  prometheus-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install PyYAML==6.0.3
+      - name: Extract actual rules and test fixtures
+        run: |
+          mkdir -p /tmp/otel-rule-tests
+          python - <<'PY'
+          from pathlib import Path
+          import yaml
+          source = Path('infrastructure/controllers/opentelemetry-operator-observability/collector-alerts.yaml')
+          rules = yaml.safe_load(source.read_text())['spec']
+          Path('/tmp/otel-rule-tests/collector.rules.yaml').write_text(yaml.safe_dump(rules))
+          PY
+          cp infrastructure/controllers/opentelemetry-operator-observability/tests/collector-alerts.test.yaml /tmp/otel-rule-tests/
+      - name: Check rules and evaluate synthetic time series
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint promtool -v /tmp/otel-rule-tests:/work:ro -w /work prom/prometheus:v3.5.0 check rules collector.rules.yaml
+          docker run --rm --entrypoint promtool -v /tmp/otel-rule-tests:/work:ro -w /work prom/prometheus:v3.5.0 test rules collector-alerts.test.yaml

--- a/.github/workflows/telemetry-rule-tests.yml
+++ b/.github/workflows/telemetry-rule-tests.yml
@@ -3,11 +3,15 @@ on:
   pull_request:
     paths:
       - 'infrastructure/controllers/opentelemetry-operator-observability/**'
+      - 'scripts/prepare-telemetry-rule-tests.py'
+      - 'scripts/tests/test_prepare_telemetry_rule_tests.py'
       - '.github/workflows/telemetry-rule-tests.yml'
   push:
     branches: [main]
     paths:
       - 'infrastructure/controllers/opentelemetry-operator-observability/**'
+      - 'scripts/prepare-telemetry-rule-tests.py'
+      - 'scripts/tests/test_prepare_telemetry_rule_tests.py'
       - '.github/workflows/telemetry-rule-tests.yml'
 permissions:
   contents: read
@@ -20,17 +24,10 @@ jobs:
         with:
           python-version: '3.12'
       - run: python -m pip install PyYAML==6.0.3
-      - name: Extract actual rules and test fixtures
-        run: |
-          mkdir -p /tmp/otel-rule-tests
-          python - <<'PY'
-          from pathlib import Path
-          import yaml
-          source = Path('infrastructure/controllers/opentelemetry-operator-observability/collector-alerts.yaml')
-          rules = yaml.safe_load(source.read_text())['spec']
-          Path('/tmp/otel-rule-tests/collector.rules.yaml').write_text(yaml.safe_dump(rules))
-          PY
-          cp infrastructure/controllers/opentelemetry-operator-observability/tests/collector-alerts.test.yaml /tmp/otel-rule-tests/
+      - name: Test rule-file preparation
+        run: python -m unittest discover -s scripts/tests -p test_prepare_telemetry_rule_tests.py -v
+      - name: Prepare alert-rule tests
+        run: python scripts/prepare-telemetry-rule-tests.py /tmp/otel-rule-tests
       - name: Check rules and evaluate synthetic time series
         run: |
           set -euo pipefail

--- a/infrastructure/controllers/opentelemetry-operator-observability/README.md
+++ b/infrastructure/controllers/opentelemetry-operator-observability/README.md
@@ -1,0 +1,54 @@
+# Is the telemetry pipeline itself working?
+
+This optional, post-Prometheus overlay observes the OTel agents and gateway. It
+must not move Prometheus CRDs or monitoring resources into the bootstrap operator
+application. The collectors, storage, retention and replica counts are unchanged.
+
+The ServiceMonitor selects the operator's monitoring-service label by existence,
+not by a hard-coded label value. Target relabeling identifies the homelab stack
+and the expected `otel-agent`/`otel-gateway` monitoring Services. Verify these
+names against the rendered operator output when changing collector names.
+
+## What the alerts mean
+
+- **TargetsMissing:** no discovered target for a required collector role. Check
+  ServiceMonitor, Service labels/ports, endpoints, and Prometheus selection. This
+  detects the case where `up == 0` cannot fire because `up` does not exist.
+- **TargetDown:** a discovered endpoint is not scrapeable. Check its pod and
+  networking. Other pipeline rules cannot establish health for this target.
+- **Backpressure:** a named pod is refusing logs/traces or failing exports. This
+  is not automatically permanent data loss: retries can succeed. Inspect the
+  queue, backend status, and receiver/exporter together. Both cumulative-counter
+  naming forms (with or without `_total`) are covered across collector versions.
+- **QueueNearCapacity:** a named exporter queue is above 80% for ten minutes.
+  Check whether the downstream backend is slow/unavailable before increasing
+  buffers. Zero-capacity queues are excluded rather than dividing by zero.
+
+PromQL to start an investigation:
+
+```promql
+up{telemetry_stack="homelab"}
+otelcol_exporter_queue_size{telemetry_stack="homelab"}
+otelcol_exporter_queue_capacity{telemetry_stack="homelab"}
+```
+
+Collector and Loki pod logs are deliberately excluded from the Loki ingestion
+pipeline to avoid recursive failure storms. Use Kubernetes pod logs for these
+components (including through a read-only investigation agent). Do not interpret
+an empty Loki query for them as "no errors".
+
+## Verification and limitations
+
+The workflow extracts `spec.groups` from the actual PrometheusRule and tests it
+with promtool. Tests cover a healthy pipeline, absent discovery, trace-export
+failures, legacy log counter names, full queues, and zero-capacity queues. No
+parallel manually maintained copy of the rules is used.
+
+After sync, verify one gateway target and the expected agent targets exist. Use
+a disposable telemetry event to check end-to-end delivery. These rules cannot
+detect silent data loss inside an application SDK, prove trace completeness,
+prove zero event loss, or alert when Prometheus/the entire cluster is down.
+That last case still requires an outside observer.
+
+Rollback is a Git revert of this overlay change. It changes observation only,
+not the telemetry data path, storage, or application workloads.

--- a/infrastructure/controllers/opentelemetry-operator-observability/collector-alerts.yaml
+++ b/infrastructure/controllers/opentelemetry-operator-observability/collector-alerts.yaml
@@ -9,21 +9,56 @@ spec:
       rules:
         - alert: OpenTelemetryCollectorBackpressure
           expr: |
-            sum(rate(otelcol_receiver_refused_log_records[5m])) > 0
+            max by (namespace, pod, receiver) (
+              rate({__name__=~"otelcol_receiver_refused_(log_records|spans)(_total)?",telemetry_stack="homelab"}[5m])
+            ) > 0
             or
-            sum(rate(otelcol_exporter_send_failed_log_records[5m])) > 0
+            max by (namespace, pod, exporter) (
+              rate({__name__=~"otelcol_exporter_send_failed_(log_records|spans)(_total)?",telemetry_stack="homelab"}[5m])
+            ) > 0
           for: 10m
           labels:
             severity: warning
+            component: opentelemetry
           annotations:
-            summary: OpenTelemetry collectors are refusing or dropping logs
-            description: The log pipeline has sustained receiver refusals or failed exports for 10 minutes.
+            summary: OpenTelemetry telemetry is being refused or exports are failing
+            description: 'Collector {{ $labels.namespace }}/{{ $labels.pod }} has sustained log/trace refusals or export failures. Retries may recover these; this is not proof of permanent data loss.'
+            runbook_url: https://github.com/mitchross/talos-argocd-proxmox/blob/main/infrastructure/controllers/opentelemetry-operator-observability/README.md
         - alert: OpenTelemetryCollectorQueueNearCapacity
           expr: |
-            max(otelcol_exporter_queue_size / otelcol_exporter_queue_capacity) > 0.8
+            max by (namespace, pod, exporter) (
+              otelcol_exporter_queue_size{telemetry_stack="homelab"}
+              /
+              (otelcol_exporter_queue_capacity{telemetry_stack="homelab"} > 0)
+            ) > 0.8
           for: 10m
           labels:
             severity: warning
+            component: opentelemetry
           annotations:
             summary: OpenTelemetry collector retry queue is near capacity
-            description: A collector exporter queue has remained above 80% full for 10 minutes.
+            description: 'Collector {{ $labels.namespace }}/{{ $labels.pod }} exporter {{ $labels.exporter }} has remained above 80% queue utilization.'
+            runbook_url: https://github.com/mitchross/talos-argocd-proxmox/blob/main/infrastructure/controllers/opentelemetry-operator-observability/README.md
+        - alert: OpenTelemetryCollectorTargetDown
+          expr: up{telemetry_stack="homelab"} == 0
+          for: 5m
+          labels:
+            severity: warning
+            component: opentelemetry
+          annotations:
+            summary: OpenTelemetry collector metrics target cannot be scraped
+            description: 'Prometheus cannot scrape {{ $labels.otel_collector }} at {{ $labels.instance }}. Pipeline-health alerts for this target are blind.'
+            runbook_url: https://github.com/mitchross/talos-argocd-proxmox/blob/main/infrastructure/controllers/opentelemetry-operator-observability/README.md
+        - alert: OpenTelemetryCollectorTargetsMissing
+          expr: |
+            absent(up{telemetry_stack="homelab",otel_collector="otel-agent"})
+            or
+            absent(up{telemetry_stack="homelab",otel_collector="otel-gateway"})
+          for: 10m
+          labels:
+            severity: critical
+            component: opentelemetry
+          annotations:
+            summary: OpenTelemetry collector metrics discovery is missing
+            description: 'No scrape target exists for {{ $labels.otel_collector }}. Check ServiceMonitor selection and operator monitoring Services; missing data is not healthy telemetry.'
+            runbook_url: https://github.com/mitchross/talos-argocd-proxmox/blob/main/infrastructure/controllers/opentelemetry-operator-observability/README.md

--- a/infrastructure/controllers/opentelemetry-operator-observability/collector-servicemonitor.yaml
+++ b/infrastructure/controllers/opentelemetry-operator-observability/collector-servicemonitor.yaml
@@ -8,9 +8,17 @@ spec:
     matchNames:
       - opentelemetry
   selector:
-    matchLabels:
-      operator.opentelemetry.io/collector-monitoring-service: Exists
+    matchExpressions:
+      - key: operator.opentelemetry.io/collector-monitoring-service
+        operator: Exists
   endpoints:
     - port: monitoring
       interval: 30s
       scrapeTimeout: 10s
+      relabelings:
+        - targetLabel: telemetry_stack
+          replacement: homelab
+        - sourceLabels: [__meta_kubernetes_service_name]
+          regex: '(otel-agent|otel-gateway)-collector-monitoring'
+          targetLabel: otel_collector
+          replacement: '${1}'

--- a/infrastructure/controllers/opentelemetry-operator-observability/tests/collector-alerts.test.yaml
+++ b/infrastructure/controllers/opentelemetry-operator-observability/tests/collector-alerts.test.yaml
@@ -1,0 +1,128 @@
+rule_files:
+- collector.rules.yaml
+evaluation_interval: 1m
+tests:
+- name: healthy targets and no errors
+  interval: 1m
+  input_series:
+  - &id002
+    series: up{telemetry_stack="homelab",otel_collector="otel-agent"}
+    values: 1+0x20
+  - &id001
+    series: up{telemetry_stack="homelab",otel_collector="otel-gateway"}
+    values: 1+0x20
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: OpenTelemetryCollectorBackpressure
+    exp_alerts: []
+  - eval_time: 15m
+    alertname: OpenTelemetryCollectorQueueNearCapacity
+    exp_alerts: []
+  - eval_time: 15m
+    alertname: OpenTelemetryCollectorTargetDown
+    exp_alerts: []
+  - eval_time: 15m
+    alertname: OpenTelemetryCollectorTargetsMissing
+    exp_alerts: []
+- name: missing agent discovery is not healthy
+  interval: 1m
+  input_series:
+  - *id001
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: OpenTelemetryCollectorTargetsMissing
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        component: opentelemetry
+        telemetry_stack: homelab
+        otel_collector: otel-agent
+      exp_annotations:
+        summary: OpenTelemetry collector metrics discovery is missing
+        description: No scrape target exists for otel-agent. Check ServiceMonitor
+          selection and operator monitoring Services; missing data is not healthy
+          telemetry.
+        runbook_url: https://github.com/mitchross/talos-argocd-proxmox/blob/main/infrastructure/controllers/opentelemetry-operator-observability/README.md
+- name: trace failures with total suffix
+  interval: 1m
+  input_series:
+  - *id002
+  - *id001
+  - series: otelcol_exporter_send_failed_spans_total{telemetry_stack="homelab",namespace="opentelemetry",pod="gateway-0",exporter="otlp/tempo"}
+    values: 0+60x20
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: OpenTelemetryCollectorBackpressure
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        component: opentelemetry
+        namespace: opentelemetry
+        pod: gateway-0
+        exporter: otlp/tempo
+      exp_annotations:
+        summary: OpenTelemetry telemetry is being refused or exports are failing
+        description: Collector opentelemetry/gateway-0 has sustained log/trace refusals
+          or export failures. Retries may recover these; this is not proof of permanent
+          data loss.
+        runbook_url: https://github.com/mitchross/talos-argocd-proxmox/blob/main/infrastructure/controllers/opentelemetry-operator-observability/README.md
+- name: legacy log failure counter
+  interval: 1m
+  input_series:
+  - *id002
+  - *id001
+  - series: otelcol_exporter_send_failed_log_records{telemetry_stack="homelab",namespace="opentelemetry",pod="gateway-0",exporter="otlp/tempo"}
+    values: 0+60x20
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: OpenTelemetryCollectorBackpressure
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        component: opentelemetry
+        namespace: opentelemetry
+        pod: gateway-0
+        exporter: otlp/tempo
+      exp_annotations:
+        summary: OpenTelemetry telemetry is being refused or exports are failing
+        description: Collector opentelemetry/gateway-0 has sustained log/trace refusals
+          or export failures. Retries may recover these; this is not proof of permanent
+          data loss.
+        runbook_url: https://github.com/mitchross/talos-argocd-proxmox/blob/main/infrastructure/controllers/opentelemetry-operator-observability/README.md
+- name: queue capacity 100
+  interval: 1m
+  input_series:
+  - *id002
+  - *id001
+  - series: otelcol_exporter_queue_size{telemetry_stack="homelab",namespace="opentelemetry",pod="gateway-0",exporter="otlp/tempo"}
+    values: 95+0x20
+  - series: otelcol_exporter_queue_capacity{telemetry_stack="homelab",namespace="opentelemetry",pod="gateway-0",exporter="otlp/tempo"}
+    values: 100+0x20
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: OpenTelemetryCollectorQueueNearCapacity
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        component: opentelemetry
+        namespace: opentelemetry
+        pod: gateway-0
+        exporter: otlp/tempo
+      exp_annotations:
+        summary: OpenTelemetry collector retry queue is near capacity
+        description: Collector opentelemetry/gateway-0 exporter otlp/tempo has remained
+          above 80% queue utilization.
+        runbook_url: https://github.com/mitchross/talos-argocd-proxmox/blob/main/infrastructure/controllers/opentelemetry-operator-observability/README.md
+- name: queue capacity 0
+  interval: 1m
+  input_series:
+  - *id002
+  - *id001
+  - series: otelcol_exporter_queue_size{telemetry_stack="homelab",namespace="opentelemetry",pod="gateway-0",exporter="otlp/tempo"}
+    values: 95+0x20
+  - series: otelcol_exporter_queue_capacity{telemetry_stack="homelab",namespace="opentelemetry",pod="gateway-0",exporter="otlp/tempo"}
+    values: 0+0x20
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: OpenTelemetryCollectorQueueNearCapacity
+    exp_alerts: []

--- a/scripts/prepare-telemetry-rule-tests.py
+++ b/scripts/prepare-telemetry-rule-tests.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Prepare the repository's collector alert rules and fixtures for promtool."""
+import argparse
+from pathlib import Path
+import sys
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_DIR = REPO_ROOT / "infrastructure/controllers/opentelemetry-operator-observability"
+
+
+def prepare_tests(source_dir: Path, output_dir: Path) -> None:
+    manifest = yaml.safe_load((source_dir / "collector-alerts.yaml").read_text(encoding="utf-8"))
+    rules = manifest.get("spec") if isinstance(manifest, dict) else None
+    if not isinstance(rules, dict) or not isinstance(rules.get("groups"), list) or not rules["groups"]:
+        raise ValueError("collector-alerts.yaml must contain a non-empty spec.groups list")
+    fixtures = (source_dir / "tests/collector-alerts.test.yaml").read_bytes()
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "collector.rules.yaml").write_text(yaml.safe_dump(rules), encoding="utf-8")
+    (output_dir / "collector-alerts.test.yaml").write_bytes(fixtures)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output_dir", type=Path, help="Directory for promtool input files")
+    args = parser.parse_args()
+    try:
+        prepare_tests(SOURCE_DIR, args.output_dir)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"ERROR: could not prepare telemetry rule tests: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_prepare_telemetry_rule_tests.py
+++ b/scripts/tests/test_prepare_telemetry_rule_tests.py
@@ -1,0 +1,84 @@
+"""Offline tests for preparing the inputs consumed by promtool."""
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import yaml
+
+SCRIPT = Path(__file__).resolve().parents[1] / "prepare-telemetry-rule-tests.py"
+spec = importlib.util.spec_from_file_location("prepare_telemetry", SCRIPT)
+prepare = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(prepare)
+
+
+class PrepareTelemetryTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.source = Path(temporary.name) / "source"
+        self.output = Path(temporary.name) / "output/nested"
+        (self.source / "tests").mkdir(parents=True)
+        self.manifest = {
+            "apiVersion": "monitoring.coreos.com/v1",
+            "kind": "PrometheusRule",
+            "metadata": {"name": "example"},
+            "spec": {"groups": [{"name": "example", "rules": [{"alert": "Down", "expr": "up == 0"}]}]},
+        }
+        self.rule_file = self.source / "collector-alerts.yaml"
+        self.rule_file.write_text(yaml.safe_dump(self.manifest), encoding="utf-8")
+        self.fixture_file = self.source / "tests/collector-alerts.test.yaml"
+        self.fixture_file.write_bytes(b"rule_files:\n- collector.rules.yaml\ntests: []\n")
+
+    def test_output_matches_previous_inline_script(self):
+        prepare.prepare_tests(self.source, self.output)
+        self.assertEqual(
+            (self.output / "collector.rules.yaml").read_text(encoding="utf-8"),
+            yaml.safe_dump(self.manifest["spec"]),
+        )
+        self.assertEqual(
+            (self.output / "collector-alerts.test.yaml").read_bytes(),
+            self.fixture_file.read_bytes(),
+        )
+
+    def test_repeat_run_updates_generated_rules(self):
+        prepare.prepare_tests(self.source, self.output)
+        self.manifest["spec"]["groups"][0]["rules"][0]["expr"] = "up == 1"
+        self.rule_file.write_text(yaml.safe_dump(self.manifest), encoding="utf-8")
+        prepare.prepare_tests(self.source, self.output)
+        self.assertEqual(
+            yaml.safe_load((self.output / "collector.rules.yaml").read_text(encoding="utf-8")),
+            self.manifest["spec"],
+        )
+
+    def test_missing_or_empty_groups_fail_before_writing(self):
+        for manifest in (None, [], {}, {"spec": {}}, {"spec": {"groups": []}}):
+            with self.subTest(manifest=manifest):
+                self.rule_file.write_text(yaml.safe_dump(manifest), encoding="utf-8")
+                with self.assertRaises(ValueError):
+                    prepare.prepare_tests(self.source, self.output)
+                self.assertFalse(self.output.exists())
+
+    def test_invalid_yaml_fails_before_writing(self):
+        self.rule_file.write_text("spec: [", encoding="utf-8")
+        with self.assertRaises(yaml.YAMLError):
+            prepare.prepare_tests(self.source, self.output)
+        self.assertFalse(self.output.exists())
+
+    def test_missing_fixture_fails_before_writing(self):
+        self.fixture_file.unlink()
+        with self.assertRaises(FileNotFoundError):
+            prepare.prepare_tests(self.source, self.output)
+        self.assertFalse(self.output.exists())
+
+    def test_cli_returns_failure_when_inputs_are_missing(self):
+        with patch.object(prepare, "SOURCE_DIR", self.source / "missing"), \
+             patch("sys.argv", [str(SCRIPT), str(self.output)]), \
+             patch("sys.stderr") as stderr:
+            self.assertEqual(prepare.main(), 1)
+        self.assertIn("ERROR:", "".join(call.args[0] for call in stderr.write.call_args_list))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What was wrong?

Monitoring could miss a collector that disappeared completely. Some alerts also lost the name of the failing collector or destination, leaving us with an error but little help finding it.

## What does this fix?

Raise an alert when a known collector is down and when an expected collector is missing altogether. Keep the namespace, pod, and destination in the alerts so we can see where to look.

Cover trace delivery failures as well as log failures. Improve the queue checks so an empty or disabled queue does not cause a divide-by-zero problem. Add six alert tests and a troubleshooting guide.

## Scripts are now separate files

The Python previously embedded in the GitHub workflow now lives in `scripts/prepare-telemetry-rule-tests.py`. The workflow calls it directly:

```yaml
- name: Prepare alert-rule tests
  run: python scripts/prepare-telemetry-rule-tests.py /tmp/otel-rule-tests
```

Editing that script or its tests also starts the workflow. The two straightforward `promtool` commands remain in the workflow.

This runs on GitHub's test runner, not inside the cluster, so it does not need a ConfigMap or a Kubernetes Job. This cleanup leaves the alert rules, collector selection, and existing alert-test cases unchanged.

## What changes on the cluster?

The PR changes monitoring discovery settings and alert rules. It does not change how logs and traces are collected, where they are stored, how long they are kept, or how many collector pods run. The script cleanup itself changes no cluster configuration.

## Tests and remaining work

For the updated head `b913dca`, all six new script tests passed locally and in GitHub Actions. They check that the output matches the previous embedded Python, repeat runs pick up changed rules, and invalid or missing inputs cause a clear failure.

GitHub's Telemetry Rule Tests workflow also passed: it ran the standalone script, validated all four alert rules with `promtool`, and passed the existing six alert scenarios. Review the latest Cluster CI result before merging. The PR remains a draft.

No live cluster tests were performed. After deployment, confirm Prometheus sees both `otel-agent` and `otel-gateway` with `telemetry_stack=homelab`, then send one harmless test event and confirm it reaches its destination.

This cannot warn us when Prometheus or the whole cluster is offline. That requires monitoring from outside the cluster. Revert this PR to restore the previous monitoring settings.