### PR TITLE
Fix backup alert context and remove unused Longhorn rules

### DIFF
--- a/.github/workflows/telemetry-rule-tests.yml
+++ b/.github/workflows/telemetry-rule-tests.yml
@@ -1,8 +1,10 @@
-name: Telemetry Rule Tests
+name: Telemetry and Backup Rule Tests
 on:
   pull_request:
     paths:
       - 'infrastructure/controllers/opentelemetry-operator-observability/**'
+      - 'monitoring/prometheus-stack/kopiur-alerts.yaml'
+      - 'monitoring/prometheus-stack/tests/kopiur-alerts.test.yaml'
       - 'scripts/prepare-telemetry-rule-tests.py'
       - 'scripts/tests/test_prepare_telemetry_rule_tests.py'
       - '.github/workflows/telemetry-rule-tests.yml'
@@ -10,6 +12,8 @@ on:
     branches: [main]
     paths:
       - 'infrastructure/controllers/opentelemetry-operator-observability/**'
+      - 'monitoring/prometheus-stack/kopiur-alerts.yaml'
+      - 'monitoring/prometheus-stack/tests/kopiur-alerts.test.yaml'
       - 'scripts/prepare-telemetry-rule-tests.py'
       - 'scripts/tests/test_prepare_telemetry_rule_tests.py'
       - '.github/workflows/telemetry-rule-tests.yml'
@@ -28,8 +32,12 @@ jobs:
         run: python -m unittest discover -s scripts/tests -p test_prepare_telemetry_rule_tests.py -v
       - name: Prepare alert-rule tests
         run: python scripts/prepare-telemetry-rule-tests.py /tmp/otel-rule-tests
+      - name: Prepare backup-rule tests
+        run: python scripts/prepare-telemetry-rule-tests.py /tmp/otel-rule-tests --suite kopiur
       - name: Check rules and evaluate synthetic time series
         run: |
           set -euo pipefail
           docker run --rm --entrypoint promtool -v /tmp/otel-rule-tests:/work:ro -w /work prom/prometheus:v3.5.0 check rules collector.rules.yaml
           docker run --rm --entrypoint promtool -v /tmp/otel-rule-tests:/work:ro -w /work prom/prometheus:v3.5.0 test rules collector-alerts.test.yaml
+          docker run --rm --entrypoint promtool -v /tmp/otel-rule-tests:/work:ro -w /work prom/prometheus:v3.5.0 check rules kopiur.rules.yaml
+          docker run --rm --entrypoint promtool -v /tmp/otel-rule-tests:/work:ro -w /work prom/prometheus:v3.5.0 test rules kopiur-alerts.test.yaml

--- a/monitoring/prometheus-stack/kopiur-alerts.yaml
+++ b/monitoring/prometheus-stack/kopiur-alerts.yaml
@@ -15,7 +15,15 @@ spec:
     - name: kopiur.backup
       rules:
         - alert: KopiurSnapshotsFailing
-          expr: kopiur_snapshot_consecutive_failures >= 3
+          # Scraping renames the policy namespace to exported_namespace; this metric calls the policy name.
+          expr: >-
+            max by (namespace, policy) (
+              label_replace(
+                label_replace(kopiur_snapshot_consecutive_failures,
+                  "namespace", "$1", "exported_namespace", "(.+)"),
+                "policy", "$1", "name", "(.+)"
+              )
+            ) >= 3
           for: 10m
           labels:
             severity: warning
@@ -25,16 +33,16 @@ spec:
             summary: "kopiur backups failing repeatedly: {{ $labels.namespace }}/{{ $labels.policy }}"
             description: |
               {{ $value }} consecutive snapshot failures.
