### PR TITLE
Import Mink notes into SurfSense from Git

### DIFF
--- a/my-apps/ai/surfsense/CLAUDE.md
+++ b/my-apps/ai/surfsense/CLAUDE.md
@@ -58,7 +58,7 @@ Do not put the Kopiur `Restore` CR in an earlier isolated wave than its PVC. The
 10. **Local llama.cpp is free infrastructure, not a credit-metered provider.** Keep `qwen3.8-27b` at `billing_tier: free`. `selfhost.env` must keep `DEFAULT_CREDIT_MICROS_BALANCE=0` and hosted-style billing switches disabled. The credit-policy hook must reconcile restored or pre-policy wallet rows before workloads start; do not replace it with manual SQL or fake premium model entries.
 11. **Reuse cluster SearXNG** at `http://searxng.searxng.svc.cluster.local:8080`; do not deploy another copy.
 12. **Secrets stay in 1Password.** Item `surfsense`: `secret_key`, `db_password`, `zero_admin_password`, `zero_query_api_key`.
-13. **Obsidian sync is client-pushed through a loopback Kubernetes tunnel.** The CachyOS plugin syncs only Mink `wiki/` through `127.0.0.1:18000`; do not add a server-side vault mount, route note-body bursts through Cloudflare, or commit the plugin PAT.
+13. **Mink imports from Git through the folder-upload API.** Keep the CronJob client-only, credentials in its dedicated ExternalSecret, and scripts in a generated ConfigMap; no Obsidian plugin or server-side vault mount is needed. See the README for activation and batch-completion safeguards.
 
 ## Storage choices
 

--- a/my-apps/ai/surfsense/README.md
+++ b/my-apps/ai/surfsense/README.md
@@ -52,23 +52,77 @@ operator-owned global model catalog:
 
 Initial embeddings use CPU-local `sentence-transformers/all-MiniLM-L6-v2`, so SurfSense does not request a GPU.
 
-## Obsidian / Mink integration
+## Mink Git import
 
-The CachyOS Obsidian client uses `/home/vanillax/.mink` as its vault and the
-official SurfSense Obsidian plugin `0.1.0`. Its server URL is
-`http://127.0.0.1:18000`, supplied by the enabled user unit
-`~/.config/systemd/user/surfsense-obsidian-tunnel.service`, which maintains an
-authenticated `kubectl port-forward` to the backend Service. The plugin targets
-workspace `My Workspace`, includes only the `wiki/` folder, leaves attachments
-disabled, and reconciles every 10 minutes in addition to realtime note events.
+The GitOps manifests define `surfsense-mink-sync`, a six-hourly CronJob that
+shallow-clones `mitchross/mink-data` (`main`) and uploads visible Markdown under
+`wiki/` into the `Mink` folder in `My Workspace` (ID `1`). Only notes pushed to
+GitHub are imported; local-only changes wait for Mink's normal Git sync.
+The credentials are provisioned and the CronJob is enabled in Git. Deployment
+and first-run verification follow merging this change.
+The removed Obsidian plugin and desktop tunnel are not required.
 
