### PR TITLE
Add a read-only tool to inspect Proxmox disks and Longhorn storage

### DIFF
--- a/.github/workflows/storage-evidence-tests.yml
+++ b/.github/workflows/storage-evidence-tests.yml
@@ -1,0 +1,25 @@
+name: Storage Evidence Tests
+on:
+  pull_request:
+    paths:
+      - 'scripts/collect-storage-evidence.py'
+      - 'scripts/tests/test_storage_evidence.py'
+      - '.github/workflows/storage-evidence-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/collect-storage-evidence.py'
+      - 'scripts/tests/test_storage_evidence.py'
+      - '.github/workflows/storage-evidence-tests.yml'
+permissions:
+  contents: read
+jobs:
+  evidence-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Test with synthetic storage objects and mocked host commands
+        run: python -m unittest discover -s scripts/tests -p test_storage_evidence.py -v

--- a/docs/domains/storage/collecting-storage-evidence.md
+++ b/docs/domains/storage/collecting-storage-evidence.md
@@ -1,0 +1,86 @@
+# Read-only storage evidence collection
+
+Use this before blaming a disk, Longhorn, the NAS, or a Kubernetes request
+setting. The collector creates a private JSON report and performs no benchmarks,
+workload writes, migrations, node changes, SSH, sudo, trim, SMART tests, or
+storage reconfiguration. It does not query Secrets, ConfigMaps, or pod logs.
+
+## Cluster report
+
+From a client with existing read permissions:
+
+```sh
+python scripts/collect-storage-evidence.py cluster \
+  --context "$(kubectl config current-context)" \
+  --output "cluster-storage-$(date -u +%Y%m%dT%H%M%SZ).json"
+```
+
+Check the selected context yourself. The report joins actual PVC -> PV ->
+Longhorn volume -> replica -> node zone. It retains desired replica count,
+Longhorn robustness, replica process state, unknown placement, node conditions,
+and Longhorn disk availability/scheduling figures separately. It does not call a
+volume healthy merely because its StorageClass requests two copies.
+
+A detached volume or stopped replica process is not automatically a fault.
+Use volume robustness and current attachment/workload context. Kubernetes zone
+labels describe the configured topology, not verified independent power,
+networking, or physical hardware.
+
+## Host report
+
+Run the same script locally on each Proxmox host, not inside its Talos guest:
+
+```sh
+python3 collect-storage-evidence.py host \
+  --output "host-storage-$(date -u +%Y%m%dT%H%M%SZ).json"
+```
+
+The fixed commands are `lsblk`, `vgs`, `lvs`, and a short `iostat -x` observation.
+Missing commands or insufficient read permissions are reported as unavailable;
+the script never installs packages or elevates permissions. The host report
+includes block-device models/mounts, thick/thin LVM inventory and allocation
+headroom, plus observed device latency. It intentionally omits disk serials.
+
+Match guest virtual disks to physical backing storage through the reviewed
+Proxmox VM/storage configuration. Never infer a physical SSD model or IOPS limit
+from the name of a Kubernetes StorageClass.
+
+## Read the layers separately
+
+| Signal | What it means | What it does not mean |
+|---|---|---|
+| Thick VG free extents | Capacity still available for allocating/extending LVs | Guest filesystem free space; a nearly allocated VG is not automatically a full guest disk |
+| Thin pool data/metadata percentage | Physical thin-pool utilization | The sum of PVC requests or guest filesystem occupancy |
+| Longhorn scheduled bytes | Requested replica placement budget | Actual written bytes or physical host capacity |
+| Longhorn available bytes | Filesystem headroom reported by its node | SSD wear, power-loss protection, or independent replicas |
+| `iostat` latency sample | Observed behavior during the short interval | A benchmark, durable-write p99, or a diagnosis of the application |
+| Replica zone labels | The declared node failure domains | Proof of different hypervisors, outlets, controllers, or switches |
+
+No report establishes backup freshness or application recovery. Those still need
+the existing Kopiur and application acceptance checks. SMART/endurance and
+hardware/cabling/PCIe investigations remain separate; this tool does not invent
+missing physical evidence.
+
+## Handling the result
+
+Exit 0 means all requested data sources returned, not that the system is healthy.
+Exit 2 means a useful partial report was written; missing data must remain
+unknown. Exit 1 means collection/output failed. Existing files are never
+overwritten and new reports use mode 0600. Keep reports private: node names,
+volume names, mount paths and topology are operational information. Do not
+commit reports or attach them to a public issue without reviewing them.
+
+Record the application symptom, UTC window, image/revision, current load and
+concurrent maintenance beside the reports. Compare idle, normal application
+load, and an already approved maintenance event. Do not start a production
+replica failure or write benchmark merely to populate this report.
+
+## Tests
+
+```sh
+python -m unittest discover -s scripts/tests -p test_storage_evidence.py -v
+```
+
+The tests use mocked subprocesses and synthetic Kubernetes objects. This change
+adds tooling only; no DaemonSet or Application is deployed. Reverting the PR
+removes the collector without changing any live infrastructure.