-
-              Actions:
-              1. kubectl -n {{ $labels.namespace }} get snapshot | tail
-              2. Check the failed Snapshot's status.failure and mover Job logs
-              3. Common causes: source PVC unattachable (Longhorn volume
-                 faulted), repo unreachable, mover uid/gid mismatch
+              Inspect policy {{ $labels.policy }} and its failed Snapshots:
+              kubectl -n {{ $labels.namespace }} get snapshotpolicy,snapshot
+              Check source volume health, repository access, and mover permissions.
         - alert: KopiurBackupStale
-          # All app PVCs snapshot hourly (the canary is daily), so >26h with
-          # no successful backup means the schedule is broken, not just slow.
-          expr: time() - kopiur_policy_last_backup_success_timestamp_seconds > 26 * 3600
+          # The 26h threshold covers daily schedules; it is not an hourly recovery-point guarantee.
+          expr: >-
+            time() - max by (namespace, policy) (
+              label_replace(kopiur_policy_last_backup_success_timestamp_seconds,
+                "namespace", "$1", "exported_namespace", "(.+)")
+            ) > 26 * 3600
           for: 15m
           labels:
             severity: critical
@@ -43,13 +51,10 @@ spec:
           annotations:
             summary: "kopiur backup stale (>26h): {{ $labels.namespace }}/{{ $labels.policy }}"
             description: |
-              No successful kopiur snapshot for over 26 hours. The restore
-              point for this PVC is aging — a volume failure now means losing
-              everything since the last snapshot.
-
-              Actions:
-              1. kubectl -n {{ $labels.namespace }} get snapshotpolicy,snapshotschedule,snapshot
-              2. Check SnapshotSchedule is not suspended and Snapshots' failure status
+              No successful kopiur snapshot for policy {{ $labels.policy }} in over 26 hours.
+              Inspect its schedule and failed Snapshots:
+              kubectl -n {{ $labels.namespace }} get snapshotpolicy,snapshotschedule,snapshot
+              Preserve the source volume before recovery; the latest backup may omit recent writes.
         - alert: KopiurCascadeDeletedSnapshots
           # onPolicyDelete: Retain is pinned in the kopiur-backup component — a mode="delete" cascade means the pin was bypassed and history is being destroyed.
           expr: increase(kopiur_policy_cascade_children_deleted_total{mode="delete"}[15m]) > 0

--- a/monitoring/prometheus-stack/longhorn-alerts.yaml
+++ b/monitoring/prometheus-stack/longhorn-alerts.yaml
@@ -52,19 +52,6 @@ spec:
               1. Check node health and storage capacity
               2. Check replica rebuild progress in the Longhorn UI
             runbook_url: "https://longhorn.io/docs/latest/troubleshooting/"
