### PR TITLE
feat(power): redesign the Homelab Power dashboard and track gaming sessions

### DIFF
--- a/docs/domains/power/metering.md
+++ b/docs/domains/power/metering.md
@@ -258,3 +258,20 @@ totals; `sensor.solar_generated_total` is the Energy dashboard's solar source.
 
 If the Pi is down every `solar_*` sensor goes unavailable and the Prometheus
 target shows `up == 0`; nothing on the grid side is affected.
+
+## Gaming sessions
+
+`binary_sensor.gaming_pc_gaming` is on while the Gaming PC plug draws more than
+`input_number.gaming_pc_active_threshold_w` (350 W; idle is ~200 W, gaming
+gaming is 450–600 W) and turns off after five quiet minutes. Three template
+feeds are integrated only while it is on:
+
+| Sensor | Meaning |
+|---|---|
+| `sensor.gaming_pc_gaming_energy` / `_cost` (+ daily/weekly/monthly/yearly meters) | kWh and USD spent gaming |
+| `sensor.gaming_pc_gaming_hours` (+ meters) | hours gamed, from integrating a 1/0 flag, so it does not depend on recorder retention |
+| `sensor.gaming_pc_idle_cost_daily` / `_monthly` | the rest of the PC's cost: total minus gaming |
+
+Grafana **Gaming PC** (`gaming-pc.json`) and the **Gaming** view of the Homelab
+Power dashboard read these. The threshold is a slider so it can be tuned without
+a deploy; a permanent change goes in `configuration.yaml`.