-The backend already serves the plugin API beneath `/api/v1/obsidian/*`; no
-server-side vault mount belongs in this deployment. Enable API access for the
-workspace and create a dedicated personal access token in SurfSense before
-configuring the plugin. The token lives only in the plugin's local `data.json`
-and must remain excluded from Mink's Git sync. Keep note sync on the loopback
-tunnel: plugin `0.1.0` replays vault create events on every Obsidian startup,
-and sending that burst through Cloudflare can produce managed-WAF 403s.
+This follows the [Hoyt Labs folder-upload approach](https://github.com/drewpayment/hoytlabs-talos/blob/main/apps/surfsense/minknotes-sync-cronjob.yaml).
+[`scripts/sync-mink.py`](scripts/sync-mink.py) is mounted from a hash-suffixed
+Kustomize ConfigMap. The job uses temporary node storage, calls `http://backend:8000`
+inside the cluster, and uploads at most 500 files per batch. SurfSense identifies
+files by folder name and relative path, skips unchanged bytes, and versions edits.
+Deleted or renamed source notes are **not pruned**; prior Obsidian imports remain
+separate and may duplicate these notes in search. Hidden paths, symlinks, non-Markdown
+files, and files outside `wiki/` are excluded.
+
+### Enable and verify
+
+1. The `surfsense` item in 1Password vault `homelab-prod` contains concealed fields
+   `mink_github_token` (the existing GitHub CLI OAuth credential, with repository
+   access) and `mink_api_token` (the dedicated `Mink Git sync` SurfSense PAT for
+   the workspace owner). A replacement GitHub token needs only read-only Contents
+   access to `mitchross/mink-data`.
+   Enable API access in `My Workspace`. The token must permit document creation
+   and reading folders and task logs. The dedicated ExternalSecret keeps these
+   credentials separate from the application containers.
+2. Merge the enabled [`mink-sync-cronjob.yaml`](mink-sync-cronjob.yaml) through
+   the normal GitOps workflow. ArgoCD manages the resources;
+   the schedule runs at 00:17, 06:17, 12:17, and 18:17 UTC. Initial processing can
+   take hours on CPU; the Job deadline is four hours.
+3. Check the credentials and scheduled run:
+
+   ```bash
+   kubectl -n surfsense get externalsecret surfsense-mink-sync
+   kubectl -n surfsense get cronjob surfsense-mink-sync
+   kubectl -n surfsense get jobs --sort-by=.metadata.creationTimestamp
+   kubectl -n surfsense logs job/<scheduled-job-name>
+   ```
+
+   Expect `SecretSynced`, an unsuspended CronJob, and a completed Job whose final
+   line is `Mink import complete`. Check the `Mink/wiki` tree in SurfSense and
+   search for a known note to confirm retrieval. A repeat run should retain the
+   same folder and documents while skipping unchanged files.
+
+The uploader waits for a **new worker task log to complete**, including the final
+batch; an idle folder flag alone can mean the worker has not started. It fails on
+partial indexing errors, ambiguous concurrent folder-upload logs, authentication
+errors, and timeouts. Avoid other folder uploads in this workspace during a run:
+SurfSense 0.0.39 does not return the worker task ID from this endpoint. HTTP reads
+retry transient failures; uploads and failed Jobs do not automatically retry because
+the server may already have accepted the request. Inspect SurfSense task logs and
+wait for any outstanding worker before the next run.
+
+Operator credential bootstrap is recorded in
+[`scripts/provision-mink-credentials.py`](scripts/provision-mink-credentials.py).
+Run it locally with authenticated `op`, `gh`, and `kubectl` access. It preserves
+existing item fields, verifies GitHub access, saves concealed tokens through stdin,
+and registers only the SurfSense token hash in the app database for workspace 1's
+active owner. This is an administrative account-data operation; it does not change
+Kubernetes resources. Re-running reuses the stored token without revoking other
+PATs. Expiry follows `PAT_MAX_EXPIRY_DAYS` when configured; otherwise it has no
+expiry, matching the deployment default. Revoke `Mink Git sync` in SurfSense to
+remove its access; never print the 1Password values in logs.
+
+For rollback, commit `suspend: true`; existing imported documents remain available.
+Suspension prevents future Jobs and does not cancel a Job already running.
+Validate locally with `kustomize build my-apps/ai/surfsense` and
+`python -m unittest discover -s my-apps/ai/surfsense/scripts -p 'test_*.py'` (requires `httpx`).
 
 ## Self-host billing policy
 

--- a/my-apps/ai/surfsense/kustomization.yaml
+++ b/my-apps/ai/surfsense/kustomization.yaml
@@ -5,6 +5,8 @@ namespace: surfsense
 resources:
   - namespace.yaml
   - externalsecret.yaml
+  - mink-sync-externalsecret.yaml
+  - mink-sync-cronjob.yaml
   - app/pvc.yaml
   - postgres/deployment.yaml
   - postgres/service.yaml
@@ -28,6 +30,9 @@ components:
   - ../../common/kopiur-backup
 
 configMapGenerator:
+  - name: surfsense-mink-sync-script
+    files:
+      - scripts/sync-mink.py
   - name: surfsense-global-llm-config
     files:
       - global_llm_config.yaml

--- a/my-apps/ai/surfsense/mink-sync-cronjob.yaml
+++ b/my-apps/ai/surfsense/mink-sync-cronjob.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: surfsense-mink-sync
+  namespace: surfsense
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  schedule: "17 */6 * * *"
+  timeZone: Etc/UTC
+  suspend: false
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 14400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: surfsense-mink-sync
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: sync
+              image: ghcr.io/modsetter/surfsense-backend:0.0.39
+              command: [python, /sync/sync-mink.py]
+              envFrom:
+                - secretRef:
+                    name: surfsense-mink-sync
+              env:
+                - {name: SOURCE_REPO, value: mitchross/mink-data}
+                - {name: SOURCE_BRANCH, value: main}
+                - {name: INCLUDE_DIRS, value: wiki}
+                - {name: FOLDER_NAME, value: Mink}
+                - {name: WORKSPACE_ID, value: "1"}
+                - {name: SURFSENSE_API, value: http://backend:8000}
+                - {name: BATCH_SIZE, value: "500"}
+                - {name: INDEX_TIMEOUT_SECONDS, value: "5400"}
+                - {name: WORKDIR, value: /work}
+                - {name: TMPDIR, value: /work}
+                - {name: PYTHONDONTWRITEBYTECODE, value: "1"}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              resources:
+                requests: {cpu: 100m, memory: 256Mi}
+                limits: {memory: 1Gi}
+              volumeMounts:
+                - {name: script, mountPath: /sync, readOnly: true}
+                - {name: work, mountPath: /work}
+          volumes:
+            - name: script
+              configMap:
+                name: surfsense-mink-sync-script
+            - name: work
+              emptyDir:
+                sizeLimit: 2Gi

--- a/my-apps/ai/surfsense/mink-sync-externalsecret.yaml
+++ b/my-apps/ai/surfsense/mink-sync-externalsecret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: surfsense-mink-sync
+  namespace: surfsense
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: surfsense-mink-sync
+    creationPolicy: Owner
+  data:
+    - secretKey: GITHUB_PAT
+      remoteRef:
+        key: surfsense
+        property: mink_github_token
+    - secretKey: SURFSENSE_TOKEN
+      remoteRef:
+        key: surfsense
+        property: mink_api_token

--- a/my-apps/ai/surfsense/scripts/provision-mink-credentials.py
+++ b/my-apps/ai/surfsense/scripts/provision-mink-credentials.py
@@ -1,0 +1,81 @@
+"""Bootstrap Mink credentials with operator access to 1Password and SurfSense Postgres."""
+
+import hashlib
+import json
+import re
+import secrets
+import subprocess
+import sys
+import urllib.request
+
+
+def run(args, data=None):
+    result = subprocess.run(args, input=data, capture_output=True, text=True, timeout=60)
+    if result.returncode:
+        raise RuntimeError(f"{args[0]} failed; sensitive command output suppressed")
+    return result.stdout
+
+
+def sql(statement):
+    return run(["kubectl", "-n", "surfsense", "exec", "-i", "deploy/surfsense-postgres",
+                "--", "psql", "-X", "-qAt", "-v", "ON_ERROR_STOP=1", "-U", "surfsense",
+                "-d", "surfsense"], statement)
+
+
+def main():
+    item_args = ["op", "item", "get", "surfsense", "--vault", "homelab-prod", "--format", "json"]
+    item = json.loads(run(item_args))
+    fields = {f["label"]: f for f in item["fields"]}
+    github = fields.get("mink_github_token", {}).get("value") or run(["gh", "auth", "token"]).strip()
+    request = urllib.request.Request(
+        "https://api.github.com/repos/mitchross/mink-data/contents/wiki?ref=main",
+        headers={"Authorization": f"Bearer {github}", "Accept": "application/vnd.github+json"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        if not isinstance(json.load(response), list):
+            raise RuntimeError("GitHub wiki directory verification failed")
+    owner = sql('SELECT w.id FROM workspaces w JOIN "user" u ON w.user_id=u.id '
+                'WHERE w.id=1 AND w.api_access_enabled AND u.is_active;').strip()
+    if owner != "1":
+        raise RuntimeError("Workspace 1 must have an active owner and API access enabled")
+
+    token = fields.get("mink_api_token", {}).get("value") or f"ss_pat_{secrets.token_urlsafe(32)}"
+    if not re.fullmatch(r"ss_pat_[A-Za-z0-9_-]{43}", token):
+        raise RuntimeError("Stored SurfSense token has an unexpected format")
+    max_days = run(["kubectl", "-n", "surfsense", "exec", "deploy/surfsense", "-c", "api",
+                    "--", "python", "-c", "import os; print(os.getenv('PAT_MAX_EXPIRY_DAYS', ''))"]).strip()
+    expiry = f"now() + interval '{int(max_days)} days'" if max_days else "NULL"
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+
+    # Save the recoverable plaintext before registering only its hash in SurfSense.
+    for label, value in (("mink_github_token", github), ("mink_api_token", token)):
+        if label in fields:
+            fields[label].update(type="CONCEALED", value=value)
+        else:
+            item["fields"].append({"id": label, "label": label, "type": "CONCEALED", "value": value})
+    run(["op", "item", "edit", item["id"], "--vault", "homelab-prod", "--format", "json"], json.dumps(item))
+    saved = {f["label"]: f for f in json.loads(run(item_args))["fields"]}
+    for label, value in (("mink_github_token", github), ("mink_api_token", token)):
+        if saved[label]["value"] != value or saved[label]["type"] != "CONCEALED":
+            raise RuntimeError("1Password read-back verification failed")
+
+    # Operator bootstrap for 0.0.39: preserve existing PATs and its SHA-256 token format.
+    sql(f"""INSERT INTO personal_access_tokens
+        (user_id, token_hash, token_prefix, label, expires_at, created_at)
+        SELECT user_id, '{token_hash}', '{token[:16]}', 'Mink Git sync', {expiry}, now()
+        FROM workspaces WHERE id=1
+        ON CONFLICT (token_hash) DO NOTHING;
+    """)
+    valid = sql(f"""SELECT p.id FROM personal_access_tokens p JOIN workspaces w ON p.user_id=w.user_id
+        WHERE w.id=1 AND p.token_hash='{token_hash}' AND (p.expires_at IS NULL OR p.expires_at>now());
+    """).strip()
+    if not valid.isdigit():
+        raise RuntimeError("Stored SurfSense token is expired or belongs to another account")
+    print(f"Both concealed 1Password fields verified; SurfSense PAT ID {valid} registered")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        sys.exit(f"Credential bootstrap failed: {type(error).__name__}; inspect access without printing secrets")

--- a/my-apps/ai/surfsense/scripts/sync-mink.py
+++ b/my-apps/ai/surfsense/scripts/sync-mink.py
@@ -1,0 +1,178 @@
+"""Import Git-backed Mink Markdown through SurfSense 0.0.39's folder API."""
+
+import base64
+from contextlib import ExitStack
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import time
+
+import httpx
+
+
+def collect_notes(repo: Path, include: str) -> list[Path]:
+    files = set()
+    for directory in include.split(","):
+        relative = Path(directory.strip())
+        if not relative.parts or relative.is_absolute() or any(
+            part.startswith(".") for part in relative.parts
+        ):
+            raise ValueError("INCLUDE_DIRS must contain visible relative directories")
+        base = repo / relative
+        if not base.is_dir() or any(p.is_symlink() for p in [base, *base.parents] if p != repo):
+            raise ValueError(f"Missing or symlinked include directory: {relative}")
+        for path in base.rglob("*.md"):
+            parts = path.relative_to(repo).parts
+            if any(part.startswith(".") for part in parts):
+                continue
+            if any(p.is_symlink() for p in [path, *path.parents] if p != repo):
+                continue
+            if path.is_file():
+                if len(parts) > 8:
+                    raise ValueError("Note exceeds SurfSense's eight-level folder limit")
+                files.add(path)
+    if not files:
+        raise ValueError("No Markdown notes found; refusing an empty import")
+    return sorted(files)
+
+
+def clone_repo(destination: Path, repository: str, branch: str, token: str) -> None:
+    if not re.fullmatch(r"[\w.-]+/[\w.-]+", repository):
+        raise ValueError("SOURCE_REPO must be a GitHub owner/repository")
+    auth = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    env = os.environ.copy()
+    env.update({
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.https://github.com/.extraheader",
+        "GIT_CONFIG_VALUE_0": f"Authorization: Basic {auth}",
+    })
+    result = subprocess.run(
+        ["git", "clone", "--quiet", "--depth=1", "--single-branch",
+         "--branch", branch, "--", f"https://github.com/{repository}.git", str(destination)],
+        env=env, capture_output=True, timeout=300,
+    )
+    if result.returncode:
+        raise RuntimeError("Git clone failed; check repository, branch, and read token")
+
+
+def get_json(client: httpx.Client, path: str, **kwargs):
+    for attempt in range(4):
+        try:
+            response = client.get(path, **kwargs)
+            if response.status_code != 429 and response.status_code < 500:
+                response.raise_for_status()
+                return response.json()
+        except httpx.TransportError:
+            if attempt == 3:
+                raise
+        if attempt < 3:
+            time.sleep(2 ** attempt)
+    raise RuntimeError(f"SurfSense read failed after retries: {path}")
+
+
+def upload_logs(client: httpx.Client, workspace: int) -> list[dict]:
+    return get_json(client, "/api/v1/logs", params={
+        "workspace_id": workspace, "source": "uploaded_folder_indexing", "limit": 100,
+    })
+
+
+def wait_for_batch(client: httpx.Client, workspace: int, previous_id: int,
+                   count: int, timeout: float, poll: float = 15) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        logs = [entry for entry in upload_logs(client, workspace) if entry["id"] > previous_id]
+        if len(logs) > 1:
+            raise RuntimeError("Concurrent folder uploads detected; cannot identify this batch")
+        if logs:
+            entry = logs[0]
+            if (entry.get("log_metadata") or {}).get("file_count") != count:
+                raise RuntimeError("Worker log does not match the uploaded batch")
+            if entry["status"] == "FAILED":
+                raise RuntimeError(f"SurfSense worker failed; inspect log {entry['id']}")
+            if entry["status"] == "SUCCESS":
+                # 0.0.39 can report SUCCESS with failed files; counters are in its message.
+                match = re.fullmatch(r"Upload indexing complete: (\d+) indexed, (\d+) failed", entry["message"])
+                if not match or int(match[2]):
+                    raise RuntimeError(f"SurfSense reported indexing errors; inspect log {entry['id']}")
+                print(f"Worker completed batch: {match[1]} indexed, remaining files unchanged", flush=True)
+                return
+        time.sleep(poll)
+    raise RuntimeError("Timed out waiting for the worker to complete the uploaded batch")
+
+
+def sync_notes(client: httpx.Client, repo: Path, files: list[Path], workspace: int,
+               folder: str, batch_size: int, timeout: float) -> None:
+    if not 1 <= batch_size <= 500:
+        raise ValueError("BATCH_SIZE must be between 1 and 500")
+    folders = get_json(client, "/api/v1/folders", params={"workspace_id": workspace})
+    roots = [f for f in folders if f["name"] == folder and f["parent_id"] is None]
+    if len(roots) > 1:
+        raise RuntimeError("Multiple Mink root folders found")
+    root_id = roots[0]["id"] if roots else None
+    for offset in range(0, len(files), batch_size):
+        previous = upload_logs(client, workspace)
+        if any(entry["status"] == "IN_PROGRESS" for entry in previous):
+            raise RuntimeError("A folder upload is still running; wait for it before syncing")
+        previous_id = max((entry["id"] for entry in previous), default=0)
+        batch = files[offset:offset + batch_size]
+        relative = [p.relative_to(repo).as_posix() for p in batch]
+        data = {
+            "folder_name": folder, "workspace_id": str(workspace),
+            "relative_paths": json.dumps(relative), "processing_mode": "basic",
+        }
+        if root_id is not None:
+            data["root_folder_id"] = str(root_id)
+        with ExitStack() as stack:
+            multipart = [("files", (name, stack.enter_context(path.open("rb")), "text/markdown"))
+                         for name, path in zip(relative, batch)]
+            # Never retry an ambiguous POST: it may already have queued a worker task.
+            response = client.post("/api/v1/documents/folder-upload", data=data, files=multipart)
+        response.raise_for_status()
+        body = response.json()
+        if not isinstance(body.get("root_folder_id"), int) or body.get("file_count") != len(batch):
+            raise RuntimeError("Unexpected folder-upload response")
+        if root_id is not None and body["root_folder_id"] != root_id:
+            raise RuntimeError("SurfSense returned a different root folder")
+        root_id = body["root_folder_id"]
+        print(f"Accepted {offset + len(batch)}/{len(files)} notes; waiting for worker", flush=True)
+        wait_for_batch(client, workspace, previous_id, len(batch), timeout)
+    print(f"Mink import complete: {len(files)} notes processed in folder {root_id}", flush=True)
+
+
+def main() -> None:
+    token = os.environ["SURFSENSE_TOKEN"]
+    if not token.startswith("ss_pat_"):
+        raise ValueError("SURFSENSE_TOKEN must be a SurfSense personal access token")
+    work = Path(os.environ.get("WORKDIR", "/work"))
+    work.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="mink-", dir=work) as scratch:
+        repo = Path(scratch) / "repo"
+        clone_repo(repo, os.environ["SOURCE_REPO"], os.environ.get("SOURCE_BRANCH", "main"),
+                   os.environ["GITHUB_PAT"])
+        files = collect_notes(repo, os.environ.get("INCLUDE_DIRS", "wiki"))
+        print(f"Selected {len(files)} Markdown notes", flush=True)
+        with httpx.Client(
+            base_url=os.environ["SURFSENSE_API"].rstrip("/"),
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=httpx.Timeout(600, connect=10), follow_redirects=False,
+        ) as client:
+            sync_notes(client, repo, files, int(os.environ["WORKSPACE_ID"]),
+                       os.environ.get("FOLDER_NAME", "Mink"),
+                       int(os.environ.get("BATCH_SIZE", "500")),
+                       float(os.environ.get("INDEX_TIMEOUT_SECONDS", "5400")))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (httpx.HTTPError, subprocess.TimeoutExpired) as error:
+        # Avoid response bodies and subprocess output, which may contain notes or credentials.
+        status = error.response.status_code if isinstance(error, httpx.HTTPStatusError) else type(error).__name__
+        sys.exit(f"Mink sync failed: {status}; inspect SurfSense task logs or Git access")
+    except (KeyError, ValueError, RuntimeError) as error:
+        sys.exit(f"Mink sync failed: {error}")

--- a/my-apps/ai/surfsense/scripts/test_sync_mink.py
+++ b/my-apps/ai/surfsense/scripts/test_sync_mink.py
@@ -1,0 +1,97 @@
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import httpx
+
+spec = importlib.util.spec_from_file_location("sync_mink", Path(__file__).with_name("sync-mink.py"))
+sync = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sync)
+
+
+def worker_log(status="SUCCESS", failed=0):
+    return {"id": 2, "status": status, "log_metadata": {"file_count": 1},
+            "message": f"Upload indexing complete: 1 indexed, {failed} failed"}
+
+
+class MinkSyncTests(unittest.TestCase):
+    def test_selection_excludes_hidden_and_symlinked_notes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            (repo / "wiki/.hidden").mkdir(parents=True)
+            (repo / "wiki/note.md").write_text("note")
+            (repo / "wiki/.hidden/token.md").write_text("secret")
+            (repo / "outside.md").write_text("outside")
+            (repo / "wiki/link.md").symlink_to(repo / "outside.md")
+            self.assertEqual(sync.collect_notes(repo, "wiki"), [repo / "wiki/note.md"])
+            for include in ("../", "/tmp", "missing", ""):
+                with self.assertRaises(ValueError):
+                    sync.collect_notes(repo, include)
+
+    @patch.object(sync.time, "sleep")
+    def test_waits_for_worker_start_and_finish(self, sleep):
+        with patch.object(sync, "upload_logs", side_effect=[[], [worker_log("IN_PROGRESS")], [worker_log()]]):
+            sync.wait_for_batch(None, 1, 1, 1, 10)
+        self.assertEqual(sleep.call_count, 2)
+
+    def test_partial_failure_is_not_success(self):
+        with patch.object(sync, "upload_logs", return_value=[worker_log(failed=1)]):
+            with self.assertRaisesRegex(RuntimeError, "indexing errors"):
+                sync.wait_for_batch(None, 1, 1, 1, 10)
+
+    def test_concurrent_upload_is_rejected(self):
+        with patch.object(sync, "upload_logs", return_value=[worker_log(), {**worker_log(), "id": 3}]):
+            with self.assertRaisesRegex(RuntimeError, "Concurrent"):
+                sync.wait_for_batch(None, 1, 1, 1, 10)
+
+    def test_batch_timeout(self):
+        with patch.object(sync, "upload_logs", return_value=[]), patch.object(sync.time, "monotonic", side_effect=[0, 11]):
+            with self.assertRaisesRegex(RuntimeError, "Timed out"):
+                sync.wait_for_batch(None, 1, 1, 1, 10)
+
+    def test_upload_waits_for_every_batch_and_reuses_root(self):
+        requests = []
+
+        def handler(request):
+            requests.append(request)
+            if request.url.path == "/api/v1/folders":
+                return httpx.Response(200, json=[{"name": "Mink", "id": 7, "parent_id": None}])
+            self.assertEqual(request.method, "POST")
+            self.assertIn(b'name="root_folder_id"\r\n\r\n7', request.content)
+            return httpx.Response(200, json={"root_folder_id": 7, "file_count": 1})
+
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            files = [repo / "a.md", repo / "b.md"]
+            for file in files:
+                file.write_text("Markdown")
+            with httpx.Client(base_url="http://backend", transport=httpx.MockTransport(handler)) as client:
+                with patch.object(sync, "upload_logs", return_value=[]), patch.object(sync, "wait_for_batch") as wait:
+                    sync.sync_notes(client, repo, files, 1, "Mink", 1, 10)
+                    self.assertEqual(wait.call_count, 2)
+            self.assertEqual(len(requests), 3)
+
+    def test_ambiguous_post_is_not_retried(self):
+        posts = []
+
+        def handler(request):
+            if request.method == "GET":
+                return httpx.Response(200, json=[])
+            posts.append(request)
+            raise httpx.ReadTimeout("ambiguous upload")
+
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            file = repo / "a.md"
+            file.write_text("Markdown")
+            with httpx.Client(base_url="http://backend", transport=httpx.MockTransport(handler)) as client:
+                with self.assertRaises(httpx.ReadTimeout):
+                    sync.sync_notes(client, repo, [file], 1, "Mink", 1, 10)
+            self.assertEqual(len(posts), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Import Mink knowledge without running the Obsidian plugin or a desktop tunnel. An enabled six-hourly CronJob pulls `mitchross/mink-data` and uploads visible `wiki/` Markdown into `My Workspace → Mink` through the in-cluster SurfSense folder API.

- Stores the uploader in a generated ConfigMap and obtains credentials from a dedicated 1Password ExternalSecret. Both concealed fields are already provisioned and authentication has been verified.
- Uploads in batches of up to 500 files and waits for worker completion, including the last batch. Fails on partial indexing errors, ambiguous concurrent uploads, or timeouts; ambiguous uploads are not retried automatically.
- Preserves existing documents and excludes hidden files and symlinks. Source deletions are not propagated; prior Obsidian imports may duplicate notes in search.
- Includes the administrative credential bootstrap script and an activation/rollback runbook. The GitHub credential currently reuses the authenticated CLI OAuth token with repository access; the SurfSense PAT is dedicated to Mink sync.

Validation: seven unit tests passed, Kustomize rendering passed, the inline-script check passed, and `git diff --check` passed. A private source clone selected 1,134 Markdown notes; authenticated SurfSense folders and logs requests returned HTTP 200. The first scheduled import and search-retrieval verification remain pending deployment.

Merging enables the scheduled import through ArgoCD. No manual Kubernetes configuration changes are required.
