### PR TITLE
feat(power): shed solar page and the solar-fed shed plug

### DIFF
--- a/docs/domains/power/metering.md
+++ b/docs/domains/power/metering.md
@@ -17,11 +17,13 @@ what it costs, and how to add a plug.
 | HP Elite Mini G9 | `hp_elite_*` | homelab | HP Elite Mini 600 G9 (`.22`) |
 | Gaming PC | `gaming_pc_*` | office | 7800X3D workstation with the second RTX 3090. **Not a cluster node** |
 | MacBook + Monitor | `macbook_*` | office | Office desk |
+| Shed Lab (solar) | `shed_lab_*` | none | HP micro in the shed (`.20`), solar-fed |
 
-**Not metered:** the HP micro in the shed (`.20`). It runs off its own solar and
-battery bank, has no plug, and would cost nothing on the bill anyway. Its supply
-side (MPPT yield, battery bank voltage and state of charge) lives in the separate
-Grafana **Solar MPPT Monitor** dashboard (`solar-mppt-monitor`).
+**Shed Lab** runs off the shed's own solar and battery bank, so it has watts and
+kWh (with the daily/weekly/monthly/yearly meters) but no cost entities, and it is
+not in any group or in the house-share numbers. Its supply side (MPPT yield,
+battery bank voltage and state of charge) lives in the separate Grafana
+**Solar MPPT Monitor** dashboard (`solar-mppt-monitor`).
 
 Household plugs (dryer, TV, office lamps, the garage fridge) exist in Home
 Assistant but are outside this accounting: the Prometheus filter only exports