-        - alert: LonghornSnapshotChainTooLong
-          expr: longhorn_volume_snapshot_count > 100
-          for: 5m
-          labels:
-            severity: warning
-            component: longhorn
-            category: snapshot
-          annotations:
-            summary: "Longhorn volume has too many snapshots: {{ $labels.volume }}"
-            description: |
-              Volume {{ $labels.volume }} has {{ $value }} snapshots.
-              Long snapshot chains can impact performance.
-            runbook_url: "https://longhorn.io/docs/latest/snapshots-and-backups/snapshots/"
         - alert: LonghornNodeStorageLow
           expr: |
             (
@@ -84,34 +71,4 @@ spec:
               Actions:
               1. Clean up unused volumes/snapshots
               2. Add more storage to the node
-            runbook_url: "https://longhorn.io/docs/latest/troubleshooting/"
-    - name: longhorn.performance
-      rules:
-        - alert: LonghornVolumeHighLatency
-          expr: "histogram_quantile(0.99, \n  rate(longhorn_volume_read_latency_seconds_bucket[5m])\n) > 0.1\n"
-          for: 5m
-          labels:
-            severity: warning
-            component: longhorn
-            category: performance
-          annotations:
-            summary: "High read latency on Longhorn volume: {{ $labels.volume }}"
-            description: |
-              Volume {{ $labels.volume }} is experiencing high read latency.
-              99th percentile latency: {{ $value | humanizeDuration }}
-            runbook_url: "https://longhorn.io/docs/latest/troubleshooting/"
-        - alert: LonghornVolumeHighIOPS
-          expr: "rate(longhorn_volume_read_iops_total[5m]) + \nrate(longhorn_volume_write_iops_total[5m]) > 1000\n"
-          for: 10m
-          labels:
-            severity: info
-            component: longhorn
-            category: performance
-          annotations:
-            summary: "High IOPS on Longhorn volume: {{ $labels.volume }}"
-            description: |
-              Volume {{ $labels.volume }} is experiencing high IOPS.
-              Current IOPS: {{ $value | humanize }}
-
-              This is informational - monitor for performance impact.
             runbook_url: "https://longhorn.io/docs/latest/troubleshooting/"

--- a/monitoring/prometheus-stack/tests/kopiur-alerts.test.yaml
+++ b/monitoring/prometheus-stack/tests/kopiur-alerts.test.yaml
@@ -1,0 +1,72 @@
+rule_files:
+  - kopiur.rules.yaml
+evaluation_interval: 1m
+tests:
+  - name: failed backups identify the data namespace and policy across controller restarts
+    interval: 1m
+    input_series:
+      - series: kopiur_snapshot_consecutive_failures{namespace="kopiur-system",exported_namespace="gitea",name="gitea-shared-storage",pod="controller-old"}
+        values: '3+0x6 stale _x13'
+      - series: kopiur_snapshot_consecutive_failures{namespace="kopiur-system",exported_namespace="gitea",name="gitea-shared-storage",pod="controller-new"}
+        values: '_x6 3+0x13'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: KopiurSnapshotsFailing
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: KopiurSnapshotsFailing
+        exp_alerts:
+          - exp_labels:
+              namespace: gitea
+              policy: gitea-shared-storage
+              severity: warning
+              component: kopiur
+              category: backup
+            exp_annotations:
+              summary: 'kopiur backups failing repeatedly: gitea/gitea-shared-storage'
+              description: |
+                3 consecutive snapshot failures.
+                Inspect policy gitea-shared-storage and its failed Snapshots:
+                kubectl -n gitea get snapshotpolicy,snapshot
+                Check source volume health, repository access, and mover permissions.
+  - name: stale backups identify the data namespace and collapse duplicate scrapes
+    interval: 1m
+    input_series:
+      - series: kopiur_policy_last_backup_success_timestamp_seconds{namespace="kopiur-system",exported_namespace="gitea",policy="gitea-shared-storage",instance="first"}
+        values: '-100000+0x20'
+      - series: kopiur_policy_last_backup_success_timestamp_seconds{namespace="kopiur-system",exported_namespace="gitea",policy="gitea-shared-storage",instance="second"}
+        values: '-100000+0x20'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: KopiurBackupStale
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: KopiurBackupStale
+        exp_alerts:
+          - exp_labels:
+              namespace: gitea
+              policy: gitea-shared-storage
+              severity: critical
+              component: kopiur
+              category: backup
+            exp_annotations:
+              summary: 'kopiur backup stale (>26h): gitea/gitea-shared-storage'
+              description: |
+                No successful kopiur snapshot for policy gitea-shared-storage in over 26 hours.
+                Inspect its schedule and failed Snapshots:
+                kubectl -n gitea get snapshotpolicy,snapshotschedule,snapshot
+                Preserve the source volume before recovery; the latest backup may omit recent writes.
+  - name: healthy backups and failures below the threshold do not alert
+    interval: 1m
+    input_series:
+      - series: kopiur_snapshot_consecutive_failures{namespace="kopiur-system",exported_namespace="gitea",name="gitea-shared-storage"}
+        values: '2+0x20'
+      - series: kopiur_policy_last_backup_success_timestamp_seconds{namespace="kopiur-system",exported_namespace="gitea",policy="gitea-shared-storage"}
+        values: '0+60x20'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: KopiurSnapshotsFailing
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: KopiurBackupStale
+        exp_alerts: []

--- a/scripts/prepare-telemetry-rule-tests.py
+++ b/scripts/prepare-telemetry-rule-tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prepare the repository's collector alert rules and fixtures for promtool."""
+"""Prepare collector or backup alert rules and fixtures for promtool."""
 import argparse
 from pathlib import Path
 import sys
@@ -10,24 +10,27 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SOURCE_DIR = REPO_ROOT / "infrastructure/controllers/opentelemetry-operator-observability"
 
 
-def prepare_tests(source_dir: Path, output_dir: Path) -> None:
-    manifest = yaml.safe_load((source_dir / "collector-alerts.yaml").read_text(encoding="utf-8"))
+def prepare_tests(source_dir: Path, output_dir: Path, suite: str = "collector") -> None:
+    manifest_name = f"{suite}-alerts.yaml"
+    manifest = yaml.safe_load((source_dir / manifest_name).read_text(encoding="utf-8"))
     rules = manifest.get("spec") if isinstance(manifest, dict) else None
     if not isinstance(rules, dict) or not isinstance(rules.get("groups"), list) or not rules["groups"]:
-        raise ValueError("collector-alerts.yaml must contain a non-empty spec.groups list")
-    fixtures = (source_dir / "tests/collector-alerts.test.yaml").read_bytes()
+        raise ValueError(f"{manifest_name} must contain a non-empty spec.groups list")
+    fixtures = (source_dir / f"tests/{suite}-alerts.test.yaml").read_bytes()
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    (output_dir / "collector.rules.yaml").write_text(yaml.safe_dump(rules), encoding="utf-8")
-    (output_dir / "collector-alerts.test.yaml").write_bytes(fixtures)
+    (output_dir / f"{suite}.rules.yaml").write_text(yaml.safe_dump(rules), encoding="utf-8")
+    (output_dir / f"{suite}-alerts.test.yaml").write_bytes(fixtures)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("output_dir", type=Path, help="Directory for promtool input files")
+    parser.add_argument("--suite", choices=("collector", "kopiur"), default="collector")
     args = parser.parse_args()
     try:
-        prepare_tests(SOURCE_DIR, args.output_dir)
+        source_dir = SOURCE_DIR if args.suite == "collector" else REPO_ROOT / "monitoring/prometheus-stack"
+        prepare_tests(source_dir, args.output_dir, args.suite)
     except (OSError, ValueError, yaml.YAMLError) as exc:
         print(f"ERROR: could not prepare telemetry rule tests: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## What changes

- Fix backup alerts so they identify the affected application's namespace and backup policy, rather than the backup controller's namespace or an empty policy name.
- Keep the alert identity stable across controller restarts and duplicate scrapes.
- Remove three Longhorn rules that reference metrics absent from this deployment: snapshot-chain length, read latency, and high IOPS. Keep faulted-volume, degraded-volume, and low-storage alerts.
- Reuse the existing rule-test workflow for three small backup regression cases. No new test framework or embedded programs.

## Why

The live Gitea incident exposed incorrect backup-alert context. Separately, the three removed Longhorn rules could not evaluate useful data against the live metric names. This is a small cleanup of existing monitoring, not an expansion of the alert stack.

## Verification

- Six rule-preparation unit tests passed.
- Prometheus 3.5.0 rule validation and the collector and backup scenario suites passed.
- All three remaining Longhorn rules passed syntax validation.
- Proposed backup expressions were checked against live labels using read-only queries.
- git diff --check passed.

These checks do not prove a deployed rollout. After merge, confirm Argo sync and loaded Prometheus rule health; any backup alerts should name the data namespace and policy.

## Scope

No dashboard deployment, Holmes activation, Trivy removal, storage changes, or running-cluster mutations are included. The separate Gitea recovery and root Argo annotation repair were already completed during the audit. Reverting this commit restores the previous rule definitions.