### PR TITLE
fix(consumers-energy-sync): run at 13:17 and bump to v0.1.2

### DIFF
--- a/my-apps/home/consumers-energy-sync/cronjob.yaml
+++ b/my-apps/home/consumers-energy-sync/cronjob.yaml
@@ -4,8 +4,8 @@ metadata:
   name: consumers-energy-sync
   namespace: consumers-energy-sync
 spec:
-  # CE posts the previous day overnight; 06:17 local catches it with margin.
-  schedule: "17 6 * * *"
+  # CE posts the previous day late morning; a 06:17 run got stale data. 13:17 has margin.
+  schedule: "17 13 * * *"
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
@@ -27,7 +27,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: sync
-              image: ghcr.io/mitchross/consumers-energy-sync:v0.1.1@sha256:81cff10b88945d15ecee92679658c48723fd19c51c363524f1288cb7e854fe12
+              image: ghcr.io/mitchross/consumers-energy-sync:v0.1.2@sha256:0d6c6d211e98dbd778e27723e2b9192f16aa99cf9367916ad24e53abdfb70ffa
               envFrom:
                 - secretRef:
                     name: consumers-energy-sync


### PR DESCRIPTION
- **Schedule 06:17 → 13:17 ET.** Consumers posts the previous day late morning: this morning's scheduled run completed but pulled data ending two days back; a manual noon run had yesterday.
- **Image v0.1.2** (digest pinned): reports the Okta step-up page as the real error. v0.1.3 with the sensor read-back fix follows once consumers-energy-sync PR #4 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DKqZAPv1o5F7BDHJYwboj