### PR TITLE
Check VM and storage settings when Omni files change

### DIFF
--- a/.github/workflows/omni-contract-tests.yml
+++ b/.github/workflows/omni-contract-tests.yml
@@ -1,0 +1,33 @@
+name: Omni Machine Contract
+on:
+  pull_request:
+    paths:
+      - 'omni/**'
+      - 'scripts/validate-omni-contract.py'
+      - 'scripts/tests/test_omni_contract.py'
+      - '.github/workflows/omni-contract-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'omni/**'
+      - 'scripts/validate-omni-contract.py'
+      - 'scripts/tests/test_omni_contract.py'
+      - '.github/workflows/omni-contract-tests.yml'
+permissions:
+  contents: read
+concurrency:
+  group: omni-contract-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  machine-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install PyYAML==6.0.3
+      - name: Exercise contract regressions
+        run: python -m unittest discover -s scripts/tests -p test_omni_contract.py -v
+      - name: Validate declared production topology
+        run: python scripts/validate-omni-contract.py

--- a/docs/domains/scheduling/omni-contract-validation.md
+++ b/docs/domains/scheduling/omni-contract-validation.md
@@ -1,0 +1,56 @@
+# Omni machine contract in CI
+
+The `Omni Machine Contract` workflow runs for `omni/**` changes independently
+of Cluster CI. Kubernetes manifest rendering cannot validate the separate
+MachineClass provider data and machine-set placement contract.
+
+The check reads the committed `cluster-template-prod-v2.yaml` and its referenced
+`omni/machine-classes/<name>.yaml` files. It checks class identity, positive VM
+sizes, disk selectors, inline host zones, unique Longhorn disk names/paths,
+and the shed Wi-Fi worker's taint and disabled Longhorn scheduling.
+
+In this repository one Proxmox provider identifies one physical host. Multiple
+VMs from that provider cannot claim different physical-host zones. Reported
+CPU/memory totals sum declared guests per provider; they are NOT measurements,
+reservations, admission decisions, or proof that the physical host has capacity.
+The check never derives host limits from comments or assumes all vCPUs are
+independent physical cores.
+
+## Run
+
+```sh
+python -m unittest discover -s scripts/tests -p test_omni_contract.py -v
+python scripts/validate-omni-contract.py
+```
+
+No cluster API, SSH, credentials, or host command is used. Referenced secret
+patches are deliberately not opened. The validator is scoped to the production
+v2 template and its inline placement convention, not every future Omni layout.
+A future file-based topology patch needs explicit validator support.
+
+## What passing does not establish
+
+This is a repository contract check, not the version-matched Omni/Talos schema
+validator. Run the official template validation and inspect the template sync
+dry run before an approved provisioning change. Applying a MachineClass does
+not prove an already allocated VM changed. Verify actual Omni state and the VM
+hardware separately. Do not add credentials to CI to make these static tests
+pretend to be an integration test.
+
+A hardware PR should record the exact hosts affected, current and proposed
+allocation, storage ownership, expected restart/replacement behavior, backup
+acceptance evidence, and rollback. Node replacement or data migration requires
+its own explicit execution plan; a green check is not authorization to destroy
+provider-owned disks.
+
+## Delivery gate
+
+Repository administrators must separately configure required status checks and
+branch rules. Adding this workflow does not enable branch protection. For the
+single-operator lab, an explicit emergency bypass can be preferable to a
+reviewer count that makes normal changes impossible. Do not represent a
+workflow file as an enforced approval policy.
+
+This PR changes validation only. It does not alter machines, templates, disk
+placement, networking, or any Kubernetes Application. Reverting it removes the
+additional check without changing the lab.

--- a/scripts/tests/test_omni_contract.py
+++ b/scripts/tests/test_omni_contract.py
@@ -1,0 +1,109 @@
+"""Synthetic Omni contracts; no API, VM, disk or credential is accessed."""
+from copy import deepcopy
+import importlib.util
+from pathlib import Path
+import unittest
+
+import yaml
+
+SPEC = importlib.util.spec_from_file_location("omni_contract", Path(__file__).parents[1] / "validate-omni-contract.py")
+contract = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(contract)
+
+
+def fixtures():
+    data = {"cores": 4, "sockets": 1, "memory": 8192, "disk_size": 100, "storage_selector": 'name == "cp-storage"'}
+    classes = {"cp": {"metadata": {"id": "cp", "type": "MachineClasses.omni.sidero.dev"}, "spec": {"autoprovision": {"providerid": "host-a", "providerdata": yaml.safe_dump(data)}}}}
+    documents = [{"kind": "Cluster", "name": "test"}, {"kind": "ControlPlane", "machineClass": {"name": "cp", "size": 1}, "patches": [{"inline": {"machine": {"nodeLabels": {contract.ZONE: "host-a", contract.LINK: "wired"}}}}]}]
+    return documents, classes
+
+
+class OmniContractTests(unittest.TestCase):
+    def test_valid_contract_and_declared_budget(self):
+        errors, totals = contract.validate(*fixtures())
+        self.assertEqual(errors, [])
+        self.assertEqual(totals["host-a"]["memory_mib"], 8192)
+        self.assertEqual(totals["host-a"]["vcpus"], 4)
+
+    def test_missing_class(self):
+        docs, classes = fixtures()
+        self.assertTrue(contract.validate(docs, {})[0])
+
+    def test_machine_identity(self):
+        docs, classes = fixtures()
+        classes["cp"]["metadata"]["id"] = "not-cp"
+        self.assertTrue(contract.validate(docs, classes)[0])
+
+    def test_invalid_size_and_boolean(self):
+        for value in (0, -1, True, "2"):
+            with self.subTest(value=value):
+                docs, classes = fixtures()
+                docs[1]["machineClass"]["size"] = value
+                self.assertTrue(contract.validate(docs, classes)[0])
+
+    def test_invalid_providerdata_does_not_echo_payload(self):
+        docs, classes = fixtures()
+        classes["cp"]["spec"]["autoprovision"]["providerdata"] = "[not-a-mapping, sensitive-value]"
+        errors, _ = contract.validate(docs, classes)
+        self.assertTrue(errors)
+        self.assertNotIn("sensitive-value", str(errors))
+
+    def test_same_host_cannot_claim_two_failure_domains(self):
+        docs, classes = fixtures()
+        worker = deepcopy(docs[1])
+        worker.update(kind="Workers", name="worker")
+        worker["patches"][0]["inline"]["machine"]["nodeLabels"][contract.ZONE] = "invented-zone"
+        docs.append(worker)
+        self.assertTrue(any("multiple physical-host zones" in e for e in contract.validate(docs, classes)[0]))
+
+    def test_multiple_guests_same_host_same_zone(self):
+        docs, classes = fixtures()
+        worker = deepcopy(docs[1])
+        worker.update(kind="Workers", name="worker")
+        docs.append(worker)
+        errors, totals = contract.validate(docs, classes)
+        self.assertFalse(errors)
+        self.assertEqual(totals["host-a"]["machines"], 2)
+        self.assertEqual(totals["host-a"]["memory_mib"], 16384)
+
+    def test_missing_control_plane_and_zone(self):
+        docs, classes = fixtures()
+        self.assertTrue(contract.validate(docs[:1], classes)[0])
+        del docs[1]["patches"][0]["inline"]["machine"]["nodeLabels"][contract.ZONE]
+        self.assertTrue(contract.validate(docs, classes)[0])
+
+    def test_wifi_requires_taint_and_unschedulable_disks(self):
+        docs, classes = fixtures()
+        machine = docs[1]["patches"][0]["inline"]["machine"]
+        machine["nodeLabels"][contract.LINK] = "wifi"
+        self.assertTrue(contract.validate(docs, classes)[0])
+        machine["nodeTaints"] = {contract.LINK: "wifi:NoSchedule"}
+        machine["nodeAnnotations"] = {contract.DISKS: '[{"name":"data","path":"/var/mnt/data","allowScheduling":true}]'}
+        self.assertTrue(contract.validate(docs, classes)[0])
+        machine["nodeAnnotations"][contract.DISKS] = '[{"name":"data","path":"/var/mnt/data","allowScheduling":false}]'
+        self.assertFalse(contract.validate(docs, classes)[0])
+        machine["nodeAnnotations"]["node.longhorn.io/default-node-tags"] = '["wired-storage"]'
+        self.assertTrue(contract.validate(docs, classes)[0])
+
+    def test_duplicate_or_relative_longhorn_paths(self):
+        for declaration in ('[{"name":"a","path":"relative"}]', '[{"name":"a","path":"/data"},{"name":"b","path":"/data"}]'):
+            docs, classes = fixtures()
+            docs[1]["patches"][0]["inline"]["machine"]["nodeAnnotations"] = {contract.DISKS: declaration}
+            self.assertTrue(contract.validate(docs, classes)[0])
+
+    def test_invalid_disk_and_memory_budget(self):
+        for field in ("memory", "cores", "disk_size"):
+            docs, classes = fixtures()
+            data = yaml.safe_load(classes["cp"]["spec"]["autoprovision"]["providerdata"])
+            data[field] = -1
+            classes["cp"]["spec"]["autoprovision"]["providerdata"] = yaml.safe_dump(data)
+            self.assertTrue(contract.validate(docs, classes)[0])
+
+    def test_duplicate_machine_set(self):
+        docs, classes = fixtures()
+        docs.append(deepcopy(docs[1]))
+        self.assertTrue(any("Duplicate" in e for e in contract.validate(docs, classes)[0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-omni-contract.py
+++ b/scripts/validate-omni-contract.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Check this repository's Omni machine/placement contract without contacting a cluster.
+
+This is not an Omni or Talos schema validator. Secret patches are not opened.
+Host allocation totals are declared requests, not observed capacity or usage.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+import json
+from pathlib import Path
+import sys
+
+import yaml
+
+TEMPLATE = "omni/cluster-template/cluster-template-prod-v2.yaml"
+CLASS_DIR = "omni/machine-classes"
+LINK = "node.vanillax.dev/link"
+ZONE = "topology.kubernetes.io/zone"
+DISKS = "node.longhorn.io/default-disks-config"
+
+
+def positive_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def machine_patch(doc: dict) -> dict:
+    """Combine the inline machine labels/annotations/taints used by this template."""
+    result = {"nodeLabels": {}, "nodeAnnotations": {}, "nodeTaints": {}}
+    for patch in doc.get("patches", []):
+        inline = patch.get("inline", {})
+        machine = inline.get("machine", {}) if isinstance(inline, dict) else {}
+        for key in result:
+            values = machine.get(key, {})
+            if not isinstance(values, dict):
+                raise ValueError(f"{key} must be a mapping")
+            result[key].update(values)
+    return result
+
+
+def validate(documents: list[dict], classes: dict[str, dict]) -> tuple[list[str], dict]:
+    errors: list[str] = []
+    totals: dict = defaultdict(lambda: {"vcpus": 0, "memory_mib": 0, "machines": 0, "zones": set()})
+    clusters = [d for d in documents if d.get("kind") == "Cluster"]
+    sets = [d for d in documents if d.get("kind") in ("ControlPlane", "Workers")]
+    if len(clusters) != 1:
+        errors.append("Expected exactly one Cluster document")
+    if not any(d.get("kind") == "ControlPlane" for d in sets):
+        errors.append("No ControlPlane document found")
+    seen: set[str] = set()
+    for doc in sets:
+        identity = str(doc.get("name") or doc["kind"])
+        if identity in seen:
+            errors.append(f"Duplicate machine-set identity: {identity}")
+        seen.add(identity)
+        ref = doc.get("machineClass") or {}
+        name, count = ref.get("name"), ref.get("size")
+        if not isinstance(name, str) or not name or name not in classes:
+            errors.append(f"{identity}: missing referenced MachineClass {name!r}")
+            continue
+        if not positive_int(count):
+            errors.append(f"{identity}: machineClass.size must be a positive integer")
+            continue
+        resource = classes[name]
+        metadata = resource.get("metadata") or {}
+        if metadata.get("id") != name or metadata.get("type") != "MachineClasses.omni.sidero.dev":
+            errors.append(f"{name}: MachineClass metadata identity/type does not match its reference")
+        provision = (resource.get("spec") or {}).get("autoprovision") or {}
+        provider = provision.get("providerid")
+        if not isinstance(provider, str) or not provider.strip():
+            errors.append(f"{name}: missing autoprovision.providerid")
+            continue
+        try:
+            data = yaml.safe_load(provision.get("providerdata", ""))
+            if not isinstance(data, dict):
+                raise ValueError("providerdata must decode to a mapping")
+            for key in ("cores", "memory", "disk_size"):
+                if not positive_int(data.get(key)):
+                    raise ValueError(f"{key} must be a positive integer")
+            if not positive_int(data.get("sockets", 1)):
+                raise ValueError("sockets must be a positive integer")
+            disks = [{"disk_size": data["disk_size"], "storage_selector": data.get("storage_selector")}]
+            extras = data.get("additional_disks") or []
+            if not isinstance(extras, list):
+                raise ValueError("additional_disks must be a list")
+            disks.extend(extras)
+            for disk in disks:
+                if not isinstance(disk, dict) or not positive_int(disk.get("disk_size")):
+                    raise ValueError("every declared disk requires a positive disk_size")
+                if not isinstance(disk.get("storage_selector"), str) or not disk["storage_selector"].strip():
+                    raise ValueError("every declared disk requires a storage_selector")
+            machine = machine_patch(doc)
+            labels = machine["nodeLabels"]
+            zone = labels.get(ZONE)
+            if not isinstance(zone, str) or not zone:
+                errors.append(f"{identity}: no inline {ZONE}; physical-host placement cannot be checked")
+            else:
+                totals[provider]["zones"].add(zone)
+            totals[provider]["vcpus"] += data["cores"] * data.get("sockets", 1) * count
+            totals[provider]["memory_mib"] += data["memory"] * count
+            totals[provider]["machines"] += count
+            annotations = machine["nodeAnnotations"]
+            declared_disks = json.loads(annotations.get(DISKS, "[]"))
+            if not isinstance(declared_disks, list):
+                raise ValueError("Longhorn default-disks-config must be a JSON list")
+            disk_names, paths = set(), set()
+            for disk in declared_disks:
+                if not isinstance(disk, dict):
+                    raise ValueError("Longhorn disk entries must be mappings")
+                disk_name, path = disk.get("name"), disk.get("path")
+                if not isinstance(disk_name, str) or not disk_name or disk_name in disk_names:
+                    raise ValueError("Longhorn disk names must be present and unique within a node")
+                if not isinstance(path, str) or not path.startswith("/") or path in paths:
+                    raise ValueError("Longhorn disk paths must be absolute and unique within a node")
+                disk_names.add(disk_name)
+                paths.add(path)
+            if labels.get(LINK) == "wifi":
+                if machine["nodeTaints"].get(LINK) != "wifi:NoSchedule":
+                    errors.append(f"{identity}: Wi-Fi worker is missing its NoSchedule taint")
+                if any(d.get("allowScheduling", True) is not False for d in declared_disks):
+                    errors.append(f"{identity}: Wi-Fi Longhorn disks must explicitly disable scheduling")
+                node_tags = json.loads(annotations.get("node.longhorn.io/default-node-tags", "[]"))
+                if "wired-storage" in node_tags:
+                    errors.append(f"{identity}: Wi-Fi worker cannot carry wired-storage")
+        except (yaml.YAMLError, ValueError, TypeError, AttributeError, KeyError):
+            # Do not print providerdata: a malformed configuration can contain credentials.
+            errors.append(f"{name}: invalid providerdata or inline placement/disk declaration; inspect that class and machine set")
+    for provider, values in totals.items():
+        if len(values["zones"]) > 1:
+            errors.append(f"{provider}: one provider is assigned multiple physical-host zones: {sorted(values['zones'])}")
+        values["zones"] = sorted(values["zones"])
+    return errors, dict(totals)
+
+
+def load(root: Path) -> tuple[list[dict], dict[str, dict]]:
+    documents = [d for d in yaml.safe_load_all((root / TEMPLATE).read_text()) if isinstance(d, dict)]
+    classes = {}
+    for doc in documents:
+        if doc.get("kind") not in ("ControlPlane", "Workers"):
+            continue
+        name = (doc.get("machineClass") or {}).get("name")
+        if not isinstance(name, str) or not name or Path(name).name != name or name in (".", ".."):
+            continue
+        path = root / CLASS_DIR / f"{name}.yaml"
+        if path.is_file():
+            resource = yaml.safe_load(path.read_text())
+            if not isinstance(resource, dict):
+                raise ValueError("MachineClass must be a mapping")
+            classes[name] = resource
+    return documents, classes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+    try:
+        errors, totals = validate(*load(args.root))
+    except (OSError, yaml.YAMLError, ValueError, TypeError, AttributeError):
+        print("FAIL: unable to read template or referenced MachineClass YAML", file=sys.stderr)
+        return 1
+    print(json.dumps({"declared_provider_allocations": totals, "errors": errors}, indent=2))
+    print("Allocation totals are requests, not host capacity, usage, or reservations. Secret patches and live Omni state were not checked.")
+    return int(bool(errors))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What was missing?

Changes under `omni/` could skip Cluster CI, even though those files decide how the VMs are built and where storage can run.

## What does this add?

A GitHub check for the production v2 template. It checks that referenced machine classes exist, CPU/memory/disk sizes are positive, and the same physical host is not described as two separate failure zones.

It also checks for duplicate or invalid Longhorn disk paths and makes sure the Wi-Fi worker keeps its restrictions on ordinary workloads and storage placement. Twelve tests cover these checks.

The report totals the VM resources requested on each Proxmox host. Those totals are **not** measurements of actual usage or proof that a host has enough capacity.

## Will this change my VMs?

No. It adds checks and documentation only. It does not resize or rebuild VMs, change disks, move data, edit the cluster template, or connect to the lab. It does not read secret patches.

## Tests and remaining work

The tests and production-template check are included in the new GitHub workflow. Review that result before merging; the PR remains a draft.

This checks the configuration written in this repo. It does not replace Omni's own validation or prove that provisioning works on the real hardware. It supports the repo's current way of declaring host zones, not every possible Omni configuration.

Adding a workflow does not make it mandatory before merging. Required checks still need to be enabled in GitHub's repository settings. Reverting this PR removes the extra checks without changing the cluster.