--- a/scripts/collect-storage-evidence.py
+++ b/scripts/collect-storage-evidence.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Collect storage evidence without benchmarks, SSH, workload writes or disk changes.
+
+Run host mode on each Proxmox host and cluster mode from an administrative client.
+Reports deliberately distinguish physical-host evidence from Kubernetes evidence.
+"""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+
+MAX_OUTPUT = 8 * 1024 * 1024
+
+
+def run(command: list[str], structured: bool = True) -> dict:
+    try:
+        result = subprocess.run(command, capture_output=True, timeout=20, check=False)
+    except FileNotFoundError:
+        return {"status": "unavailable", "reason": "command not installed"}
+    except (OSError, subprocess.TimeoutExpired):
+        return {"status": "unavailable", "reason": "command failed to start or timed out"}
+    if result.returncode:
+        return {"status": "unavailable", "reason": f"command exited {result.returncode}"}
+    if len(result.stdout) > MAX_OUTPUT:
+        return {"status": "unavailable", "reason": "output exceeded report limit"}
+    try:
+        data = json.loads(result.stdout) if structured else result.stdout.decode("utf-8")
+    except (ValueError, UnicodeError):
+        return {"status": "unavailable", "reason": "unexpected output format"}
+    return {"status": "collected", "data": data}
+
+
+def items(raw: dict, key: str) -> list[dict]:
+    result = raw.get(key, {})
+    data = result.get("data", {})
+    return data.get("items", []) if result.get("status") == "collected" and isinstance(data, dict) else []
+
+
+def conditions(obj: dict) -> dict:
+    values = (obj.get("status") or {}).get("conditions") or []
+    if isinstance(values, dict):
+        values = values.values()
+    return {str(c.get("type")): c.get("status") for c in values if isinstance(c, dict)}
+
+
+def summarize_cluster(raw: dict) -> dict:
+    nodes = {}
+    for node in items(raw, "nodes"):
+        metadata, spec = node.get("metadata", {}), node.get("spec", {})
+        labels = metadata.get("labels", {})
+        nodes[metadata.get("name")] = {
+            "zone": labels.get("topology.kubernetes.io/zone"),
+            "class": labels.get("node.vanillax.dev/class"),
+            "link": labels.get("node.vanillax.dev/link"),
+            "conditions": conditions(node),
+            "allocatable": (node.get("status") or {}).get("allocatable", {}),
+            "unschedulable": spec.get("unschedulable", False),
+        }
+    pvs = {p.get("metadata", {}).get("name"): p for p in items(raw, "persistentvolumes")}
+    volumes = {v.get("metadata", {}).get("name"): v for v in items(raw, "longhorn_volumes")}
+    replicas = items(raw, "longhorn_replicas")
+    claims = []
+    for pvc in items(raw, "claims"):
+        metadata, spec = pvc.get("metadata", {}), pvc.get("spec", {})
+        pv = pvs.get(spec.get("volumeName"), {})
+        csi = pv.get("spec", {}).get("csi", {})
+        handle = csi.get("volumeHandle") if csi.get("driver") == "driver.longhorn.io" else None
+        volume = volumes.get(handle, {})
+        placement = []
+        for replica in replicas:
+            rspec = replica.get("spec", {})
+            if not handle or rspec.get("volumeName") != handle:
+                continue
+            node_name = rspec.get("nodeID")
+            placement.append({
+                "replica": replica.get("metadata", {}).get("name"),
+                "node": node_name,
+                "zone": nodes.get(node_name, {}).get("zone"),
+                "disk_id": rspec.get("diskID"),
+                "process_state": replica.get("status", {}).get("currentState"),
+                "failed_at": rspec.get("failedAt") or None,
+            })
+        record = {
+            "namespace": metadata.get("namespace"), "claim": metadata.get("name"),
+            "phase": pvc.get("status", {}).get("phase"),
+            "storage_class": spec.get("storageClassName"),
+            "requested_storage": spec.get("resources", {}).get("requests", {}).get("storage"),
+            "pv": spec.get("volumeName"), "csi_driver": csi.get("driver"),
+            "backup_exempt": metadata.get("labels", {}).get("backup-exempt") == "true",
+            "longhorn": None,
+        }
+        if volume:
+            vstatus, vspec = volume.get("status", {}), volume.get("spec", {})
+            record["longhorn"] = {
+                "volume": handle, "desired_replicas": vspec.get("numberOfReplicas"),
+                "state": vstatus.get("state"), "robustness": vstatus.get("robustness"),
+                "engine_node": vstatus.get("currentNodeID"), "replica_placement": placement,
+                "observed_zones": sorted({r["zone"] for r in placement if r["zone"]}),
+                "unknown_zone_replicas": sum(r["zone"] is None for r in placement),
+            }
+        claims.append(record)
+    disks = []
+    for node in items(raw, "longhorn_nodes"):
+        name = node.get("metadata", {}).get("name")
+        statuses = node.get("status", {}).get("diskStatus", {}) or {}
+        for disk_name, disk in (node.get("spec", {}).get("disks", {}) or {}).items():
+            status = statuses.get(disk_name, {})
+            disks.append({
+                "node": name, "disk": disk_name, "path": disk.get("path"),
+                "allow_scheduling": disk.get("allowScheduling"), "tags": disk.get("tags", []),
+                "reserved_bytes": disk.get("storageReserved"), "maximum_bytes": status.get("storageMaximum"),
+                "available_bytes": status.get("storageAvailable"), "scheduled_bytes": status.get("storageScheduled"),
+                "conditions": conditions({"status": {"conditions": status.get("conditions", {})}}),
+            })
+    return {"nodes": nodes, "claims": claims, "longhorn_disks": disks}
+
+
+def collect_cluster(context: str) -> dict:
+    prefix = ["kubectl", "--context", context, "--request-timeout=15s", "get"]
+    queries = {
+        "nodes": ["nodes"], "claims": ["persistentvolumeclaims", "--all-namespaces"],
+        "persistentvolumes": ["persistentvolumes"],
+        "longhorn_volumes": ["volumes.longhorn.io", "-n", "longhorn-system"],
+        "longhorn_replicas": ["replicas.longhorn.io", "-n", "longhorn-system"],
+        "longhorn_nodes": ["nodes.longhorn.io", "-n", "longhorn-system"],
+    }
+    raw = {name: run(prefix + args + ["-o", "json"]) for name, args in queries.items()}
+    return {
+        "collection": {key: {k: v for k, v in result.items() if k != "data"} for key, result in raw.items()},
+        "evidence": summarize_cluster(raw),
+        "not_proven": [
+            "Replica process state and declared zones do not prove independent healthy physical copies.",
+            "PVC capacity and Longhorn scheduling are not physical host free space or SSD endurance.",
+            "No backup freshness, restore correctness, application latency or availability test was performed.",
+        ],
+    }
+
+
+def collect_host() -> dict:
+    # Fixed read-only commands. Never sudo, SSH, SMART self-test, fio, trim or alter LVM.
+    commands = {
+        "block_devices": (["lsblk", "--json", "--bytes", "--output", "NAME,TYPE,SIZE,ROTA,MODEL,MOUNTPOINTS"], True),
+        "volume_groups": (["vgs", "--reportformat", "json", "--units", "b", "--nosuffix", "--options", "vg_name,vg_size,vg_free"], True),
+        "logical_volumes": (["lvs", "--reportformat", "json", "--units", "b", "--nosuffix", "--options", "vg_name,lv_name,lv_size,segtype,data_percent,metadata_percent"], True),
+        "device_latency_sample": (["iostat", "-x", "-y", "1", "3"], False),
+    }
+    results = {key: run(command, structured) for key, (command, structured) in commands.items()}
+    return {
+        "collection": results,
+        "not_proven": [
+            "This is a short observation, not an IOPS benchmark or hardware qualification.",
+            "SMART/endurance, PCIe/cabling errors, ZFS pools and guest-to-physical mapping require separate evidence.",
+            "Free extents in a thick VG are allocation headroom, not the filesystem free space inside an allocated guest disk.",
+            "Thin-pool data and metadata percentages are different from guest filesystem occupancy.",
+        ],
+    }
+
+
+def write_report(path: Path, report: dict) -> None:
+    """Create a private, new report; never overwrite a prior diagnostic artifact."""
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+        json.dump(report, output, indent=2)
+        output.write("\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("host", "cluster"))
+    parser.add_argument("--context", help="Explicit kubectl context; required for cluster mode")
+    parser.add_argument("--output", type=Path, required=True, help="New private JSON report; existing files are refused")
+    args = parser.parse_args()
+    if args.mode == "cluster" and not args.context:
+        parser.error("cluster mode requires --context")
+    if args.output.exists():
+        parser.error("output already exists; choose a new report filename")
+    report = {"schema_version": 1, "collected_at_utc": datetime.now(timezone.utc).isoformat(), "mode": args.mode}
+    try:
+        if args.mode == "cluster":
+            report["context"] = args.context
+            report.update(collect_cluster(args.context))
+        else:
+            report["host"] = socket.gethostname()
+            report.update(collect_host())
+        write_report(args.output, report)
+    except (OSError, ValueError, TypeError, AttributeError) as exc:
+        print(f"Report not completed ({type(exc).__name__}); no infrastructure changes were requested.", file=sys.stderr)
+        return 1
+    partial = any(item.get("status") != "collected" for item in report["collection"].values())
+    print(f"Wrote {'PARTIAL' if partial else 'collected'} evidence to {args.output}. This is not a cluster health certification.")
+    return 2 if partial else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_storage_evidence.py
+++ b/scripts/tests/test_storage_evidence.py
@@ -1,0 +1,123 @@
+"""Offline tests: subprocesses are mocked; no Kubernetes or host disks are queried."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location("storage_evidence", Path(__file__).parents[1] / "collect-storage-evidence.py")
+evidence = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(evidence)
+
+
+def source(*objects):
+    return {"status": "collected", "data": {"items": list(objects)}}
+
+
+def fixture():
+    return {
+        "nodes": source({"metadata": {"name": "worker-a", "labels": {"topology.kubernetes.io/zone": "host-a"}}, "status": {"conditions": [{"type": "Ready", "status": "True"}]}}),
+        "claims": source({"metadata": {"name": "db", "namespace": "app", "annotations": {"private": "do-not-export"}}, "spec": {"volumeName": "pv-a", "storageClassName": "longhorn-wired-ha"}, "status": {"phase": "Bound"}}),
+        "persistentvolumes": source({"metadata": {"name": "pv-a"}, "spec": {"csi": {"driver": "driver.longhorn.io", "volumeHandle": "vol-a", "volumeAttributes": {"secret": "do-not-export"}}}}),
+        "longhorn_volumes": source({"metadata": {"name": "vol-a"}, "spec": {"numberOfReplicas": 2}, "status": {"state": "attached", "robustness": "degraded"}}),
+        "longhorn_replicas": source({"metadata": {"name": "replica-a"}, "spec": {"volumeName": "vol-a", "nodeID": "worker-a", "diskID": "disk-a"}, "status": {"currentState": "running"}}),
+        "longhorn_nodes": source(),
+    }
+
+
+class StorageEvidenceTests(unittest.TestCase):
+    def test_claim_to_volume_to_replica_mapping(self):
+        result = evidence.summarize_cluster(fixture())
+        volume = result["claims"][0]["longhorn"]
+        self.assertEqual(volume["volume"], "vol-a")
+        self.assertEqual(volume["robustness"], "degraded")
+        self.assertEqual(volume["observed_zones"], ["host-a"])
+        self.assertEqual(volume["desired_replicas"], 2)
+        self.assertEqual(len(volume["replica_placement"]), 1)
+
+    def test_unavailable_data_stays_unknown(self):
+        raw = fixture()
+        raw["longhorn_volumes"] = {"status": "unavailable"}
+        self.assertIsNone(evidence.summarize_cluster(raw)["claims"][0]["longhorn"])
+
+    def test_sensitive_unrelated_fields_are_not_exported(self):
+        self.assertNotIn("do-not-export", json.dumps(evidence.summarize_cluster(fixture())))
+
+    def test_missing_zone_is_not_a_new_failure_domain(self):
+        raw = fixture()
+        raw["nodes"] = source()
+        result = evidence.summarize_cluster(raw)["claims"][0]["longhorn"]
+        self.assertEqual(result["observed_zones"], [])
+        self.assertEqual(result["unknown_zone_replicas"], 1)
+
+    def test_non_longhorn_csi_is_not_guessed(self):
+        raw = fixture()
+        raw["persistentvolumes"]["data"]["items"][0]["spec"]["csi"]["driver"] = "nfs.csi.k8s.io"
+        self.assertIsNone(evidence.summarize_cluster(raw)["claims"][0]["longhorn"])
+
+    def test_condition_mapping_supports_core_and_longhorn(self):
+        self.assertEqual(evidence.conditions({"status": {"conditions": {"ready": {"type": "Ready", "status": "False"}}}}), {"Ready": "False"})
+        self.assertEqual(evidence.conditions({}), {})
+
+    def test_run_failure_does_not_include_stderr(self):
+        process = subprocess.CompletedProcess([], 1, stdout=b"", stderr=b"secret-do-not-export")
+        with patch.object(evidence.subprocess, "run", return_value=process):
+            result = evidence.run(["kubectl", "get", "nodes"])
+        self.assertEqual(result["status"], "unavailable")
+        self.assertNotIn("secret-do-not-export", str(result))
+
+    def test_missing_command(self):
+        with patch.object(evidence.subprocess, "run", side_effect=FileNotFoundError):
+            self.assertEqual(evidence.run(["iostat"])["status"], "unavailable")
+
+    def test_timeout(self):
+        with patch.object(evidence.subprocess, "run", side_effect=subprocess.TimeoutExpired("kubectl", 20)):
+            self.assertEqual(evidence.run(["kubectl"])["status"], "unavailable")
+
+    def test_json_and_size_limits(self):
+        process = subprocess.CompletedProcess([], 0, stdout=b"not json", stderr=b"")
+        with patch.object(evidence.subprocess, "run", return_value=process):
+            self.assertEqual(evidence.run(["example"])["status"], "unavailable")
+        process.stdout = b'{"ok":true}'
+        with patch.object(evidence.subprocess, "run", return_value=process), patch.object(evidence, "MAX_OUTPUT", 2):
+            self.assertEqual(evidence.run(["example"])["status"], "unavailable")
+
+    def test_cluster_only_uses_get_and_explicit_context(self):
+        with patch.object(evidence, "run", return_value=source()) as runner:
+            result = evidence.collect_cluster("chosen-context")
+        self.assertTrue(result["not_proven"])
+        for call in runner.call_args_list:
+            args = call.args[0]
+            self.assertEqual(args[:5], ["kubectl", "--context", "chosen-context", "--request-timeout=15s", "get"])
+            self.assertNotIn("secrets", args)
+            self.assertNotIn("configmaps", args)
+
+    def test_host_uses_fixed_read_only_inventory_commands(self):
+        with patch.object(evidence, "run", return_value={"status": "unavailable"}) as runner:
+            result = evidence.collect_host()
+        self.assertEqual({call.args[0][0] for call in runner.call_args_list}, {"lsblk", "vgs", "lvs", "iostat"})
+        self.assertEqual(len(result["collection"]), 4)
+
+    def test_private_file_and_no_overwrite(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "report.json"
+            evidence.write_report(path, {"ok": True})
+            self.assertEqual(json.loads(path.read_text()), {"ok": True})
+            if os.name == "posix":
+                self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+            with self.assertRaises(FileExistsError):
+                evidence.write_report(path, {"overwritten": True})
+            self.assertEqual(json.loads(path.read_text()), {"ok": True})
+
+    def test_cli_refuses_implicit_cluster_context(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = subprocess.run([os.sys.executable, str(SPEC.origin), "cluster", "--output", str(Path(directory) / "report.json")], capture_output=True, text=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("requires --context", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What is this for?

Collect the facts needed to investigate slow storage or limited disk space before changing the storage layout.

There are two ways to run it. On a Proxmox host, it reads the disks, LVM layout, and disk activity. In cluster mode, it maps app volumes to Longhorn copies, nodes, and disks, and reports their condition and available space. Cluster mode requires you to choose a Kubernetes context explicitly.

## What does it change?

Nothing on the hosts or cluster. It writes a new private JSON report locally; it does not overwrite an existing report or upload anything.

It does not SSH to hosts, use sudo, install tools, run disk self-tests, or run write benchmarks. Cluster access uses read requests only. It does not collect Kubernetes Secrets, ConfigMaps, or pod logs. There are time limits on the commands it runs.

When a source is unavailable, the report says so and the tool exits with code 2. Missing information is not reported as healthy.

## Is it ready to trust?

Fourteen offline tests and a GitHub workflow are included. Review CI before merging; the PR remains a draft.

The tool has not been run against the lab. We still need an intentional read-only run to check which host commands are available and whether the resulting report is useful. A completed report is not proof that disks are healthy or backups can be recovered.

The included guide explains how physical disk space, LVM space, VM filesystems, and Longhorn capacity differ. This tool gathers information; it does not automatically tune or migrate anything. Reverting the PR removes the tool without changing infrastructure.