--- a/monitoring/prometheus-stack/dashboards/gaming-pc.json
+++ b/monitoring/prometheus-stack/dashboards/gaming-pc.json
@@ -1,0 +1,1614 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "row",
+      "title": "Right now",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Gaming?",
+      "description": "Plug draw above the threshold for a while.",
+      "id": 2,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "idle",
+                  "color": "text"
+                },
+                "1": {
+                  "text": "GAMING",
+                  "color": "green"
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_binary_sensor_state{entity=\"binary_sensor.gaming_pc_gaming\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Draw Now",
+      "description": "",
+      "id": 3,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 350
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.gaming_pc_current_consumption\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Idle Floor (24h min)",
+      "description": "What it draws doing nothing. This runs all day.",
+      "id": 4,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "min_over_time((max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.gaming_pc_current_consumption\"}))[24h:5m])",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Threshold",
+      "description": "input_number.gaming_pc_active_threshold_w in HA.",
+      "id": 5,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_w{entity=\"input_number.gaming_pc_active_threshold_w\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Burn Rate While Gaming",
+      "description": "USD per hour at this instant, zero when idle.",
+      "id": 6,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 3,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd_per_h{entity=\"sensor.gaming_pc_gaming_cost_rate\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Sessions Today",
+      "description": "",
+      "id": 7,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_{entity=\"sensor.gaming_pc_sessions_today\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Hours, energy and money",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 8,
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Hours Gamed Today",
+      "description": "",
+      "id": 9,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_h{entity=\"sensor.gaming_pc_gaming_hours_daily\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Hours Gamed This Month",
+      "description": "",
+      "id": 10,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_h{entity=\"sensor.gaming_pc_gaming_hours_monthly\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "kWh Gaming Today",
+      "description": "",
+      "id": 11,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.gaming_pc_gaming_energy_daily\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "kWh Gaming This Month",
+      "description": "",
+      "id": 12,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.gaming_pc_gaming_energy_monthly\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Cost Per Gaming Hour",
+      "description": "This month's gaming cost ÷ hours gamed.",
+      "id": 13,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 3,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd_per_h{entity=\"sensor.gaming_pc_cost_per_gaming_hour\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Whole PC This Month",
+      "description": "",
+      "id": 14,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.gaming_pc_cost_monthly\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Gaming Cost Today",
+      "description": "",
+      "id": 15,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 3,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.gaming_pc_gaming_cost_daily\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Idle Tax Today",
+      "description": "Whole PC minus gaming: the cost of leaving it on.",
+      "id": 16,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 3,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.gaming_pc_idle_cost_daily\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Gaming Cost This Month",
+      "description": "",
+      "id": 17,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.gaming_pc_gaming_cost_monthly\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Idle Tax This Month",
+      "description": "",
+      "id": 18,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.gaming_pc_idle_cost_monthly\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Gaming Cost Last Month",
+      "description": "",
+      "id": 19,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_usd{entity=\"sensor.gaming_pc_gaming_cost_last_month\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "stat",
+      "title": "Hours Gamed Last Month",
+      "description": "",
+      "id": 20,
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_h{entity=\"sensor.gaming_pc_gaming_hours_last_month\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Sessions",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 21,
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "timeseries",
+      "title": "Draw vs Threshold",
+      "description": "",
+      "id": 22,
+      "gridPos": {
+        "h": 10,
+        "w": 16,
+        "x": 0,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Threshold"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Idle floor"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "gray"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    4,
+                    4
+                  ]
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.gaming_pc_current_consumption\"})",
+          "legendFormat": "Gaming PC",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_w{entity=\"input_number.gaming_pc_active_threshold_w\"})",
+          "legendFormat": "Threshold",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "min_over_time((max by (entity) (homeassistant_sensor_power_w{entity=\"sensor.gaming_pc_current_consumption\"}))[24h:5m])",
+          "legendFormat": "Idle floor",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "state-timeline",
+      "title": "Session Timeline",
+      "description": "Green = gaming. Zoom the time range out for the week.",
+      "id": 23,
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "idle"
+                },
+                "1": {
+                  "text": "gaming"
+                }
+              }
+            }
+          ],
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 0
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showValue": "never",
+        "rowHeight": 0.9,
+        "mergeValues": true,
+        "legend": {
+          "showLegend": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_binary_sensor_state{entity=\"binary_sensor.gaming_pc_gaming\"})",
+          "legendFormat": "session",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "timeseries",
+      "title": "Energy Today: Gaming vs Whole PC (resets at midnight)",
+      "description": "",
+      "id": 24,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "kwatth",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.gaming_pc_gaming_energy_daily\"})",
+          "legendFormat": "Gaming",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_energy_kwh{entity=\"sensor.gaming_pc_energy_daily\"})",
+          "legendFormat": "Whole PC",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "type": "timeseries",
+      "title": "Hours Gamed Today (resets at midnight)",
+      "description": "",
+      "id": 25,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (entity) (homeassistant_sensor_unit_h{entity=\"sensor.gaming_pc_gaming_hours_daily\"})",
+          "legendFormat": "Hours",
+          "refId": "A",
+          "instant": false,
+          "range": true
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Reading this dashboard",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 26,
+      "panels": []
+    },
+    {
+      "type": "text",
+      "title": "",
+      "id": 27,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**A session** is the Gaming PC plug drawing more than the threshold (350 W by default; idle is ~200 W, gaming 450–600 W) until five quiet minutes pass. Menus and loading screens do not split a session.\n\n**Gaming cost** is the all-in rate applied only to watts drawn during sessions. **Idle tax** is everything else the PC costs: the ~200 W it draws sitting there is about 1.4 kWh a day, more than a couple of hours of gaming. If the idle tax dominates, sleep the machine; no amount of settings tuning in games will move the bill.\n\n**Tuning:** the threshold is `input_number.gaming_pc_active_threshold_w` in Home Assistant (resets to git on restart). Month numbers come from HA utility meters, so they survive Prometheus retention; the timeline here only reaches back as far as Prometheus keeps."
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "power",
+    "gaming"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Gaming PC",
+  "uid": "gaming-pc",
+  "version": 1
+}

--- a/monitoring/prometheus-stack/kustomization.yaml
+++ b/monitoring/prometheus-stack/kustomization.yaml
@@ -53,6 +53,13 @@ configMapGenerator:
       labels:
         grafana_dashboard: "1"
         app.kubernetes.io/name: grafana-dashboards
+  - name: gaming-pc-dashboard
+    files:
+      - dashboards/gaming-pc.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+        app.kubernetes.io/name: grafana-dashboards
   - name: shed-solar-dashboard
     files:
       - dashboards/shed-solar.json

--- a/my-apps/home/home-assistant/configuration.yaml
+++ b/my-apps/home/home-assistant/configuration.yaml
@@ -56,6 +56,7 @@ prometheus:
       - sensor.shed_lab_*
       - sensor.solar_*
       - binary_sensor.solar_*
+      - binary_sensor.gaming_pc_*
       - sensor.homelab_*
       - sensor.office_*
       - sensor.combined_*
@@ -289,6 +290,16 @@ input_number:
     unit_of_measurement: "%"
     icon: mdi:percent
     initial: 4.0
+  # The Gaming PC idles ~200 W and games at 450-600 W; above this counts as a session.
+  gaming_pc_active_threshold_w:
+    name: "Gaming PC — Active Threshold"
+    min: 200
+    max: 800
+    step: 10
+    mode: box
+    unit_of_measurement: "W"
+    icon: mdi:controller
+    initial: 350
 
 # Cost integrates a live USD/h cost-rate (power * current TOU rate), not a fixed tariff.
 # Every integral starts at 0 when first created; totals only fill in as data accumulates.
@@ -424,6 +435,37 @@ sensor:
     unit_time: h
     round: 4
     method: left
+  # --- gaming sessions: only the watts drawn while binary_sensor.gaming_pc_gaming is on ---
+  - platform: integration
+    source: sensor.gaming_pc_gaming_power
+    name: "Gaming PC Gaming Energy"
+    unique_id: gaming_pc_gaming_energy
+    unit_prefix: k
+    round: 3
+    method: left
+  - platform: integration
+    source: sensor.gaming_pc_gaming_cost_rate
+    name: "Gaming PC Gaming Cost"
+    unique_id: gaming_pc_gaming_cost
+    unit_time: h
+    round: 4
+    method: left
+  # 1 while gaming, else 0, integrated over hours = hours gamed. Survives the recorder purge.
+  - platform: integration
+    source: sensor.gaming_pc_gaming_flag
+    name: "Gaming PC Gaming Hours"
+    unique_id: gaming_pc_gaming_hours
+    unit_time: h
+    round: 3
+    method: left
+  - platform: history_stats
+    name: "Gaming PC Sessions Today"
+    unique_id: gaming_pc_sessions_today
+    entity_id: binary_sensor.gaming_pc_gaming
+    state: "on"
+    type: count
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
   - platform: integration
     source: sensor.homelab_cost_rate
     name: "Homelab Cost"
@@ -739,6 +781,55 @@ utility_meter:
     name: "Gaming PC Cost Yearly"
     source: sensor.gaming_pc_cost
     cycle: yearly
+  # Gaming sessions (energy / cost / hours while gaming)
+  gaming_pc_gaming_energy_daily:
+    name: "Gaming PC Gaming Energy Daily"
+    source: sensor.gaming_pc_gaming_energy
+    cycle: daily
+  gaming_pc_gaming_energy_weekly:
+    name: "Gaming PC Gaming Energy Weekly"
+    source: sensor.gaming_pc_gaming_energy
+    cycle: weekly
+  gaming_pc_gaming_energy_monthly:
+    name: "Gaming PC Gaming Energy Monthly"
+    source: sensor.gaming_pc_gaming_energy
+    cycle: monthly
+  gaming_pc_gaming_energy_yearly:
+    name: "Gaming PC Gaming Energy Yearly"
+    source: sensor.gaming_pc_gaming_energy
+    cycle: yearly
+  gaming_pc_gaming_cost_daily:
+    name: "Gaming PC Gaming Cost Daily"
+    source: sensor.gaming_pc_gaming_cost
+    cycle: daily
+  gaming_pc_gaming_cost_weekly:
+    name: "Gaming PC Gaming Cost Weekly"
+    source: sensor.gaming_pc_gaming_cost
+    cycle: weekly
+  gaming_pc_gaming_cost_monthly:
+    name: "Gaming PC Gaming Cost Monthly"
+    source: sensor.gaming_pc_gaming_cost
+    cycle: monthly
+  gaming_pc_gaming_cost_yearly:
+    name: "Gaming PC Gaming Cost Yearly"
+    source: sensor.gaming_pc_gaming_cost
+    cycle: yearly
+  gaming_pc_gaming_hours_daily:
+    name: "Gaming PC Gaming Hours Daily"
+    source: sensor.gaming_pc_gaming_hours
+    cycle: daily
+  gaming_pc_gaming_hours_weekly:
+    name: "Gaming PC Gaming Hours Weekly"
+    source: sensor.gaming_pc_gaming_hours
+    cycle: weekly
+  gaming_pc_gaming_hours_monthly:
+    name: "Gaming PC Gaming Hours Monthly"
+    source: sensor.gaming_pc_gaming_hours
+    cycle: monthly
+  gaming_pc_gaming_hours_yearly:
+    name: "Gaming PC Gaming Hours Yearly"
+    source: sensor.gaming_pc_gaming_hours
+    cycle: yearly
   # MacBook + Monitor
   macbook_cost_daily:
     name: "MacBook Cost Daily"
@@ -810,7 +901,85 @@ utility_meter:
 
 # Template sensors: live all-in rate, tariff window, group totals, per-device cost-rate and share.
 template:
+  # Gaming = plug draw above the threshold; 5 min of quiet ends the session (menus, loading).
+  - binary_sensor:
+      - name: "Gaming PC Gaming"
+        unique_id: gaming_pc_gaming
+        icon: mdi:controller
+        delay_off: "00:05:00"
+        state: >
+          {{ states('sensor.gaming_pc_current_consumption') | float(0)
+             > states('input_number.gaming_pc_active_threshold_w') | float(350) }}
   - sensor:
+      - name: "Gaming PC Gaming Flag"
+        unique_id: gaming_pc_gaming_flag
+        state_class: measurement
+        icon: mdi:controller
+        state: "{{ 1 if is_state('binary_sensor.gaming_pc_gaming', 'on') else 0 }}"
+
+      - name: "Gaming PC Gaming Power"
+        unique_id: gaming_pc_gaming_power
+        unit_of_measurement: "W"
+        device_class: power
+        state_class: measurement
+        state: >
+          {{ states('sensor.gaming_pc_current_consumption') | float(0)
+             if is_state('binary_sensor.gaming_pc_gaming', 'on') else 0 }}
+
+      - name: "Gaming PC Gaming Cost Rate"
+        unique_id: gaming_pc_gaming_cost_rate
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        icon: mdi:cash-fast
+        state: >
+          {{ (states('sensor.gaming_pc_gaming_power') | float(0) / 1000
+            * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
+
+      # Idle tax: what the PC costs when nobody is gaming (total minus gaming).
+      - name: "Gaming PC Idle Cost Daily"
+        unique_id: gaming_pc_idle_cost_daily
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:sleep
+        state: >
+          {{ (states('sensor.gaming_pc_cost_daily') | float(0)
+            - states('sensor.gaming_pc_gaming_cost_daily') | float(0)) | round(4) }}
+
+      - name: "Gaming PC Idle Cost Monthly"
+        unique_id: gaming_pc_idle_cost_monthly
+        unit_of_measurement: "USD"
+        state_class: total
+        icon: mdi:sleep
+        state: >
+          {{ (states('sensor.gaming_pc_cost_monthly') | float(0)
+            - states('sensor.gaming_pc_gaming_cost_monthly') | float(0)) | round(4) }}
+
+      - name: "Gaming PC Gaming Cost Last Month"
+        unique_id: gaming_pc_gaming_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.gaming_pc_gaming_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "Gaming PC Gaming Hours Last Month"
+        unique_id: gaming_pc_gaming_hours_last_month
+        unit_of_measurement: "h"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.gaming_pc_gaming_hours_monthly', 'last_period') | float(0) | round(2) }}
+
+      - name: "Gaming PC Cost Per Gaming Hour"
+        unique_id: gaming_pc_cost_per_gaming_hour
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        icon: mdi:cash-clock
+        availability: "{{ states('sensor.gaming_pc_gaming_hours_monthly') | float(0) > 0.25 }}"
+        state: >
+          {{ (states('sensor.gaming_pc_gaming_cost_monthly') | float(0)
+            / states('sensor.gaming_pc_gaming_hours_monthly') | float(1)) | round(3) }}
+
       # now()-based templates re-render every minute; float(<bill default>) keeps this right
       # before the input_number sliders are first touched.
       # Summer is June-August: September bills at the non-summer rate.

--- a/my-apps/home/home-assistant/lovelace-homelab-power.yaml
+++ b/my-apps/home/home-assistant/lovelace-homelab-power.yaml
@@ -1,655 +1,1187 @@
 # YAML-mode dashboard, wired via lovelace.dashboards.homelab-power in configuration.yaml.
 # Cost = the all-in TOU rate from sensor.current_electricity_rate; long-term trends come from HA LTS.
+# Layout: `sections` views, one question per section, most important top-left. The built-in
+# Energy dashboard is the per-day ledger; this page is "what is it costing me, live".
 title: Homelab Power
 views:
+  # ───────────────────────── Overview: the money question ─────────────────────────
   - title: Overview
     icon: mdi:server-network
     path: overview
-    cards:
-      - type: markdown
-        content: |
-          # Homelab Power & Cost
-          Every box sits behind a Tapo P115 plug. **Homelab** is the five always-on
-          servers, **Office** is the Gaming PC and the MacBook, **Combined** is both.
-          Cost uses the **all-in marginal rate** (energy + delivery riders + tax),
-          which varies by season and peak/off-peak window.
-
-          The **HP SFF** plug feeds two hosts (HP 8500 + Optiplex 8500), so its draw
-          cannot be split. Homelab switches are locked read-only by the
-          `Homelab plug power-off lockout` automation; the office plugs are not.
-
-          The **Shed Lab** plug (HP micro in the shed) runs on solar: watts and kWh are
-          tracked, but it has no cost and stays out of the grid groups above.
-
-      - type: entities
-        title: Rate
-        entities:
-          - entity: sensor.current_electricity_rate
-            name: Effective rate
-          - entity: sensor.electricity_tariff_period
-            name: Tariff window
-          - entity: sensor.homelab_cost_rate
-            name: Homelab burn rate (USD/h)
-          - entity: sensor.office_cost_rate
-            name: Office burn rate (USD/h)
-          - type: section
-            label: Inputs (temporary — git is source of truth)
-          - entity: input_number.rate_summer_onpeak
-            name: Summer on-peak
-          - entity: input_number.rate_summer_offpeak
-            name: Summer off-peak
-          - entity: input_number.rate_nonsummer
-            name: Non-summer
-          - entity: input_number.rate_delivery_riders
-            name: Delivery riders
-          - entity: input_number.rate_sales_tax_pct
-            name: Sales tax
-
-      - type: entities
-        title: House (Consumers Energy)
-        entities:
-          - entity: sensor.consumers_energy_kwh_yesterday
-            name: House yesterday
-          - entity: sensor.homelab_total_energy_yesterday
-            name: Homelab yesterday
-          - entity: sensor.homelab_share_of_house
-            name: Homelab share of house
-          - entity: sensor.combined_share_of_house
-            name: Homelab + office share of house
-          - entity: sensor.consumers_energy_cost_yesterday
-            name: CE cost yesterday
-          - entity: sensor.consumers_energy_effective_rate
-            name: CE effective rate
-          - entity: sensor.current_electricity_rate
-            name: Modelled rate now
-          - type: section
-            label: Month to date and last month
-          - entity: sensor.consumers_energy_kwh_month
-            name: House this month
-          - entity: sensor.consumers_energy_cost_month
-            name: CE cost this month
-          - entity: sensor.consumers_energy_kwh_last_month
-            name: House last month
-          - entity: sensor.consumers_energy_cost_last_month
-            name: CE cost last month
-          - entity: sensor.consumers_energy_last_reading
-            name: Last CE reading
-
-      - type: statistics-graph
-        title: House vs homelab by day (30d)
-        chart_type: bar
-        period: day
-        days_to_show: 30
-        stat_types:
-          - change
-        entities:
-          - consumers_energy:grid_kwh
-          - sensor.homelab_total_energy
-          - sensor.office_total_energy
-
-      - type: glance
-        title: Live draw
-        state_color: false
-        columns: 4
-        entities:
-          - entity: sensor.homelab_total_power
-            name: HOMELAB
-          - entity: sensor.office_total_power
-            name: OFFICE
-          - entity: sensor.combined_total_power
-            name: COMBINED
-          - entity: sensor.threadripper_current_consumption
-            name: Threadripper Host
-          - entity: sensor.nas_psu_current_consumption
-            name: NAS Drive PSU
-          - entity: sensor.truenas_current_consumption
-            name: TrueNAS (DL360)
-          - entity: sensor.hp_sff_current_consumption
-            name: HP SFF + Optiplex
-          - entity: sensor.hp_elite_current_consumption
-            name: HP Elite Mini G9
-          - entity: sensor.gaming_pc_current_consumption
-            name: Gaming PC
-          - entity: sensor.macbook_current_consumption
-            name: MacBook + Monitor
-          - entity: sensor.shed_lab_current_consumption
-            name: Shed Lab (solar)
-
-      - type: glance
-        title: Homelab cost so far
-        show_state: true
-        columns: 4
-        entities:
-          - entity: sensor.homelab_cost_daily
-            name: Today
-          - entity: sensor.homelab_cost_weekly
-            name: This Week
-          - entity: sensor.homelab_cost_monthly
-            name: This Month
-          - entity: sensor.homelab_cost_yearly
-            name: This Year
-
-      - type: glance
-        title: Office cost so far
-        show_state: true
-        columns: 4
-        entities:
-          - entity: sensor.office_cost_daily
-            name: Today
-          - entity: sensor.office_cost_weekly
-            name: This Week
-          - entity: sensor.office_cost_monthly
-            name: This Month
-          - entity: sensor.office_cost_yearly
-            name: This Year
-
-      - type: glance
-        title: Combined cost so far
-        show_state: true
-        columns: 4
-        entities:
-          - entity: sensor.combined_cost_daily
-            name: Today
-          - entity: sensor.combined_cost_weekly
-            name: This Week
-          - entity: sensor.combined_cost_monthly
-            name: This Month
-          - entity: sensor.combined_cost_yearly
-            name: This Year
-
-      - type: glance
-        title: Shed Lab energy (solar, no cost)
-        show_state: true
-        columns: 4
-        entities:
-          - entity: sensor.shed_lab_energy_daily
-            name: Today
-          - entity: sensor.shed_lab_energy_weekly
-            name: This Week
-          - entity: sensor.shed_lab_energy_monthly
-            name: This Month
-          - entity: sensor.shed_lab_energy_yearly
-            name: This Year
-
-      - type: glance
-        title: Last completed month (homelab)
-        show_state: true
-        columns: 3
-        entities:
-          - entity: sensor.homelab_cost_last_month
-            name: Cost last month
-          - entity: sensor.homelab_total_energy_last_month
-            name: Energy last month
-          - entity: sensor.homelab_cost_yesterday
-            name: Cost yesterday
-
-      - type: glance
-        title: Last completed month (office)
-        show_state: true
-        columns: 3
-        entities:
-          - entity: sensor.office_cost_last_month
-            name: Cost last month
-          - entity: sensor.office_total_energy_last_month
-            name: Energy last month
-          - entity: sensor.office_cost_yesterday
-            name: Cost yesterday
-
-      - type: entities
-        title: Cost last month — per device
-        entities:
-          - entity: sensor.threadripper_cost_last_month
-            name: Threadripper Host
-          - entity: sensor.nas_psu_cost_last_month
-            name: NAS Drive PSU
-          - entity: sensor.truenas_cost_last_month
-            name: TrueNAS (DL360)
-          - entity: sensor.hp_sff_cost_last_month
-            name: HP SFF + Optiplex
-          - entity: sensor.hp_elite_cost_last_month
-            name: HP Elite Mini G9
-          - entity: sensor.gaming_pc_cost_last_month
-            name: Gaming PC
-          - entity: sensor.macbook_cost_last_month
-            name: MacBook + Monitor
-
-      - type: entities
-        title: Energy last month — per device
-        entities:
-          - entity: sensor.threadripper_energy_last_month
-            name: Threadripper Host
-          - entity: sensor.nas_psu_energy_last_month
-            name: NAS Drive PSU
-          - entity: sensor.truenas_energy_last_month
-            name: TrueNAS (DL360)
-          - entity: sensor.hp_sff_energy_last_month
-            name: HP SFF + Optiplex
-          - entity: sensor.hp_elite_energy_last_month
-            name: HP Elite Mini G9
-          - entity: sensor.gaming_pc_energy_last_month
-            name: Gaming PC
-          - entity: sensor.macbook_energy_last_month
-            name: MacBook + Monitor
-          - entity: sensor.shed_lab_energy_last_month
-            name: Shed Lab (solar)
-
+    type: sections
+    max_columns: 4
+    dense_section_placement: true
+    sections:
       - type: grid
-        title: Share of combined draw
-        columns: 4
-        square: false
         cards:
-          - type: gauge
+          - type: heading
+            heading: Right now
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.electricity_tariff_period
+                name: Tariff
+              - type: entity
+                entity: sensor.current_electricity_rate
+                name: Rate
+          - type: tile
+            entity: sensor.homelab_total_power
+            name: Homelab
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.office_total_power
+            name: Office
+            grid_options:
+              columns: 6
+              rows: 1
+            color: purple
+          - type: tile
+            entity: sensor.shed_lab_current_consumption
+            name: Shed (solar)
+            grid_options:
+              columns: 6
+              rows: 1
+            color: green
+          - type: tile
+            entity: sensor.combined_cost_rate
+            name: Burn rate
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+      - type: grid
+        cards:
+          - type: heading
+            heading: This month
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.homelab_cost_last_month
+                name: Homelab last month
+          - type: tile
+            entity: sensor.homelab_cost_monthly
+            name: Homelab
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.office_cost_monthly
+            name: Office
+            grid_options:
+              columns: 6
+              rows: 1
+            color: purple
+          - type: tile
+            entity: sensor.combined_cost_monthly
+            name: Both together
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.consumers_energy_cost_month
+            name: Whole house (CE)
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+      - type: grid
+        cards:
+          - type: heading
+            heading: Today
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.homelab_cost_yesterday
+                name: Homelab yesterday
+          - type: tile
+            entity: sensor.homelab_cost_daily
+            name: Homelab cost
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.office_cost_daily
+            name: Office cost
+            grid_options:
+              columns: 6
+              rows: 1
+            color: purple
+          - type: tile
+            entity: sensor.homelab_total_energy_daily
+            name: Homelab kWh
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.office_total_energy_daily
+            name: Office kWh
+            grid_options:
+              columns: 6
+              rows: 1
+            color: purple
+      - type: grid
+        cards:
+          - type: heading
+            heading: Share of the house
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.consumers_energy_last_reading
+                name: CE data through
+          - type: tile
+            entity: sensor.homelab_share_of_house
+            name: Homelab
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.combined_share_of_house
+            name: Homelab + office
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.consumers_energy_kwh_yesterday
+            name: House yesterday
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: tile
+            entity: sensor.homelab_total_energy_yesterday
+            name: Homelab yesterday
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: House vs homelab, by day
+            heading_style: title
+          - type: statistics-graph
+            title: 
+            chart_type: bar
+            period: day
+            days_to_show: 30
+            stat_types:
+              - change
+            entities:
+              - consumers_energy:grid_kwh
+              - sensor.homelab_total_energy
+              - sensor.office_total_energy
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Draw, last 24 hours
+            heading_style: title
+          - type: history-graph
+            title: 
+            hours_to_show: 24
+            refresh_interval: 60
+            entities:
+              - entity: sensor.homelab_total_power
+                name: Homelab
+              - entity: sensor.office_total_power
+                name: Office
+              - entity: sensor.shed_lab_current_consumption
+                name: Shed (solar)
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Where the energy goes, by day
+            heading_style: title
+          - type: statistics-graph
+            title: 
+            chart_type: bar
+            period: day
+            days_to_show: 30
+            stat_types:
+              - change
+            entities:
+              - sensor.threadripper_energy
+              - sensor.nas_psu_energy
+              - sensor.truenas_energy
+              - sensor.hp_sff_energy
+              - sensor.hp_elite_energy
+              - sensor.gaming_pc_energy
+              - sensor.macbook_energy
+              - sensor.shed_lab_energy
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Cost by month
+            heading_style: title
+          - type: statistics-graph
+            title: 
+            chart_type: bar
+            period: month
+            days_to_show: 365
+            stat_types:
+              - change
+            entities:
+              - sensor.homelab_cost
+              - sensor.office_cost
+
+  # ───────────────────────── Devices: one section per plug ─────────────────────────
+  - title: Devices
+    icon: mdi:power-plug
+    path: devices
+    type: sections
+    max_columns: 4
+    dense_section_placement: true
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Threadripper Host
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.threadripper_current_consumption
+          - type: tile
+            entity: sensor.threadripper_current_consumption
+            name: Power now
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+            icon: mdi:server
+          - type: tile
             entity: sensor.threadripper_power_share
-            name: Threadripper Host
-            unit: "%"
-            min: 0
-            max: 100
-            needle: true
-          - type: gauge
+            name: Share of draw
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.threadripper_cost_daily
+            name: Cost today
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.threadripper_cost_monthly
+            name: This month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.threadripper_cost_last_month
+            name: Last month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: grey
+      - type: grid
+        cards:
+          - type: heading
+            heading: NAS Drive PSU
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.nas_psu_current_consumption
+          - type: tile
+            entity: sensor.nas_psu_current_consumption
+            name: Power now
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+            icon: mdi:harddisk
+          - type: tile
             entity: sensor.nas_psu_power_share
-            name: NAS Drive PSU
-            unit: "%"
-            min: 0
-            max: 100
-            needle: true
-          - type: gauge
+            name: Share of draw
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.nas_psu_cost_daily
+            name: Cost today
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.nas_psu_cost_monthly
+            name: This month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.nas_psu_cost_last_month
+            name: Last month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: grey
+      - type: grid
+        cards:
+          - type: heading
+            heading: TrueNAS (DL360)
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.truenas_current_consumption
+          - type: tile
+            entity: sensor.truenas_current_consumption
+            name: Power now
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+            icon: mdi:nas
+          - type: tile
             entity: sensor.truenas_power_share
-            name: TrueNAS (DL360)
-            unit: "%"
-            min: 0
-            max: 100
-            needle: true
-          - type: gauge
+            name: Share of draw
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.truenas_cost_daily
+            name: Cost today
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.truenas_cost_monthly
+            name: This month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.truenas_cost_last_month
+            name: Last month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: grey
+      - type: grid
+        cards:
+          - type: heading
+            heading: HP SFF + Optiplex
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.hp_sff_current_consumption
+          - type: tile
+            entity: sensor.hp_sff_current_consumption
+            name: Power now
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+            icon: mdi:desktop-tower
+          - type: tile
             entity: sensor.hp_sff_power_share
-            name: HP SFF + Optiplex
-            unit: "%"
-            min: 0
-            max: 100
-            needle: true
-          - type: gauge
+            name: Share of draw
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.hp_sff_cost_daily
+            name: Cost today
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.hp_sff_cost_monthly
+            name: This month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.hp_sff_cost_last_month
+            name: Last month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: grey
+      - type: grid
+        cards:
+          - type: heading
+            heading: HP Elite Mini G9
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.hp_elite_current_consumption
+          - type: tile
+            entity: sensor.hp_elite_current_consumption
+            name: Power now
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+            icon: mdi:desktop-classic
+          - type: tile
             entity: sensor.hp_elite_power_share
-            name: HP Elite Mini G9
-            unit: "%"
-            min: 0
-            max: 100
-            needle: true
-          - type: gauge
+            name: Share of draw
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.hp_elite_cost_daily
+            name: Cost today
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.hp_elite_cost_monthly
+            name: This month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.hp_elite_cost_last_month
+            name: Last month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: grey
+      - type: grid
+        cards:
+          - type: heading
+            heading: Gaming PC
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.gaming_pc_current_consumption
+          - type: tile
+            entity: sensor.gaming_pc_current_consumption
+            name: Power now
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+            icon: mdi:controller
+          - type: tile
             entity: sensor.gaming_pc_power_share
-            name: Gaming PC
-            unit: "%"
-            min: 0
-            max: 100
-            needle: true
-          - type: gauge
+            name: Share of draw
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.gaming_pc_cost_daily
+            name: Cost today
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.gaming_pc_cost_monthly
+            name: This month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.gaming_pc_cost_last_month
+            name: Last month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: grey
+      - type: grid
+        cards:
+          - type: heading
+            heading: MacBook + Monitor
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.macbook_current_consumption
+          - type: tile
+            entity: sensor.macbook_current_consumption
+            name: Power now
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+            icon: mdi:laptop
+          - type: tile
             entity: sensor.macbook_power_share
-            name: MacBook + Monitor
-            unit: "%"
-            min: 0
-            max: 100
-            needle: true
-
-      - type: entities
-        title: Cost today
-        entities:
-          - entity: sensor.threadripper_cost_daily
-            name: Threadripper Host
-          - entity: sensor.nas_psu_cost_daily
-            name: NAS Drive PSU
-          - entity: sensor.truenas_cost_daily
-            name: TrueNAS (DL360)
-          - entity: sensor.hp_sff_cost_daily
-            name: HP SFF + Optiplex
-          - entity: sensor.hp_elite_cost_daily
-            name: HP Elite Mini G9
-          - entity: sensor.gaming_pc_cost_daily
-            name: Gaming PC
-          - entity: sensor.macbook_cost_daily
-            name: MacBook + Monitor
-
-      - type: entities
-        title: Cost this month
-        entities:
-          - entity: sensor.threadripper_cost_monthly
-            name: Threadripper Host
-          - entity: sensor.nas_psu_cost_monthly
-            name: NAS Drive PSU
-          - entity: sensor.truenas_cost_monthly
-            name: TrueNAS (DL360)
-          - entity: sensor.hp_sff_cost_monthly
-            name: HP SFF + Optiplex
-          - entity: sensor.hp_elite_cost_monthly
-            name: HP Elite Mini G9
-          - entity: sensor.gaming_pc_cost_monthly
-            name: Gaming PC
-          - entity: sensor.macbook_cost_monthly
-            name: MacBook + Monitor
-
-      - type: history-graph
-        title: Power draw (24h)
-        hours_to_show: 24
-        refresh_interval: 30
-        entities:
-          - entity: sensor.threadripper_current_consumption
-            name: Threadripper Host
-          - entity: sensor.nas_psu_current_consumption
-            name: NAS Drive PSU
-          - entity: sensor.truenas_current_consumption
-            name: TrueNAS (DL360)
-          - entity: sensor.hp_sff_current_consumption
-            name: HP SFF + Optiplex
-          - entity: sensor.hp_elite_current_consumption
-            name: HP Elite Mini G9
-          - entity: sensor.gaming_pc_current_consumption
-            name: Gaming PC
-          - entity: sensor.macbook_current_consumption
-            name: MacBook + Monitor
-          - entity: sensor.shed_lab_current_consumption
-            name: Shed Lab (solar)
-          - entity: sensor.homelab_total_power
-            name: HOMELAB
-          - entity: sensor.office_total_power
-            name: OFFICE
-
-      - type: statistics-graph
-        title: Energy by day (30d)
-        chart_type: bar
-        period: day
-        days_to_show: 30
-        stat_types:
-          - change
-        entities:
-          - sensor.threadripper_energy
-          - sensor.nas_psu_energy
-          - sensor.truenas_energy
-          - sensor.hp_sff_energy
-          - sensor.hp_elite_energy
-          - sensor.gaming_pc_energy
-          - sensor.macbook_energy
-          - sensor.shed_lab_energy
-
-      - type: statistics-graph
-        title: Cost by month (12 months)
-        chart_type: bar
-        period: month
-        days_to_show: 365
-        stat_types:
-          - change
-        entities:
-          - sensor.threadripper_cost
-          - sensor.nas_psu_cost
-          - sensor.truenas_cost
-          - sensor.hp_sff_cost
-          - sensor.hp_elite_cost
-          - sensor.gaming_pc_cost
-          - sensor.macbook_cost
-
-      - type: statistics-graph
-        title: Homelab vs office cost by month
-        chart_type: bar
-        period: month
-        days_to_show: 365
-        stat_types:
-          - change
-        entities:
-          - sensor.homelab_cost
-          - sensor.office_cost
-
-      - type: entities
-        title: Per-device detail
-        entities:
-          - type: section
-            label: Threadripper Host
-          - entity: sensor.threadripper_current_consumption
-            name: Power now
-          - entity: sensor.threadripper_power_share
-            name: Share of combined
-          - entity: sensor.threadripper_energy_daily
-            name: Energy today
-          - entity: sensor.threadripper_cost_daily
+            name: Share of draw
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.macbook_cost_daily
             name: Cost today
-          - entity: sensor.threadripper_cost_monthly
-            name: Cost this month
-          - entity: sensor.threadripper_voltage
-            name: Voltage
-          - entity: sensor.threadripper_current
-            name: Current
-          - type: section
-            label: NAS Drive PSU
-          - entity: sensor.nas_psu_current_consumption
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.macbook_cost_monthly
+            name: This month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.macbook_cost_last_month
+            name: Last month
+            grid_options:
+              columns: 4
+              rows: 1
+            color: grey
+      - type: grid
+        cards:
+          - type: heading
+            heading: Shed Lab (solar)
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.shed_lab_current_consumption
+          - type: tile
+            entity: sensor.shed_lab_current_consumption
             name: Power now
-          - entity: sensor.nas_psu_power_share
-            name: Share of combined
-          - entity: sensor.nas_psu_energy_daily
-            name: Energy today
-          - entity: sensor.nas_psu_cost_daily
-            name: Cost today
-          - entity: sensor.nas_psu_cost_monthly
-            name: Cost this month
-          - entity: sensor.nas_psu_voltage
-            name: Voltage
-          - entity: sensor.nas_psu_current
-            name: Current
-          - type: section
-            label: TrueNAS (DL360)
-          - entity: sensor.truenas_current_consumption
-            name: Power now
-          - entity: sensor.truenas_power_share
-            name: Share of combined
-          - entity: sensor.truenas_energy_daily
-            name: Energy today
-          - entity: sensor.truenas_cost_daily
-            name: Cost today
-          - entity: sensor.truenas_cost_monthly
-            name: Cost this month
-          - entity: sensor.truenas_voltage
-            name: Voltage
-          - entity: sensor.truenas_current
-            name: Current
-          - type: section
-            label: HP SFF + Optiplex
-          - entity: sensor.hp_sff_current_consumption
-            name: Power now
-          - entity: sensor.hp_sff_power_share
-            name: Share of combined
-          - entity: sensor.hp_sff_energy_daily
-            name: Energy today
-          - entity: sensor.hp_sff_cost_daily
-            name: Cost today
-          - entity: sensor.hp_sff_cost_monthly
-            name: Cost this month
-          - entity: sensor.hp_sff_voltage
-            name: Voltage
-          - entity: sensor.hp_sff_current
-            name: Current
-          - type: section
-            label: HP Elite Mini G9
-          - entity: sensor.hp_elite_current_consumption
-            name: Power now
-          - entity: sensor.hp_elite_power_share
-            name: Share of combined
-          - entity: sensor.hp_elite_energy_daily
-            name: Energy today
-          - entity: sensor.hp_elite_cost_daily
-            name: Cost today
-          - entity: sensor.hp_elite_cost_monthly
-            name: Cost this month
-          - entity: sensor.hp_elite_voltage
-            name: Voltage
-          - entity: sensor.hp_elite_current
-            name: Current
-          - type: section
-            label: Gaming PC
-          - entity: sensor.gaming_pc_current_consumption
-            name: Power now
-          - entity: sensor.gaming_pc_power_share
-            name: Share of combined
-          - entity: sensor.gaming_pc_energy_daily
-            name: Energy today
-          - entity: sensor.gaming_pc_cost_daily
-            name: Cost today
-          - entity: sensor.gaming_pc_cost_monthly
-            name: Cost this month
-          - entity: sensor.gaming_pc_voltage
-            name: Voltage
-          - entity: sensor.gaming_pc_current
-            name: Current
-          - type: section
-            label: MacBook + Monitor
-          - entity: sensor.macbook_current_consumption
-            name: Power now
-          - entity: sensor.macbook_power_share
-            name: Share of combined
-          - entity: sensor.macbook_energy_daily
-            name: Energy today
-          - entity: sensor.macbook_cost_daily
-            name: Cost today
-          - entity: sensor.macbook_cost_monthly
-            name: Cost this month
-          - entity: sensor.macbook_voltage
-            name: Voltage
-          - entity: sensor.macbook_current
-            name: Current
-          - type: section
-            label: Shed Lab (solar)
-          - entity: sensor.shed_lab_current_consumption
-            name: Power now
-          - entity: sensor.shed_lab_energy_daily
-            name: Energy today
-          - entity: sensor.shed_lab_energy_monthly
-            name: Energy this month
-          - entity: sensor.shed_lab_voltage
-            name: Voltage
-          - entity: sensor.shed_lab_current
-            name: Current
+            grid_options:
+              columns: 6
+              rows: 1
+            color: green
+            icon: mdi:solar-power
+          - type: tile
+            entity: sensor.shed_lab_energy_daily
+            name: kWh today
+            grid_options:
+              columns: 6
+              rows: 1
+            color: green
+          - type: tile
+            entity: sensor.shed_lab_energy_monthly
+            name: kWh this month
+            grid_options:
+              columns: 6
+              rows: 1
+            color: green
+          - type: tile
+            entity: sensor.shed_lab_energy_last_month
+            name: kWh last month
+            grid_options:
+              columns: 6
+              rows: 1
+            color: green
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Notes
+            heading_style: subtitle
+          - type: markdown
+            content: |
+              **HP SFF + Optiplex** share one plug, so their draw cannot be split. Homelab switches are
+              locked on by the *Homelab plug power-off lockout* automation; the office plugs are not.
+              **Shed Lab** runs on solar: kWh only, no cost, not in any group.
 
+  # ───────────────────────── House: what Consumers Energy says ─────────────────────────
+  - title: House
+    icon: mdi:home-lightning-bolt
+    path: house
+    type: sections
+    max_columns: 4
+    dense_section_placement: true
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Consumers Energy
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.consumers_energy_last_reading
+                name: Data through
+          - type: tile
+            entity: sensor.consumers_energy_kwh_yesterday
+            name: kWh yesterday
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: tile
+            entity: sensor.consumers_energy_cost_yesterday
+            name: Cost yesterday
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: tile
+            entity: sensor.consumers_energy_kwh_month
+            name: kWh this month
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: tile
+            entity: sensor.consumers_energy_cost_month
+            name: Cost this month
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: tile
+            entity: sensor.consumers_energy_kwh_last_month
+            name: kWh last month
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: tile
+            entity: sensor.consumers_energy_cost_last_month
+            name: Cost last month
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+      - type: grid
+        cards:
+          - type: heading
+            heading: Is the model right?
+            heading_style: title
+          - type: tile
+            entity: sensor.consumers_energy_effective_rate
+            name: CE charged (per kWh)
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: tile
+            entity: sensor.current_electricity_rate
+            name: Model says
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.homelab_share_of_house
+            name: Homelab share
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.combined_share_of_house
+            name: Homelab + office
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: House vs homelab, by day
+            heading_style: title
+          - type: statistics-graph
+            title: 
+            chart_type: bar
+            period: day
+            days_to_show: 60
+            stat_types:
+              - change
+            entities:
+              - consumers_energy:grid_kwh
+              - sensor.homelab_total_energy
+              - sensor.office_total_energy
+      - type: grid
+        cards:
+          - type: heading
+            heading: How this works
+            heading_style: subtitle
+          - type: markdown
+            content: |
+              A job logs into the Consumers Energy portal every afternoon and pulls the daily usage CSV.
+              Consumers posts each day late the next morning, so **yesterday** is the newest number and
+              today is always blank on the Energy dashboard. Cost is what CE actually billed for the day.
+
+  # ───────────────────────── Solar: the shed ─────────────────────────
   - title: Solar
     icon: mdi:solar-power-variant
     path: solar
-    cards:
-      - type: markdown
-        content: |
-          # Shed solar
-          Panels → **EPEVER XTRA3210N** MPPT → 12.8 V LiFePO4 bank (2× 100 Ah) →
-          **LOAD** terminal → Anker SOLIX → the shed **HP micro** (Tapo `Shed Lab`).
-          Numbers come from the rpi4's `epsolar` service, which owns the serial link
-          and the guarded LOAD automation. Nothing here costs anything on the bill.
-
-      - type: glance
-        title: Right now
-        columns: 4
-        entities:
-          - entity: sensor.solar_pv_power
+    type: sections
+    max_columns: 4
+    dense_section_placement: true
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Right now
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.solar_charging_state
+                name: Charging
+              - type: entity
+                entity: binary_sensor.solar_load_on
+                name: LOAD
+          - type: tile
+            entity: sensor.solar_pv_power
             name: Watts in (PV)
-          - entity: sensor.solar_battery_power
+            grid_options:
+              columns: 6
+              rows: 1
+            color: green
+          - type: tile
+            entity: sensor.solar_battery_power
             name: Battery (+charge)
-          - entity: sensor.solar_load_power
+            grid_options:
+              columns: 6
+              rows: 1
+            color: teal
+          - type: tile
+            entity: sensor.solar_load_power
             name: LOAD → Anker
-          - entity: sensor.shed_lab_current_consumption
+            grid_options:
+              columns: 6
+              rows: 1
+            color: orange
+          - type: tile
+            entity: sensor.shed_lab_current_consumption
             name: HP micro (Tapo)
-          - entity: sensor.solar_battery_soc
-            name: SOC (local)
-          - entity: sensor.solar_battery_voltage
-            name: Battery V
-          - entity: sensor.solar_charging_state
-            name: Charging
-          - entity: binary_sensor.solar_load_on
-            name: LOAD
-
-      - type: gauge
-        entity: sensor.solar_battery_soc
-        name: Battery state of charge
-        min: 0
-        max: 100
-        needle: true
-        severity:
-          red: 0
-          yellow: 33
-          green: 50
-
-      - type: entities
-        title: Energy (controller counters)
-        entities:
-          - entity: sensor.solar_generated_today
-            name: Generated today
-          - entity: sensor.solar_generated_month
-            name: Generated this month
-          - entity: sensor.solar_generated_year
-            name: Generated this year
-          - entity: sensor.solar_generated_total
-            name: Generated lifetime
-          - type: section
-            label: Consumed at the LOAD terminal
-          - entity: sensor.solar_consumed_today
-            name: Consumed today
-          - entity: sensor.solar_consumed_month
-            name: Consumed this month
-          - entity: sensor.solar_consumed_total
-            name: Consumed lifetime
-          - type: section
-            label: HP micro (Tapo Shed Lab)
-          - entity: sensor.shed_lab_energy_daily
-            name: Today
-          - entity: sensor.shed_lab_energy_monthly
-            name: This month
-
-      - type: history-graph
-        title: Power flow (24h)
-        hours_to_show: 24
-        refresh_interval: 30
-        entities:
-          - entity: sensor.solar_pv_power
-            name: PV in
-          - entity: sensor.solar_load_power
-            name: LOAD out
-          - entity: sensor.solar_battery_power
-            name: Battery net
-          - entity: sensor.shed_lab_current_consumption
-            name: HP micro
-
-      - type: history-graph
-        title: Battery (24h)
-        hours_to_show: 24
-        refresh_interval: 60
-        entities:
-          - entity: sensor.solar_battery_voltage
+            grid_options:
+              columns: 6
+              rows: 1
+            color: green
+      - type: grid
+        cards:
+          - type: heading
+            heading: Battery
+            heading_style: title
+          - type: gauge
+            entity: sensor.solar_battery_soc
+            name: State of charge
+            min: 0
+            max: 100
+            needle: true
+            severity:
+              red: 0
+              yellow: 33
+              green: 50
+            grid_options:
+              columns: 6
+              rows: 3
+          - type: tile
+            entity: sensor.solar_battery_voltage
             name: Voltage
-          - entity: sensor.solar_battery_soc
-            name: SOC local
-          - entity: sensor.solar_battery_soc_controller
-            name: SOC controller
-
-      - type: statistics-graph
-        title: Generated vs consumed by day (30d)
-        chart_type: bar
-        period: day
-        days_to_show: 30
-        stat_types:
-          - change
-        entities:
-          - sensor.solar_generated_total
-          - sensor.solar_consumed_total
-          - sensor.shed_lab_energy
-
-      - type: entities
-        title: Automation and health
-        entities:
-          - entity: sensor.solar_automation_state
-            name: State
-          - entity: sensor.solar_automation_reason
-            name: Reason
-          - entity: binary_sensor.solar_automation_armed
-            name: Armed (live writes)
-          - entity: binary_sensor.solar_controller_online
-            name: Controller online
-          - entity: binary_sensor.solar_fault
-            name: Controller fault
-          - entity: sensor.solar_battery_energy_remaining
+            grid_options:
+              columns: 6
+              rows: 1
+            color: teal
+          - type: tile
+            entity: sensor.solar_battery_energy_remaining
             name: Usable energy left
-          - entity: sensor.solar_runtime_remaining
+            grid_options:
+              columns: 6
+              rows: 1
+            color: teal
+          - type: tile
+            entity: sensor.solar_runtime_remaining
             name: Runtime left
-          - entity: sensor.solar_battery_temperature
+            grid_options:
+              columns: 6
+              rows: 1
+            color: teal
+          - type: tile
+            entity: sensor.solar_battery_temperature
             name: Battery temp
-          - entity: sensor.solar_controller_temperature
-            name: Controller temp
-          - entity: sensor.solar_last_update
-            name: Last reading
+            grid_options:
+              columns: 6
+              rows: 1
+            color: teal
+      - type: grid
+        cards:
+          - type: heading
+            heading: Energy (controller counters)
+            heading_style: title
+          - type: tile
+            entity: sensor.solar_generated_today
+            name: Generated today
+            grid_options:
+              columns: 6
+              rows: 1
+            color: green
+          - type: tile
+            entity: sensor.solar_consumed_today
+            name: Used at LOAD today
+            grid_options:
+              columns: 6
+              rows: 1
+            color: orange
+          - type: tile
+            entity: sensor.solar_generated_month
+            name: Generated this month
+            grid_options:
+              columns: 6
+              rows: 1
+            color: green
+          - type: tile
+            entity: sensor.solar_consumed_month
+            name: Used this month
+            grid_options:
+              columns: 6
+              rows: 1
+            color: orange
+          - type: tile
+            entity: sensor.solar_generated_total
+            name: Generated lifetime
+            grid_options:
+              columns: 6
+              rows: 1
+            color: green
+          - type: tile
+            entity: sensor.shed_lab_energy_monthly
+            name: HP micro this month
+            grid_options:
+              columns: 6
+              rows: 1
+            color: green
+      - type: grid
+        cards:
+          - type: heading
+            heading: Automation and health
+            heading_style: title
+            badges:
+              - type: entity
+                entity: binary_sensor.solar_automation_armed
+                name: Armed
+              - type: entity
+                entity: binary_sensor.solar_controller_online
+                name: Controller
+          - type: entities
+            entities:
+              - entity: sensor.solar_automation_state
+                name: State
+              - entity: sensor.solar_automation_reason
+                name: Reason
+              - entity: binary_sensor.solar_fault
+                name: Controller fault
+              - entity: sensor.solar_controller_temperature
+                name: Controller temp
+              - entity: sensor.solar_last_update
+                name: Last reading
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Power flow, last 24 hours
+            heading_style: title
+          - type: history-graph
+            title: 
+            hours_to_show: 24
+            refresh_interval: 30
+            entities:
+              - entity: sensor.solar_pv_power
+                name: PV in
+              - entity: sensor.solar_load_power
+                name: LOAD out
+              - entity: sensor.solar_battery_power
+                name: Battery net
+              - entity: sensor.shed_lab_current_consumption
+                name: HP micro
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Battery, last 24 hours
+            heading_style: title
+          - type: history-graph
+            title: 
+            hours_to_show: 24
+            refresh_interval: 60
+            entities:
+              - entity: sensor.solar_battery_voltage
+                name: Voltage
+              - entity: sensor.solar_battery_soc
+                name: SOC local
+              - entity: sensor.solar_battery_soc_controller
+                name: SOC controller
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Generated vs used, by day
+            heading_style: title
+          - type: statistics-graph
+            title: 
+            chart_type: bar
+            period: day
+            days_to_show: 30
+            stat_types:
+              - change
+            entities:
+              - sensor.solar_generated_total
+              - sensor.solar_consumed_total
+              - sensor.shed_lab_energy
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: The chain
+            heading_style: subtitle
+          - type: markdown
+            content: |
+              Panels → **EPEVER XTRA3210N** → 12.8 V LiFePO4 bank (2 × 100 Ah) → **LOAD** → Anker SOLIX →
+              the shed HP micro. The rpi4 owns the serial link and the guarded LOAD automation. Nothing
+              here costs anything on the bill.
+
+  # ───────────────────────── Gaming: sessions on the Gaming PC ─────────────────────────
+  - title: Gaming
+    icon: mdi:controller
+    path: gaming
+    type: sections
+    max_columns: 4
+    dense_section_placement: true
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Right now
+            heading_style: title
+            badges:
+              - type: entity
+                entity: binary_sensor.gaming_pc_gaming
+                name: Session
+          - type: tile
+            entity: sensor.gaming_pc_current_consumption
+            name: Draw
+            grid_options:
+              columns: 6
+              rows: 1
+            color: purple
+          - type: tile
+            entity: sensor.gaming_pc_gaming_cost_rate
+            name: Burn rate
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.gaming_pc_sessions_today
+            name: Sessions today
+            grid_options:
+              columns: 6
+              rows: 1
+            color: purple
+          - type: tile
+            entity: sensor.gaming_pc_cost_per_gaming_hour
+            name: Cost per hour gamed
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+      - type: grid
+        cards:
+          - type: heading
+            heading: Today
+            heading_style: title
+          - type: tile
+            entity: sensor.gaming_pc_gaming_hours_daily
+            name: Hours gamed
+            grid_options:
+              columns: 6
+              rows: 1
+            color: purple
+          - type: tile
+            entity: sensor.gaming_pc_gaming_energy_daily
+            name: kWh gaming
+            grid_options:
+              columns: 6
+              rows: 1
+            color: purple
+          - type: tile
+            entity: sensor.gaming_pc_gaming_cost_daily
+            name: Cost gaming
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.gaming_pc_idle_cost_daily
+            name: Idle tax
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+      - type: grid
+        cards:
+          - type: heading
+            heading: This month
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.gaming_pc_gaming_hours_last_month
+                name: Hours last month
+              - type: entity
+                entity: sensor.gaming_pc_gaming_cost_last_month
+                name: Cost last month
+          - type: tile
+            entity: sensor.gaming_pc_gaming_hours_monthly
+            name: Hours gamed
+            grid_options:
+              columns: 6
+              rows: 1
+            color: purple
+          - type: tile
+            entity: sensor.gaming_pc_gaming_energy_monthly
+            name: kWh gaming
+            grid_options:
+              columns: 6
+              rows: 1
+            color: purple
+          - type: tile
+            entity: sensor.gaming_pc_gaming_cost_monthly
+            name: Cost gaming
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.gaming_pc_idle_cost_monthly
+            name: Idle tax
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Draw and sessions, last 24 hours
+            heading_style: title
+          - type: history-graph
+            title: 
+            hours_to_show: 24
+            refresh_interval: 30
+            entities:
+              - entity: sensor.gaming_pc_current_consumption
+                name: Gaming PC
+              - entity: binary_sensor.gaming_pc_gaming
+                name: Session
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Gaming vs whole PC, by day
+            heading_style: title
+          - type: statistics-graph
+            title: 
+            chart_type: bar
+            period: day
+            days_to_show: 30
+            stat_types:
+              - change
+            entities:
+              - sensor.gaming_pc_gaming_energy
+              - sensor.gaming_pc_energy
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Hours gamed, by day
+            heading_style: title
+          - type: statistics-graph
+            title: 
+            chart_type: bar
+            period: day
+            days_to_show: 30
+            stat_types:
+              - change
+            entities:
+              - sensor.gaming_pc_gaming_hours
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: What counts as gaming
+            heading_style: subtitle
+          - type: markdown
+            content: |
+              A **session** is the plug drawing more than the threshold (350 W; idle is ~200 W, gaming
+              450–600 W) until five quiet minutes pass. **Idle tax** is everything the PC costs outside
+              sessions: sitting on at 200 W is about 1.4 kWh a day. Tune the threshold under Settings.
+
+  # ───────────────────────── Settings: rates and thresholds ─────────────────────────
+  - title: Settings
+    icon: mdi:tune
+    path: settings
+    type: sections
+    max_columns: 2
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Electricity rate
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.current_electricity_rate
+                name: All-in now
+          - type: entities
+            entities:
+              - entity: input_number.rate_summer_onpeak
+                name: Summer on-peak
+              - entity: input_number.rate_summer_offpeak
+                name: Summer off-peak
+              - entity: input_number.rate_nonsummer
+                name: Non-summer
+              - entity: input_number.rate_delivery_riders
+                name: Delivery riders
+              - entity: input_number.rate_sales_tax_pct
+                name: Sales tax
+              - entity: sensor.electricity_tariff_period
+                name: Tariff window now
+      - type: grid
+        cards:
+          - type: heading
+            heading: Gaming sessions
+            heading_style: title
+          - type: entities
+            entities:
+              - entity: input_number.gaming_pc_active_threshold_w
+                name: Session threshold
+              - entity: binary_sensor.gaming_pc_gaming
+                name: Session now
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Good to know
+            heading_style: subtitle
+          - type: markdown
+            content: |
+              **Git is the source of truth.** These sliders reset on restart; a permanent change goes in
+              `configuration.yaml`. All-in rate = (energy + delivery riders) × (1 + tax); summer is
+              June–August with a 2–7 pm weekday on-peak window.
+
+              **Lockout.** Homelab plugs are switched back on within seconds if turned off. To power-cycle
+              one on purpose, disable the *Homelab plug power-off lockout* automation first.
+
+              **Two dashboards.** The built-in **Energy** page is the per-day ledger (grid from Consumers,
+              solar, per-device). This one is the live view with cost.


### PR DESCRIPTION
## Dashboard redesign (Lovelace, YAML mode)
Six `sections` views, one question per section, tiles + headings instead of the glance walls:

- **Overview** — Right now, This month, Today, Share of the house, four charts.
- **Devices** — one block per plug: power, share, cost today / month / last month (shed: kWh only).
- **House** — Consumers numbers and "is the model right?" (CE effective rate vs ours).
- **Solar** — right now, battery gauge, controller counters, automation health, history.
- **Gaming** — session now, today, this month, idle tax, history.
- **Settings** — rate sliders, gaming threshold, the git-is-truth and lockout notes.

The built-in Energy page stays the per-day ledger; a note on Settings says so.

## Gaming sessions
- `binary_sensor.gaming_pc_gaming`: plug draw above `input_number.gaming_pc_active_threshold_w` (350 W), `delay_off` 5 min.
- Integrations while gaming: `gaming_pc_gaming_energy` (kWh), `_cost` (USD), `_hours` (integrates a 1/0 flag, so it doesn't depend on recorder retention), each with daily/weekly/monthly/yearly meters. `gaming_pc_idle_cost_*` = whole PC minus gaming. `gaming_pc_sessions_today` via history_stats.
- Grafana `dashboards/gaming-pc.json`.
- Docs: `docs/domains/power/metering.md` § Gaming sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DKqZAPv1o5F7BDHJYwboj