@@ -132,7 +134,7 @@ into Home Assistant. Source and image: `github.com/mitchross/consumers-energy-sy
 | `sensor.consumers_energy_effective_rate` | CE cost / kWh yesterday, next to the modelled rate |
 
 The live sensors are set through the REST API, so they vanish on an HA restart
-until the next 06:17 run. The statistics persist.
+until the next 13:17 run. The statistics persist.
 
 **Running it elsewhere.** The same image runs anywhere with the same env vars
 (`CE_PORTAL_USERNAME`, `CE_PORTAL_PASSWORD`, `HASS_URL`, `HASS_TOKEN`):
@@ -230,3 +232,29 @@ three or the old totals come back:
 
 Renaming an entity prefix is the same operation from Home Assistant's point of
 view: the new prefix starts at zero and the old one is orphaned.
+
+## Shed solar
+
+```
+panels → EPEVER XTRA3210N MPPT → 12.8 V LiFePO4 bank (2 × 100 Ah) → LOAD → Anker SOLIX → HP micro (Tapo Shed Lab)
+                    │
+                    └─ Modbus RTU over USB serial → rpi4 (192.168.10.174) → `epsolar` service
+```
+
+The rpi4 is the only host with the serial link. Its `epsolar` service
+(github.com/mitchross/epsolar, private) polls the controller every 5 s, runs
+the guarded LOAD automation, and serves two feeds:
+
+| Feed | Consumer |
+|---|---|
+| `:8080/metrics` (`epever_*`, `epsolar_*`, `solar_buffer_*`) | cluster Prometheus, job `epever-solar` (`monitoring/prometheus-stack/values.yaml`) |
+| `:8080/api/v1/status` (JSON) | Home Assistant `rest:` sensors `sensor.solar_*` / `binary_sensor.solar_*` (30 s) |
+
+Grafana: **Shed Solar** (`shed-solar.json`, the overview page), **Solar Buffer
+Control** (the author's detailed dashboard, copied from the epsolar repo), and
+the older **Solar MPPT Monitor**. Home Assistant: the **Solar** view of the
+Homelab Power dashboard. kWh counters are the controller's own lifetime
+totals; `sensor.solar_generated_total` is the Energy dashboard's solar source.
+
+If the Pi is down every `solar_*` sensor goes unavailable and the Prometheus
+target shows `up == 0`; nothing on the grid side is affected.

--- a/monitoring/prometheus-stack/dashboards/homelab-power.json
+++ b/monitoring/prometheus-stack/dashboards/homelab-power.json
@@ -958,7 +958,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "topk(1, label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\"))",
+          "expr": "topk(1, label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption|sensor.shed_lab_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\"))",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -1033,7 +1033,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption|sensor.shed_lab_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -1096,7 +1096,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption|sensor.shed_lab_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -1744,7 +1744,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_last_month|sensor.nas_psu_energy_last_month|sensor.truenas_energy_last_month|sensor.hp_sff_energy_last_month|sensor.hp_elite_energy_last_month|sensor.gaming_pc_energy_last_month|sensor.macbook_energy_last_month\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_last_month|sensor.nas_psu_energy_last_month|sensor.truenas_energy_last_month|sensor.hp_sff_energy_last_month|sensor.hp_elite_energy_last_month|sensor.gaming_pc_energy_last_month|sensor.macbook_energy_last_month|sensor.shed_lab_energy_last_month\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -1969,7 +1969,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_daily|sensor.nas_psu_energy_daily|sensor.truenas_energy_daily|sensor.hp_sff_energy_daily|sensor.hp_elite_energy_daily|sensor.gaming_pc_energy_daily|sensor.macbook_energy_daily\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_daily|sensor.nas_psu_energy_daily|sensor.truenas_energy_daily|sensor.hp_sff_energy_daily|sensor.hp_elite_energy_daily|sensor.gaming_pc_energy_daily|sensor.macbook_energy_daily|sensor.shed_lab_energy_daily\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -2344,7 +2344,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption|sensor.shed_lab_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -2585,7 +2585,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_daily|sensor.nas_psu_energy_daily|sensor.truenas_energy_daily|sensor.hp_sff_energy_daily|sensor.hp_elite_energy_daily|sensor.gaming_pc_energy_daily|sensor.macbook_energy_daily\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_daily|sensor.nas_psu_energy_daily|sensor.truenas_energy_daily|sensor.hp_sff_energy_daily|sensor.hp_elite_energy_daily|sensor.gaming_pc_energy_daily|sensor.macbook_energy_daily|sensor.shed_lab_energy_daily\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -2730,7 +2730,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_voltage_v{entity=~\"sensor.threadripper_voltage|sensor.nas_psu_voltage|sensor.truenas_voltage|sensor.hp_sff_voltage|sensor.hp_elite_voltage|sensor.gaming_pc_voltage|sensor.macbook_voltage\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_voltage_v{entity=~\"sensor.threadripper_voltage|sensor.nas_psu_voltage|sensor.truenas_voltage|sensor.hp_sff_voltage|sensor.hp_elite_voltage|sensor.gaming_pc_voltage|sensor.macbook_voltage|sensor.shed_lab_voltage\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -2796,7 +2796,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_current_a{entity=~\"sensor.threadripper_current|sensor.nas_psu_current|sensor.truenas_current|sensor.hp_sff_current|sensor.hp_elite_current|sensor.gaming_pc_current|sensor.macbook_current\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_current_a{entity=~\"sensor.threadripper_current|sensor.nas_psu_current|sensor.truenas_current|sensor.hp_sff_current|sensor.hp_elite_current|sensor.gaming_pc_current|sensor.macbook_current|sensor.shed_lab_current\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -3534,13 +3534,274 @@
     },
     {
       "type": "row",
-      "title": "Reading this dashboard",
+      "title": "Shed — solar-fed (free power, outside the grid totals)",
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 116
+      },
+      "id": 60,
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Shed Draw Now",
+      "description": "HP micro in the shed. Solar-fed, so it costs nothing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "watt",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.shed_lab_current_consumption\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 117
+      },
+      "id": 61
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Shed Energy Today",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "kwatth",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.shed_lab_energy_daily\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 117
+      },
+      "id": 62
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Shed Energy This Month",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "kwatth",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.shed_lab_energy_monthly\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 117
+      },
+      "id": 63
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Shed Energy Last Month",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "kwatth",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.shed_lab_energy_last_month\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 117
+      },
+      "id": 64
+    },
+    {
+      "type": "row",
+      "title": "Reading this dashboard",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 123
       },
       "id": 58,
       "panels": []
@@ -3551,13 +3812,13 @@
       "title": "",
       "options": {
         "mode": "markdown",
-        "content": "### Where the money actually goes\n\n**Idle floor is the real bill.** Peak draw is dramatic but brief; the 24h minimum runs 8,760\nhours a year. If *Baseline Cost / Year* is most of *Cost This Year*, no amount of workload\ntuning helps — only removing or consolidating a box does.\n\n**Groups.** *Homelab* is the five always-on servers and is the number to compare with the\nbill. *Office* is the Gaming PC and the MacBook: metered, priced, but not locked on, so it is\nexpected to swing to zero. *Combined* is both.\n\n**Hot-spot triage, in order:**\n\n1. **Threadripper host** is the swing consumer: big PSU, HDDs, one RTX 3090, and it spikes\n   under inference. A GPU backend left at `replicas: 1` with nothing calling it is pure idle\n   cost — see `docs/domains/ai-gpu/gpu-scale-swap.md`.\n2. **HP SFF + Optiplex share one plug.** A high reading here cannot be attributed to either\n   box. Split the outlet before deciding which one to retire.\n3. **NAS Drive PSU vs TrueNAS** are two plugs on one machine — spinning disks vs the host.\n   Persistent draw on the drive PSU with an idle host means spindles that never sleep.\n4. **HP Elite Mini G9** is the smallest server. If it is above ~40 W something is wrong.\n\n**Not metered:** the HP micro in the shed runs off its own solar and has no plug. Its supply\nside (MPPT yield, battery bank) is on the **Solar MPPT Monitor** dashboard.\n\n**What-ifs, not forecasts:** *Run-Rate / Year* and *Cost / Year If Left At This Draw*\nannualise the current instant. Use *Cost This Month* or *Cost Last Month* for a bill estimate.\n\n**Cost basis:** the all-in marginal rate — (energy + delivery riders) x (1 + sales tax) — which\nsteps between summer on-peak, summer off-peak and non-summer. Rates live in\n`my-apps/home/home-assistant/configuration.yaml` under `input_number:`; git is the source of\ntruth and the UI sliders reset to it on restart.\n\n**Plug names** come from each Home Assistant entity's `friendly_name` (customize.yaml), which\nmust read `<Device> <Metric ...>`; the dashboard strips the metric words."
+        "content": "### Where the money actually goes\n\n**Idle floor is the real bill.** Peak draw is dramatic but brief; the 24h minimum runs 8,760\nhours a year. If *Baseline Cost / Year* is most of *Cost This Year*, no amount of workload\ntuning helps — only removing or consolidating a box does.\n\n**Groups.** *Homelab* is the five always-on servers and is the number to compare with the\nbill. *Office* is the Gaming PC and the MacBook: metered, priced, but not locked on, so it is\nexpected to swing to zero. *Combined* is both.\n\n**Hot-spot triage, in order:**\n\n1. **Threadripper host** is the swing consumer: big PSU, HDDs, one RTX 3090, and it spikes\n   under inference. A GPU backend left at `replicas: 1` with nothing calling it is pure idle\n   cost — see `docs/domains/ai-gpu/gpu-scale-swap.md`.\n2. **HP SFF + Optiplex share one plug.** A high reading here cannot be attributed to either\n   box. Split the outlet before deciding which one to retire.\n3. **NAS Drive PSU vs TrueNAS** are two plugs on one machine — spinning disks vs the host.\n   Persistent draw on the drive PSU with an idle host means spindles that never sleep.\n4. **HP Elite Mini G9** is the smallest server. If it is above ~40 W something is wrong.\n\n**Shed Lab** is the HP micro in the shed, on its own solar. It is metered for watts and kWh\nbut has no cost and is outside every grid group. Its supply side (MPPT yield, battery bank) is on\nthe **Solar MPPT Monitor** dashboard.\n\n**What-ifs, not forecasts:** *Run-Rate / Year* and *Cost / Year If Left At This Draw*\nannualise the current instant. Use *Cost This Month* or *Cost Last Month* for a bill estimate.\n\n**Cost basis:** the all-in marginal rate — (energy + delivery riders) x (1 + sales tax) — which\nsteps between summer on-peak, summer off-peak and non-summer. Rates live in\n`my-apps/home/home-assistant/configuration.yaml` under `input_number:`; git is the source of\ntruth and the UI sliders reset to it on restart.\n\n**Plug names** come from each Home Assistant entity's `friendly_name` (customize.yaml), which\nmust read `<Device> <Metric ...>`; the dashboard strips the metric words."
       },
       "gridPos": {
         "h": 14,
         "w": 24,
         "x": 0,
-        "y": 117
+        "y": 124
       },
       "id": 59
     }

--- a/monitoring/prometheus-stack/dashboards/shed-solar.json
+++ b/monitoring/prometheus-stack/dashboards/shed-solar.json
@@ -1,0 +1,2536 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "row",
+      "title": "Right now — shed solar (EPEVER XTRA3210N via the rpi4)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Watts In (PV)",
+      "description": "What the panels are producing this instant.",
+      "id": 2,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 50
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_pv_power_watts",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Battery Net",
+      "description": "Positive = charging, negative = the bank is carrying the LOAD.",
+      "id": 3,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": -100
+              },
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epsolar_battery_power_watts",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "LOAD → Anker",
+      "description": "EPEVER LOAD terminal output, which feeds the Anker SOLIX.",
+      "id": 4,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_load_power_watts",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "HP Micro (Tapo)",
+      "description": "AC side, after the Anker. The only thing in the shed on a plug.",
+      "id": 5,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.shed_lab_current_consumption\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Battery SOC (local)",
+      "description": "Coulomb-counted by epsolar; controller SOC is advisory.",
+      "id": 6,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 33
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 75
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epsolar_battery_soc_percent",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Battery Voltage",
+      "description": "12.4 V emergency floor, 12.8 V cutoff, 13.3 V reconnect (policy parallel_12v).",
+      "id": 7,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 12.4
+              },
+              {
+                "color": "yellow",
+                "value": 12.8
+              },
+              {
+                "color": "green",
+                "value": 13.3
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_battery_voltage_volts",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "LOAD",
+      "description": "Confirmed electrical state of the LOAD terminal.",
+      "id": 8,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "OFF",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "ON",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_load_on",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Automation",
+      "description": "Whether epsolar may actually switch the LOAD.",
+      "id": 9,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DRY RUN",
+                  "color": "yellow"
+                },
+                "1": {
+                  "text": "ARMED",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "solar_buffer_automation_armed",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Controller",
+      "description": "",
+      "id": 10,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "OFFLINE",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "ONLINE",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epsolar_controller_online",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Fault",
+      "description": "",
+      "id": 11,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "none",
+                  "color": "green"
+                },
+                "1": {
+                  "text": "FAULT",
+                  "color": "red"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epsolar_controller_fault_active",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Usable Energy Left",
+      "description": "Above the reserve floor, at the configured efficiency.",
+      "id": 12,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watth",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epsolar_battery_estimated_energy_remaining_watt_hours",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Runtime Left",
+      "description": "At the current LOAD draw.",
+      "id": 13,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epsolar_battery_estimated_runtime_minutes",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Energy — controller counters (kWh) and what the HP micro actually used",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 14,
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Generated Today",
+      "description": "",
+      "id": 15,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 11
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_generated_energy_today_kwh",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Generated This Month",
+      "description": "",
+      "id": 16,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 11
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_generated_energy_month_kwh",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Generated This Year",
+      "description": "",
+      "id": 17,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 11
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_generated_energy_year_kwh",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Generated Lifetime",
+      "description": "",
+      "id": 18,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 11
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_generated_energy_total_kwh",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Consumed Today (LOAD)",
+      "description": "",
+      "id": 19,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 11
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_consumed_energy_today_kwh",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Consumed This Month (LOAD)",
+      "description": "",
+      "id": 20,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 11
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_consumed_energy_month_kwh",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "HP Micro Today",
+      "description": "Tapo Shed Lab plug.",
+      "id": 21,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.shed_lab_energy_daily\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "HP Micro This Month",
+      "description": "",
+      "id": 22,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.shed_lab_energy_monthly\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Homelab (grid) Today",
+      "description": "The five house servers, for scale.",
+      "id": 23,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.homelab_total_energy_daily\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Solar Share of Lab Energy Today",
+      "description": "HP micro kWh ÷ (HP micro + homelab) kWh, today.",
+      "id": 24,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.shed_lab_energy_daily\"}) / (max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.shed_lab_energy_daily\"}) + max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.homelab_total_energy_daily\"})) * 100",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Battery Round-Trip Today",
+      "description": "LOAD kWh ÷ PV kWh. Above 100 % means the bank is being drawn down.",
+      "id": 25,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_consumed_energy_today_kwh / epever_generated_energy_today_kwh * 100",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "History",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 26,
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "timeseries",
+      "title": "Power Flow",
+      "description": "Where the watts go. Battery net below zero means the bank is carrying the LOAD.",
+      "id": 27,
+      "gridPos": {
+        "h": 9,
+        "w": 16,
+        "x": 0,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_pv_power_watts",
+          "legendFormat": "PV in",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_load_power_watts",
+          "legendFormat": "LOAD → Anker",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epsolar_battery_power_watts",
+          "legendFormat": "Battery net (+charge)",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.shed_lab_current_consumption\"})",
+          "legendFormat": "HP micro (Tapo)",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "timeseries",
+      "title": "Battery Voltage vs Policy",
+      "description": "",
+      "id": 28,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Emergency floor"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cutoff"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reconnect"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_battery_voltage_volts",
+          "legendFormat": "Battery",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "solar_buffer_reconnect_voltage_volts",
+          "legendFormat": "Reconnect",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "solar_buffer_cutoff_voltage_volts",
+          "legendFormat": "Cutoff",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "solar_buffer_emergency_floor_voltage_volts",
+          "legendFormat": "Emergency floor",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "timeseries",
+      "title": "State of Charge",
+      "description": "",
+      "id": 29,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 31
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epsolar_battery_soc_percent",
+          "legendFormat": "Local (coulomb)",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_battery_soc_percent",
+          "legendFormat": "Controller (advisory)",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "timeseries",
+      "title": "Generated Today (resets at midnight)",
+      "description": "",
+      "id": 30,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 31
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_generated_energy_today_kwh",
+          "legendFormat": "Generated",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_consumed_energy_today_kwh",
+          "legendFormat": "Consumed at LOAD",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "timeseries",
+      "title": "LOAD State",
+      "description": "1 = energized. Gaps are the automation's reserve cutoffs.",
+      "id": 31,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 31
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_load_on",
+          "legendFormat": "LOAD on",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Reliability",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 32,
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Modbus Errors (1h)",
+      "description": "",
+      "id": 33,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 41
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "increase(epsolar_modbus_errors_total[1h])",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Telemetry Stale",
+      "description": "",
+      "id": 34,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 41
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "fresh",
+                  "color": "green"
+                },
+                "1": {
+                  "text": "STALE",
+                  "color": "red"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epsolar_telemetry_stale",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Scrape Up",
+      "description": "The Pi is the only path to the controller.",
+      "id": 35,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 41
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "up{job=\"epever-solar\"}",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Battery Temp",
+      "description": "",
+      "id": 36,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 41
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_battery_temp_celsius",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Controller Temp",
+      "description": "",
+      "id": 37,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 41
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "epever_device_temp_celsius",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "In This State For",
+      "description": "",
+      "id": 38,
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 41
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "solar_buffer_state_duration_seconds",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Reading this dashboard",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 39,
+      "panels": []
+    },
+    {
+      "type": "text",
+      "title": "",
+      "id": 40,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### The chain\n\n**Panels → EPEVER XTRA3210N → 12.8 V LiFePO4 bank (2 × 100 Ah, 2.56 kWh) → LOAD terminal → Anker SOLIX → HP micro.**\nThe rpi4 in the shed talks Modbus to the controller and runs `epsolar` (github.com/mitchross/epsolar): telemetry, these metrics, and the guarded LOAD automation that cuts the Anker off before the bank hits its floor.\n\n**Nothing on this page costs money.** The HP micro's plug (`Shed Lab`) is metered for watts and kWh but has no cost sensors and is outside the homelab/office groups on the *Homelab Power* dashboard.\n\n**Two SOCs.** *Local* is epsolar's calibrated coulomb count and is what the automation uses. *Controller* is the EPEVER's own guess and is advisory. Voltage always wins over both.\n\n**Detail lives elsewhere:** the *Solar Buffer Control* dashboard (the epsolar author's own) has thresholds, profiles, commissioning and decision history. Home Assistant has the same live numbers on the *Solar* view of Homelab Power."
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "solar",
+    "shed",
+    "power"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Shed Solar",
+  "uid": "shed-solar",
+  "version": 1
+}

--- a/monitoring/prometheus-stack/dashboards/solar-buffer-control.json
+++ b/monitoring/prometheus-stack/dashboards/solar-buffer-control.json
@@ -1,0 +1,1852 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(80, 227, 164, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Solar Buffer Control UI",
+      "type": "link",
+      "url": "http://192.168.10.174:8080"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "System status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "OFFLINE"
+                },
+                "1": {
+                  "text": "ONLINE"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "epsolar_controller_online",
+          "refId": "A"
+        }
+      ],
+      "title": "Controller",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "DISARMED"
+                },
+                "1": {
+                  "text": "ARMED"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "solar_buffer_automation_armed",
+          "refId": "A"
+        }
+      ],
+      "title": "Automation",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "LIVE WRITES"
+                },
+                "1": {
+                  "text": "DRY RUN"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "solar_buffer_dry_run",
+          "refId": "A"
+        }
+      ],
+      "title": "Safety mode",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "STANDBY"
+                },
+                "1": {
+                  "text": "RUNNING"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange"
+              },
+              {
+                "color": "blue",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "epsolar_load_enabled",
+          "refId": "A"
+        }
+      ],
+      "title": "LOAD",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "solar_buffer_state_duration_seconds",
+          "refId": "A"
+        }
+      ],
+      "title": "State duration",
+      "type": "stat"
+    },
+    {
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "content": "Detailed plain-language reasons and the durable decision timeline are available in the [Solar Buffer Control UI](http://192.168.10.174:8080). Reasons are intentionally not exported as Prometheus labels to avoid unbounded cardinality.",
+        "mode": "markdown"
+      },
+      "title": "Current decision",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Energy flow",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 2
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "epsolar_pv_power_watts",
+          "legendFormat": "Solar",
+          "refId": "A"
+        },
+        {
+          "expr": "epsolar_load_power_watts",
+          "legendFormat": "Anker / LOAD",
+          "refId": "B"
+        },
+        {
+          "expr": "epsolar_battery_power_watts",
+          "legendFormat": "Battery (+ charge / − discharge)",
+          "refId": "C"
+        }
+      ],
+      "title": "Solar → Battery → Anker",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 20,
+      "panels": [],
+      "title": "Battery",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8
+          },
+          "unit": "volt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "epsolar_battery_voltage_volts",
+          "legendFormat": "Battery voltage",
+          "refId": "A"
+        },
+        {
+          "expr": "solar_buffer_cutoff_voltage_volts",
+          "legendFormat": "Cutoff",
+          "refId": "B"
+        },
+        {
+          "expr": "solar_buffer_reconnect_voltage_volts",
+          "legendFormat": "Reconnect",
+          "refId": "C"
+        },
+        {
+          "expr": "solar_buffer_emergency_floor_voltage_volts",
+          "legendFormat": "Emergency floor",
+          "refId": "D"
+        }
+      ],
+      "title": "Battery voltage and thresholds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8
+          },
+          "min": 0,
+          "max": 100,
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "epsolar_battery_soc_percent",
+          "legendFormat": "Estimated SOC",
+          "refId": "A"
+        },
+        {
+          "expr": "solar_buffer_cutoff_threshold_percent",
+          "legendFormat": "Cutoff",
+          "refId": "B"
+        },
+        {
+          "expr": "solar_buffer_reconnect_threshold_percent",
+          "legendFormat": "Reconnect",
+          "refId": "C"
+        },
+        {
+          "expr": "epsolar_battery_soc_confidence * 100",
+          "legendFormat": "SOC confidence",
+          "refId": "D"
+        }
+      ],
+      "title": "SOC, confidence, and thresholds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watth"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 23
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "solar_buffer_estimated_energy_remaining_wh",
+          "refId": "A"
+        }
+      ],
+      "title": "Usable energy above reserve",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 23
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "solar_buffer_estimated_runtime_minutes",
+          "refId": "A"
+        }
+      ],
+      "title": "Estimated runtime",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "epsolar_battery_temperature_celsius",
+          "legendFormat": "Battery",
+          "refId": "A"
+        },
+        {
+          "expr": "epsolar_controller_temperature_celsius",
+          "legendFormat": "Controller",
+          "refId": "B"
+        }
+      ],
+      "title": "Temperatures",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 30,
+      "panels": [],
+      "title": "Solar, LOAD, and decisions",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 29
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "epsolar_pv_power_watts",
+          "legendFormat": "PV",
+          "refId": "A"
+        },
+        {
+          "expr": "epsolar_load_power_watts",
+          "legendFormat": "LOAD",
+          "refId": "B"
+        }
+      ],
+      "title": "PV and LOAD history",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "OFF"
+                },
+                "1": {
+                  "text": "ON"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 29
+      },
+      "id": 32,
+      "options": {
+        "colWidth": 0.9,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "epsolar_load_enabled",
+          "legendFormat": "LOAD",
+          "refId": "A"
+        },
+        {
+          "expr": "solar_buffer_manual_override_active",
+          "legendFormat": "Manual override",
+          "refId": "B"
+        },
+        {
+          "expr": "solar_buffer_state",
+          "legendFormat": "{{state}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Automation state timeline",
+      "type": "state-timeline"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 40,
+      "panels": [],
+      "title": "Reliability",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 38
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "increase(epsolar_modbus_errors_total[$__rate_interval])",
+          "legendFormat": "Poll errors",
+          "refId": "A"
+        },
+        {
+          "expr": "increase(epsolar_modbus_write_failures_total[$__rate_interval])",
+          "legendFormat": "Write failures",
+          "refId": "B"
+        },
+        {
+          "expr": "increase(epsolar_modbus_readback_failures_total[$__rate_interval])",
+          "legendFormat": "Read-back failures",
+          "refId": "C"
+        }
+      ],
+      "title": "Modbus reliability",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "max": 100,
+          "min": 0,
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 38
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "avg_over_time(epsolar_controller_online[$__range]) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Controller availability",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 50,
+      "panels": [],
+      "title": "Battery profile",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 46
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "name"
+      },
+      "targets": [
+        {
+          "expr": "epsolar_battery_profile_info == 1",
+          "legendFormat": "{{profile_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active profile",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Ah"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 6,
+        "y": 46
+      },
+      "id": 52,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "epsolar_battery_capacity_amp_hours",
+          "refId": "A"
+        }
+      ],
+      "title": "Capacity",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watth"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 10,
+        "y": 46
+      },
+      "id": 53,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "epsolar_battery_nominal_energy_watt_hours",
+          "refId": "A"
+        }
+      ],
+      "title": "Nominal energy",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "CALIBRATION REQUIRED"
+                },
+                "1": {
+                  "text": "CALIBRATED"
+                }
+              },
+              "type": "value"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 14,
+        "y": 46
+      },
+      "id": 54,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "epsolar_battery_soc_calibrated",
+          "refId": "A"
+        }
+      ],
+      "title": "SOC calibration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 46
+      },
+      "id": 55,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "epsolar_battery_profile_change_timestamp_seconds * 1000",
+          "refId": "A"
+        }
+      ],
+      "title": "Last profile change",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 60,
+      "panels": [],
+      "title": "Commissioning and confirmed LOAD state",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "INACTIVE"
+                },
+                "1": {
+                  "text": "ACTIVE"
+                }
+              },
+              "type": "value"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 52
+      },
+      "id": 61,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "epsolar_commissioning_session_active",
+          "refId": "A"
+        }
+      ],
+      "title": "Session",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "INCOMPLETE"
+                },
+                "1": {
+                  "text": "COMPLETE"
+                }
+              },
+              "type": "value"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 52
+      },
+      "id": 62,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "epsolar_commissioning_preflight_complete",
+          "refId": "A"
+        }
+      ],
+      "title": "Preflight",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "NONE"
+                },
+                "1": {
+                  "text": "PASS"
+                },
+                "2": {
+                  "text": "PARTIAL"
+                },
+                "3": {
+                  "text": "FAIL"
+                },
+                "4": {
+                  "text": "BLOCKED"
+                }
+              },
+              "type": "value"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 52
+      },
+      "id": 63,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "epsolar_commissioning_last_result",
+          "refId": "A"
+        }
+      ],
+      "title": "Last result",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 52
+      },
+      "id": 64,
+      "options": {
+        "colWidth": 0.9,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "epsolar_load_commanded_enabled",
+          "legendFormat": "Commanded",
+          "refId": "A"
+        },
+        {
+          "expr": "epsolar_load_confirmed_enabled",
+          "legendFormat": "Confirmed 0x3202 D0",
+          "refId": "B"
+        },
+        {
+          "expr": "epsolar_load_state_mismatch",
+          "legendFormat": "Mismatch",
+          "refId": "C"
+        }
+      ],
+      "title": "Commanded and confirmed LOAD",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 52
+      },
+      "id": 65,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "epsolar_commissioning_writes_total",
+          "legendFormat": "Commissioning writes",
+          "refId": "A"
+        },
+        {
+          "expr": "epsolar_commissioning_failures_total",
+          "legendFormat": "Commissioning failures",
+          "refId": "B"
+        },
+        {
+          "expr": "epsolar_modbus_write_failures_total",
+          "legendFormat": "Write failures",
+          "refId": "C"
+        },
+        {
+          "expr": "epsolar_modbus_readback_failures_total",
+          "legendFormat": "Read-back failures",
+          "refId": "D"
+        }
+      ],
+      "title": "Commissioning reliability",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 66,
+      "options": {
+        "colWidth": 0.9,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "epsolar_controller_online",
+          "legendFormat": "Controller online",
+          "refId": "A"
+        },
+        {
+          "expr": "epsolar_telemetry_stale",
+          "legendFormat": "Telemetry stale",
+          "refId": "B"
+        },
+        {
+          "expr": "epsolar_controller_fault_active",
+          "legendFormat": "Controller fault",
+          "refId": "C"
+        }
+      ],
+      "title": "Controller and telemetry safety",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 67,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "epsolar_application_start_timestamp_seconds * 1000",
+          "refId": "A"
+        }
+      ],
+      "title": "Application process started",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 70,
+      "panels": [],
+      "title": "Voltage-first control and SOC quality",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "INACTIVE"
+                },
+                "1": {
+                  "text": "ACTIVE"
+                }
+              },
+              "type": "value"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 64
+      },
+      "id": 71,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "solar_buffer_voltage_control_active",
+          "legendFormat": "Voltage-first",
+          "refId": "A"
+        },
+        {
+          "expr": "solar_buffer_soc_control_active",
+          "legendFormat": "SOC-assisted",
+          "refId": "B"
+        }
+      ],
+      "title": "Control policy (SOC advisory when voltage-first)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "volt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 10,
+        "x": 6,
+        "y": 64
+      },
+      "id": 72,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "solar_buffer_battery_voltage_authoritative",
+          "legendFormat": "Authoritative battery voltage",
+          "refId": "A"
+        },
+        {
+          "expr": "solar_buffer_voltage_cutoff_volts",
+          "legendFormat": "Reserve cutoff",
+          "refId": "B"
+        },
+        {
+          "expr": "solar_buffer_emergency_floor_volts",
+          "legendFormat": "Emergency floor",
+          "refId": "C"
+        },
+        {
+          "expr": "solar_buffer_voltage_reconnect_volts",
+          "legendFormat": "Recovery voltage",
+          "refId": "D"
+        }
+      ],
+      "title": "Authoritative voltage thresholds",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 64
+      },
+      "id": 73,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "epsolar_battery_soc_percent",
+          "legendFormat": "Controller/local advisory SOC",
+          "refId": "A"
+        },
+        {
+          "expr": "solar_buffer_voltage_soc_estimate_percent",
+          "legendFormat": "Approx voltage SOC",
+          "refId": "B"
+        },
+        {
+          "expr": "solar_buffer_soc_confidence_ratio * 100",
+          "legendFormat": "Local confidence",
+          "refId": "C"
+        },
+        {
+          "expr": "solar_buffer_voltage_soc_estimate_confidence_ratio * 100",
+          "legendFormat": "Voltage confidence",
+          "refId": "D"
+        }
+      ],
+      "title": "SOC quality (advisory)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      },
+      "id": 74,
+      "options": {
+        "colWidth": 0.9,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "epsolar_load_commanded_enabled",
+          "legendFormat": "Requested command",
+          "refId": "A"
+        },
+        {
+          "expr": "epsolar_load_confirmed_enabled",
+          "legendFormat": "Confirmed electrical",
+          "refId": "B"
+        },
+        {
+          "expr": "epsolar_load_output_inhibited",
+          "legendFormat": "Expected inhibited",
+          "refId": "C"
+        },
+        {
+          "expr": "epsolar_load_state_mismatch",
+          "legendFormat": "Any mismatch",
+          "refId": "D"
+        },
+        {
+          "expr": "epsolar_load_state_unknown",
+          "legendFormat": "Unknown state",
+          "refId": "E"
+        }
+      ],
+      "title": "Requested versus physical LOAD state",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 69
+      },
+      "id": 75,
+      "options": {
+        "colWidth": 0.9,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "solar_buffer_voltage_soc_estimate_resting",
+          "legendFormat": "Rest-qualified SOC",
+          "refId": "A"
+        },
+        {
+          "expr": "solar_buffer_soc_calibrated",
+          "legendFormat": "Local SOC calibrated",
+          "refId": "B"
+        },
+        {
+          "expr": "solar_buffer_soc_advisory",
+          "legendFormat": "SOC advisory",
+          "refId": "C"
+        }
+      ],
+      "title": "SOC eligibility and calibration",
+      "type": "state-timeline"
+    }
+  ],
+  "refresh": "15s",
+  "schemaVersion": 39,
+  "tags": [
+    "epsolar",
+    "lifepo4",
+    "shed",
+    "solar",
+    "solar-buffer"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Solar Buffer Control",
+  "uid": "solar-buffer-control",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/prometheus-stack/dashboards/tapo-power-monitoring.json
+++ b/monitoring/prometheus-stack/dashboards/tapo-power-monitoring.json
@@ -80,7 +80,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption|sensor.shed_lab_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -158,7 +158,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption|sensor.shed_lab_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -233,7 +233,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_daily|sensor.nas_psu_energy_daily|sensor.truenas_energy_daily|sensor.hp_sff_energy_daily|sensor.hp_elite_energy_daily|sensor.gaming_pc_energy_daily|sensor.macbook_energy_daily\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_energy_kwh{entity=~\"sensor.threadripper_energy_daily|sensor.nas_psu_energy_daily|sensor.truenas_energy_daily|sensor.hp_sff_energy_daily|sensor.hp_elite_energy_daily|sensor.gaming_pc_energy_daily|sensor.macbook_energy_daily|sensor.shed_lab_energy_daily\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": true,
@@ -312,7 +312,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_voltage_v{entity=~\"sensor.threadripper_voltage|sensor.nas_psu_voltage|sensor.truenas_voltage|sensor.hp_sff_voltage|sensor.hp_elite_voltage|sensor.gaming_pc_voltage|sensor.macbook_voltage\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_voltage_v{entity=~\"sensor.threadripper_voltage|sensor.nas_psu_voltage|sensor.truenas_voltage|sensor.hp_sff_voltage|sensor.hp_elite_voltage|sensor.gaming_pc_voltage|sensor.macbook_voltage|sensor.shed_lab_voltage\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -378,7 +378,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_current_a{entity=~\"sensor.threadripper_current|sensor.nas_psu_current|sensor.truenas_current|sensor.hp_sff_current|sensor.hp_elite_current|sensor.gaming_pc_current|sensor.macbook_current\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_current_a{entity=~\"sensor.threadripper_current|sensor.nas_psu_current|sensor.truenas_current|sensor.hp_sff_current|sensor.hp_elite_current|sensor.gaming_pc_current|sensor.macbook_current|sensor.shed_lab_current\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,
@@ -456,7 +456,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
+          "expr": "label_replace(max by (entity, friendly_name) (homeassistant_sensor_power_w{entity=~\"sensor.threadripper_current_consumption|sensor.nas_psu_current_consumption|sensor.truenas_current_consumption|sensor.hp_sff_current_consumption|sensor.hp_elite_current_consumption|sensor.gaming_pc_current_consumption|sensor.macbook_current_consumption|sensor.shed_lab_current_consumption\"}), \"plug\", \"$1\", \"friendly_name\", \"^(.+?) (Power|Energy|Cost|Voltage|Current|Share).*$\")",
           "legendFormat": "{{plug}}",
           "refId": "A",
           "instant": false,

--- a/monitoring/prometheus-stack/kustomization.yaml
+++ b/monitoring/prometheus-stack/kustomization.yaml
@@ -53,6 +53,21 @@ configMapGenerator:
       labels:
         grafana_dashboard: "1"
         app.kubernetes.io/name: grafana-dashboards
+  - name: shed-solar-dashboard
+    files:
+      - dashboards/shed-solar.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+        app.kubernetes.io/name: grafana-dashboards
+  # Copied from github.com/mitchross/epsolar grafana/; re-copy on upstream changes.
+  - name: solar-buffer-control-dashboard
+    files:
+      - dashboards/solar-buffer-control.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+        app.kubernetes.io/name: grafana-dashboards
 # These CRD schemas push client-side apply's last-applied annotation past the 256KB cap — keep per-CRD ServerSideApply+Replace.
 patches:
   - target:

--- a/monitoring/prometheus-stack/values.yaml
+++ b/monitoring/prometheus-stack/values.yaml
@@ -61,12 +61,14 @@ prometheus:
     # Control-plane jobs discover CP nodes via kubernetes_sd role:node, never static IPs (cluster is destroyed/recreated via Omni).
     # Needs the control-plane-performance machineconfig patch (etcd 2381, controller-manager 10257, scheduler 10259 on 0.0.0.0); job names must match the chart's default rules/dashboards.
     additionalScrapeConfigs:
+      # rpi4 in the shed: the epsolar service (github.com/mitchross/epsolar) serves both the
+      # legacy epever_* and the epsolar_*/solar_buffer_* metrics on 8080. 9812 is retired.
       - job_name: 'epever-solar'
         metrics_path: /metrics
         scheme: http
         scrape_interval: 15s
         static_configs:
-          - targets: ['192.168.10.174:9812']
+          - targets: ['192.168.10.174:8080']
             labels:
               instance: 'rpi4-solar'
               location: 'home'

--- a/my-apps/home/home-assistant/automations.yaml
+++ b/my-apps/home/home-assistant/automations.yaml
@@ -15,6 +15,7 @@
         - switch.truenas
         - switch.hp_sff
         - switch.hp_elite
+        - switch.shed_lab
       from: "on"
       to: "off"
   action:

--- a/my-apps/home/home-assistant/configuration.yaml
+++ b/my-apps/home/home-assistant/configuration.yaml
@@ -52,6 +52,10 @@ prometheus:
       - sensor.hp_elite_*
       - sensor.gaming_pc_*
       - sensor.macbook_*
+      # Solar-fed shed plug: watts/kWh only, no cost sensors.
+      - sensor.shed_lab_*
+      - sensor.solar_*
+      - binary_sensor.solar_*
       - sensor.homelab_*
       - sensor.office_*
       - sensor.combined_*
@@ -65,6 +69,163 @@ prometheus:
 
 # Energy dashboard is configured in the UI: add each sensor.<dev>_energy sensor as Individual devices.
 energy:
+
+# Shed solar: the rpi4 (github.com/mitchross/epsolar) polls the EPEVER MPPT over Modbus and serves
+# this JSON. kWh counters are the controller's own; sensors go unavailable if the Pi is down.
+rest:
+  - resource: http://192.168.10.174:8080/api/v1/status
+    scan_interval: 30
+    timeout: 10
+    sensor:
+      - name: "Solar PV Power"
+        unique_id: solar_pv_power
+        value_template: "{{ value_json.telemetry.pv_power }}"
+        unit_of_measurement: "W"
+        device_class: power
+        state_class: measurement
+      - name: "Solar PV Voltage"
+        unique_id: solar_pv_voltage
+        value_template: "{{ value_json.telemetry.pv_voltage }}"
+        unit_of_measurement: "V"
+        device_class: voltage
+        state_class: measurement
+      - name: "Solar Battery Voltage"
+        unique_id: solar_battery_voltage
+        value_template: "{{ value_json.telemetry.battery_voltage }}"
+        unit_of_measurement: "V"
+        device_class: voltage
+        state_class: measurement
+      - name: "Solar Battery SOC"
+        unique_id: solar_battery_soc
+        value_template: "{{ value_json.soc.percent | round(1) }}"
+        unit_of_measurement: "%"
+        device_class: battery
+        state_class: measurement
+      - name: "Solar Battery SOC Controller"
+        unique_id: solar_battery_soc_controller
+        value_template: "{{ value_json.telemetry.battery_soc }}"
+        unit_of_measurement: "%"
+        device_class: battery
+        state_class: measurement
+      - name: "Solar Battery Power"
+        unique_id: solar_battery_power
+        value_template: "{{ value_json.telemetry.net_battery_power | round(1) }}"
+        unit_of_measurement: "W"
+        device_class: power
+        state_class: measurement
+        icon: mdi:battery-charging
+      - name: "Solar Charge Power"
+        unique_id: solar_charge_power
+        value_template: "{{ value_json.telemetry.controller_charge_power }}"
+        unit_of_measurement: "W"
+        device_class: power
+        state_class: measurement
+      - name: "Solar Load Power"
+        unique_id: solar_load_power
+        value_template: "{{ value_json.telemetry.load_power }}"
+        unit_of_measurement: "W"
+        device_class: power
+        state_class: measurement
+        icon: mdi:power-plug
+      - name: "Solar Charging State"
+        unique_id: solar_charging_state
+        value_template: "{{ value_json.telemetry.charging_state }}"
+        icon: mdi:solar-power
+      - name: "Solar Automation State"
+        unique_id: solar_automation_state
+        value_template: "{{ value_json.automation.state }}"
+        icon: mdi:robot
+      - name: "Solar Automation Reason"
+        unique_id: solar_automation_reason
+        value_template: "{{ value_json.automation.reason }}"
+        icon: mdi:text
+      - name: "Solar Generated Today"
+        unique_id: solar_generated_today
+        value_template: "{{ value_json.telemetry.generated_today_kwh }}"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total_increasing
+      - name: "Solar Generated Month"
+        unique_id: solar_generated_month
+        value_template: "{{ value_json.telemetry.generated_month_kwh }}"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total_increasing
+      - name: "Solar Generated Year"
+        unique_id: solar_generated_year
+        value_template: "{{ value_json.telemetry.generated_year_kwh }}"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total_increasing
+      - name: "Solar Generated Total"
+        unique_id: solar_generated_total
+        value_template: "{{ value_json.telemetry.generated_total_kwh }}"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total_increasing
+      - name: "Solar Consumed Today"
+        unique_id: solar_consumed_today
+        value_template: "{{ value_json.telemetry.consumed_today_kwh }}"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total_increasing
+      - name: "Solar Consumed Month"
+        unique_id: solar_consumed_month
+        value_template: "{{ value_json.telemetry.consumed_month_kwh }}"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total_increasing
+      - name: "Solar Consumed Total"
+        unique_id: solar_consumed_total
+        value_template: "{{ value_json.telemetry.consumed_total_kwh }}"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total_increasing
+      - name: "Solar Battery Energy Remaining"
+        unique_id: solar_battery_energy_remaining
+        value_template: "{{ value_json.energy.estimated_energy_remaining_wh | round(0) }}"
+        unit_of_measurement: "Wh"
+        device_class: energy_storage
+        state_class: measurement
+      - name: "Solar Runtime Remaining"
+        unique_id: solar_runtime_remaining
+        value_template: "{{ value_json.energy.estimated_runtime_minutes | round(0) }}"
+        unit_of_measurement: "min"
+        device_class: duration
+        state_class: measurement
+        icon: mdi:timer-sand
+      - name: "Solar Battery Temperature"
+        unique_id: solar_battery_temperature
+        value_template: "{{ value_json.telemetry.battery_temperature }}"
+        unit_of_measurement: "°C"
+        device_class: temperature
+        state_class: measurement
+      - name: "Solar Controller Temperature"
+        unique_id: solar_controller_temperature
+        value_template: "{{ value_json.telemetry.controller_temperature }}"
+        unit_of_measurement: "°C"
+        device_class: temperature
+        state_class: measurement
+      - name: "Solar Last Update"
+        unique_id: solar_last_update
+        value_template: "{{ value_json.telemetry.timestamp }}"
+        device_class: timestamp
+    binary_sensor:
+      - name: "Solar Load On"
+        unique_id: solar_load_on
+        value_template: "{{ value_json.telemetry.load_on }}"
+        device_class: power
+      - name: "Solar Controller Online"
+        unique_id: solar_controller_online
+        value_template: "{{ value_json.telemetry.connected }}"
+        device_class: connectivity
+      - name: "Solar Fault"
+        unique_id: solar_fault
+        value_template: "{{ value_json.telemetry.fault_active }}"
+        device_class: problem
+      - name: "Solar Automation Armed"
+        unique_id: solar_automation_armed
+        value_template: "{{ value_json.automation_armed }}"
 
 # Enable the person integration
 person:
@@ -181,6 +342,13 @@ sensor:
     source: sensor.macbook_current_consumption
     name: "MacBook Energy"
     unique_id: macbook_energy
+    unit_prefix: k
+    round: 3
+    method: left
+  - platform: integration
+    source: sensor.shed_lab_current_consumption
+    name: "Shed Lab Energy"
+    unique_id: shed_lab_energy
     unit_prefix: k
     round: 3
     method: left
@@ -398,6 +566,23 @@ utility_meter:
   macbook_energy_yearly:
     name: "MacBook Energy Yearly"
     source: sensor.macbook_energy
+    cycle: yearly
+  # Shed Lab (solar, no cost meters)
+  shed_lab_energy_daily:
+    name: "Shed Lab Energy Daily"
+    source: sensor.shed_lab_energy
+    cycle: daily
+  shed_lab_energy_weekly:
+    name: "Shed Lab Energy Weekly"
+    source: sensor.shed_lab_energy
+    cycle: weekly
+  shed_lab_energy_monthly:
+    name: "Shed Lab Energy Monthly"
+    source: sensor.shed_lab_energy
+    cycle: monthly
+  shed_lab_energy_yearly:
+    name: "Shed Lab Energy Yearly"
+    source: sensor.shed_lab_energy
     cycle: yearly
   # Homelab total
   homelab_total_energy_daily:
@@ -988,6 +1173,14 @@ template:
         state_class: total
         state: >
           {{ state_attr('sensor.macbook_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "Shed Lab Energy Last Month"
+        unique_id: shed_lab_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total
+        state: >
+          {{ state_attr('sensor.shed_lab_energy_monthly', 'last_period') | float(0) | round(3) }}
 
       # ----- live % of combined draw -----
       - name: "Threadripper Power Share"

--- a/my-apps/home/home-assistant/customize.yaml
+++ b/my-apps/home/home-assistant/customize.yaml
@@ -267,3 +267,26 @@ sensor.macbook_cost_monthly:
   friendly_name: MacBook + Monitor Cost Monthly
 sensor.macbook_cost_yearly:
   friendly_name: MacBook + Monitor Cost Yearly
+
+# ---------- Shed Lab (solar) (shed_lab_*) — solar-fed, no cost entities ----------
+sensor.shed_lab_current_consumption:
+  friendly_name: Shed Lab (solar) Power
+sensor.shed_lab_voltage:
+  friendly_name: Shed Lab (solar) Voltage
+sensor.shed_lab_current:
+  friendly_name: Shed Lab (solar) Current
+sensor.shed_lab_energy:
+  friendly_name: Shed Lab (solar) Energy
+sensor.shed_lab_energy_last_month:
+  friendly_name: Shed Lab (solar) Energy Last Month
+sensor.shed_lab_energy_daily:
+  friendly_name: Shed Lab (solar) Energy Daily
+sensor.shed_lab_energy_weekly:
+  friendly_name: Shed Lab (solar) Energy Weekly
+sensor.shed_lab_energy_monthly:
+  friendly_name: Shed Lab (solar) Energy Monthly
+sensor.shed_lab_energy_yearly:
+  friendly_name: Shed Lab (solar) Energy Yearly
+switch.shed_lab:
+  friendly_name: Shed Lab (solar) (read-only)
+  hidden: true

--- a/my-apps/home/home-assistant/lovelace-homelab-power.yaml
+++ b/my-apps/home/home-assistant/lovelace-homelab-power.yaml
@@ -18,6 +18,9 @@ views:
           cannot be split. Homelab switches are locked read-only by the
           `Homelab plug power-off lockout` automation; the office plugs are not.
 
+          The **Shed Lab** plug (HP micro in the shed) runs on solar: watts and kWh are
+          tracked, but it has no cost and stays out of the grid groups above.
+
       - type: entities
         title: Rate
         entities:
@@ -109,6 +112,8 @@ views:
             name: Gaming PC
           - entity: sensor.macbook_current_consumption
             name: MacBook + Monitor
+          - entity: sensor.shed_lab_current_consumption
+            name: Shed Lab (solar)
 
       - type: glance
         title: Homelab cost so far
@@ -150,6 +155,20 @@ views:
           - entity: sensor.combined_cost_monthly
             name: This Month
           - entity: sensor.combined_cost_yearly
+            name: This Year
+
+      - type: glance
+        title: Shed Lab energy (solar, no cost)
+        show_state: true
+        columns: 4
+        entities:
+          - entity: sensor.shed_lab_energy_daily
+            name: Today
+          - entity: sensor.shed_lab_energy_weekly
+            name: This Week
+          - entity: sensor.shed_lab_energy_monthly
+            name: This Month
+          - entity: sensor.shed_lab_energy_yearly
             name: This Year
 
       - type: glance
@@ -211,6 +230,8 @@ views:
             name: Gaming PC
           - entity: sensor.macbook_energy_last_month
             name: MacBook + Monitor
+          - entity: sensor.shed_lab_energy_last_month
+            name: Shed Lab (solar)
 
       - type: grid
         title: Share of combined draw
@@ -322,6 +343,8 @@ views:
             name: Gaming PC
           - entity: sensor.macbook_current_consumption
             name: MacBook + Monitor
+          - entity: sensor.shed_lab_current_consumption
+            name: Shed Lab (solar)
           - entity: sensor.homelab_total_power
             name: HOMELAB
           - entity: sensor.office_total_power
@@ -342,6 +365,7 @@ views:
           - sensor.hp_elite_energy
           - sensor.gaming_pc_energy
           - sensor.macbook_energy
+          - sensor.shed_lab_energy
 
       - type: statistics-graph
         title: Cost by month (12 months)
@@ -485,3 +509,147 @@ views:
             name: Voltage
           - entity: sensor.macbook_current
             name: Current
+          - type: section
+            label: Shed Lab (solar)
+          - entity: sensor.shed_lab_current_consumption
+            name: Power now
+          - entity: sensor.shed_lab_energy_daily
+            name: Energy today
+          - entity: sensor.shed_lab_energy_monthly
+            name: Energy this month
+          - entity: sensor.shed_lab_voltage
+            name: Voltage
+          - entity: sensor.shed_lab_current
+            name: Current
+
+  - title: Solar
+    icon: mdi:solar-power-variant
+    path: solar
+    cards:
+      - type: markdown
+        content: |
+          # Shed solar
+          Panels → **EPEVER XTRA3210N** MPPT → 12.8 V LiFePO4 bank (2× 100 Ah) →
+          **LOAD** terminal → Anker SOLIX → the shed **HP micro** (Tapo `Shed Lab`).
+          Numbers come from the rpi4's `epsolar` service, which owns the serial link
+          and the guarded LOAD automation. Nothing here costs anything on the bill.
+
+      - type: glance
+        title: Right now
+        columns: 4
+        entities:
+          - entity: sensor.solar_pv_power
+            name: Watts in (PV)
+          - entity: sensor.solar_battery_power
+            name: Battery (+charge)
+          - entity: sensor.solar_load_power
+            name: LOAD → Anker
+          - entity: sensor.shed_lab_current_consumption
+            name: HP micro (Tapo)
+          - entity: sensor.solar_battery_soc
+            name: SOC (local)
+          - entity: sensor.solar_battery_voltage
+            name: Battery V
+          - entity: sensor.solar_charging_state
+            name: Charging
+          - entity: binary_sensor.solar_load_on
+            name: LOAD
+
+      - type: gauge
+        entity: sensor.solar_battery_soc
+        name: Battery state of charge
+        min: 0
+        max: 100
+        needle: true
+        severity:
+          red: 0
+          yellow: 33
+          green: 50
+
+      - type: entities
+        title: Energy (controller counters)
+        entities:
+          - entity: sensor.solar_generated_today
+            name: Generated today
+          - entity: sensor.solar_generated_month
+            name: Generated this month
+          - entity: sensor.solar_generated_year
+            name: Generated this year
+          - entity: sensor.solar_generated_total
+            name: Generated lifetime
+          - type: section
+            label: Consumed at the LOAD terminal
+          - entity: sensor.solar_consumed_today
+            name: Consumed today
+          - entity: sensor.solar_consumed_month
+            name: Consumed this month
+          - entity: sensor.solar_consumed_total
+            name: Consumed lifetime
+          - type: section
+            label: HP micro (Tapo Shed Lab)
+          - entity: sensor.shed_lab_energy_daily
+            name: Today
+          - entity: sensor.shed_lab_energy_monthly
+            name: This month
+
+      - type: history-graph
+        title: Power flow (24h)
+        hours_to_show: 24
+        refresh_interval: 30
+        entities:
+          - entity: sensor.solar_pv_power
+            name: PV in
+          - entity: sensor.solar_load_power
+            name: LOAD out
+          - entity: sensor.solar_battery_power
+            name: Battery net
+          - entity: sensor.shed_lab_current_consumption
+            name: HP micro
+
+      - type: history-graph
+        title: Battery (24h)
+        hours_to_show: 24
+        refresh_interval: 60
+        entities:
+          - entity: sensor.solar_battery_voltage
+            name: Voltage
+          - entity: sensor.solar_battery_soc
+            name: SOC local
+          - entity: sensor.solar_battery_soc_controller
+            name: SOC controller
+
+      - type: statistics-graph
+        title: Generated vs consumed by day (30d)
+        chart_type: bar
+        period: day
+        days_to_show: 30
+        stat_types:
+          - change
+        entities:
+          - sensor.solar_generated_total
+          - sensor.solar_consumed_total
+          - sensor.shed_lab_energy
+
+      - type: entities
+        title: Automation and health
+        entities:
+          - entity: sensor.solar_automation_state
+            name: State
+          - entity: sensor.solar_automation_reason
+            name: Reason
+          - entity: binary_sensor.solar_automation_armed
+            name: Armed (live writes)
+          - entity: binary_sensor.solar_controller_online
+            name: Controller online
+          - entity: binary_sensor.solar_fault
+            name: Controller fault
+          - entity: sensor.solar_battery_energy_remaining
+            name: Usable energy left
+          - entity: sensor.solar_runtime_remaining
+            name: Runtime left
+          - entity: sensor.solar_battery_temperature
+            name: Battery temp
+          - entity: sensor.solar_controller_temperature
+            name: Controller temp
+          - entity: sensor.solar_last_update
+            name: Last reading


### PR DESCRIPTION
## Shed plug (`shed_lab`)
The HP micro in the shed is now on a Tapo plug. It runs on the shed's solar, so it gets watts, kWh and the daily/weekly/monthly/yearly meters, **no cost entities**, and stays out of the homelab/office/combined groups and the house-share math. Locked on by the lockout automation like the servers. Shows up in the live-draw glance, per-plug Grafana panels and a new "Shed — solar-fed" row.

## Solar page
- **Scrape fix:** the `epever-solar` Prometheus job targeted `192.168.10.174:9812`, the old Docker exporter that exited in late July. The rpi4's `epsolar` service serves the same `epever_*` names plus `epsolar_*`/`solar_buffer_*` on **8080**. The existing Solar MPPT Monitor dashboard comes back with this.
- **Home Assistant:** `rest:` sensors from `:8080/api/v1/status` → `sensor.solar_*` / `binary_sensor.solar_*` (30 s), exported to Prometheus, and a **Solar** view on the Homelab Power dashboard. After merge I'll set `sensor.solar_generated_total` as the Energy dashboard's solar source and add `sensor.shed_lab_energy` as a device.
- **Grafana:** `dashboards/shed-solar.json` (overview: watts in, battery, LOAD → Anker, HP micro, controller kWh counters, history, reliability) and `dashboards/solar-buffer-control.json` (copied from github.com/mitchross/epsolar, datasource swapped to `prometheus`).
- Docs: `docs/domains/power/metering.md` gets the shed row and a **Shed solar** section.

Read-only on the Pi; nothing on the controller was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DKqZAPv1o5F7BDHJYwboj