### PR TITLE
Fix missing Cilium metrics and ignored exporter resources

### DIFF
--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -171,6 +171,16 @@ jobs:
           set -euo pipefail
           python3 ./scripts/validate-vpa-policies.py /tmp/all-manifests.yaml
 
+      - name: Validate metrics discovery and capability-aware Argo render
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s scripts/tests -p test_monitoring_contract.py -v
+          kustomize build infrastructure/controllers/argocd --enable-helm \
+            --helm-kube-version "${KUBERNETES_VERSION}" \
+            --helm-api-versions monitoring.coreos.com/v1 > /tmp/argocd-with-monitoring.yaml
+          python3 scripts/validate-monitoring-contract.py /tmp/all-manifests.yaml \
+            --argocd-capabilities /tmp/argocd-with-monitoring.yaml
+
   # backup-exempt-contract job RETIRED 2026-06-27 (pvc-plumber removed). It
   # hard-failed on the bare `backup-exempt-reason` key because pvc-plumber denied
   # such PVCs on CREATE; with pvc-plumber gone, nothing enforces the key, so the

--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -124,6 +124,12 @@ resources:
   limits:
     memory: 3Gi
 
+prometheus:
+  enabled: true
+  metricsService: true
+  serviceMonitor:
+    enabled: false
+
 # Hubble (Observability)
 hubble:
   enabled: true 
@@ -136,6 +142,11 @@ hubble:
 
 # Operator Configuration
 operator:
+  prometheus:
+    enabled: true
+    metricsService: true
+    serviceMonitor:
+      enabled: false
   # Required hostname anti-affinity below spreads the two replicas. Drop to 1 if only one
   # worker is schedulable — the 2nd replica would stay Pending and hang the app.
   replicas: 2

--- a/monitoring/prometheus-stack/custom-servicemonitors.yaml
+++ b/monitoring/prometheus-stack/custom-servicemonitors.yaml
@@ -110,7 +110,7 @@ spec:
     matchNames:
       - kube-system
   endpoints:
-    - port: prometheus
+    - port: metrics
       interval: 30s
       path: /metrics
 ---
@@ -132,28 +132,28 @@ spec:
     matchNames:
       - kube-system
   endpoints:
-    - port: prometheus
+    - port: metrics
       interval: 30s
       path: /metrics
 ---
-# ServiceMonitor for Gateway API (if using)
+# Gateway API traffic is handled by the per-node Cilium Envoy.
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: gateway-api-metrics
+  name: cilium-envoy-metrics
   namespace: prometheus-stack
   labels:
-    app.kubernetes.io/name: gateway-api
+    app.kubernetes.io/name: cilium-envoy
     release: kube-prometheus-stack
     prometheus: kube-prometheus-stack-prometheus
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: gateway
+      k8s-app: cilium-envoy
   namespaceSelector:
     matchNames:
-      - gateway
+      - kube-system
   endpoints:
-    - port: metrics
+    - port: envoy-metrics
       interval: 30s
       path: /metrics

--- a/monitoring/prometheus-stack/values.yaml
+++ b/monitoring/prometheus-stack/values.yaml
@@ -357,6 +357,7 @@ grafana:
 # Enable for comprehensive node-level metrics (VPA-optimized 2026-02-28)
 nodeExporter:
   enabled: true
+prometheus-node-exporter:
   hostRootFsMount:
     enabled: true
     mountPropagation: HostToContainer
@@ -369,14 +370,14 @@ nodeExporter:
       memory: 256Mi
 kubeStateMetrics:
   enabled: true
+# Expose PVC backup labels so alerts/dashboards can distinguish backup-exempt PVCs.
+kube-state-metrics:
   resources:
     requests:
       cpu: 50m
       memory: 256Mi
     limits:
       memory: 512Mi
-# Expose PVC backup labels so alerts/dashboards can distinguish backup-exempt PVCs.
-kube-state-metrics:
   metricLabelsAllowlist:
     # kube-state-metrics sanitizes cnpg.io/cluster to label_cnpg_io_cluster.
     - persistentvolumeclaims=[backup-exempt,cnpg.io/cluster]

--- a/scripts/tests/test_monitoring_contract.py
+++ b/scripts/tests/test_monitoring_contract.py
@@ -1,0 +1,63 @@
+import copy
+import importlib.util
+from pathlib import Path
+import unittest
+
+spec = importlib.util.spec_from_file_location("monitoring_contract", Path(__file__).parents[1] / "validate-monitoring-contract.py")
+contract = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(contract)
+
+
+def healthy_objects():
+    objects = []
+    for monitor, service in contract.MONITORS.items():
+        objects.extend([
+            {"kind": "ServiceMonitor", "metadata": {"name": monitor, "namespace": "prometheus-stack"},
+             "spec": {"namespaceSelector": {"matchNames": ["kube-system"]},
+                      "selector": {"matchLabels": {"app": service}}, "endpoints": [{"port": "metrics"}]}},
+            {"kind": "Service", "metadata": {"name": service, "namespace": "kube-system", "labels": {"app": service}},
+             "spec": {"ports": [{"name": "metrics", "targetPort": "prometheus"}]}},
+        ])
+    for kind, name in [("DaemonSet", "kube-prometheus-stack-prometheus-node-exporter"),
+                       ("Deployment", "kube-prometheus-stack-kube-state-metrics")]:
+        objects.append({"kind": kind, "metadata": {"name": name, "namespace": "prometheus-stack"},
+                        "spec": {"template": {"spec": {"containers": [{"name": "exporter", "resources": {
+                            "requests": {"cpu": "50m", "memory": "128Mi"}, "limits": {"memory": "256Mi"}}}]}}}})
+    return objects
+
+
+class MonitoringContractTests(unittest.TestCase):
+    def test_valid_and_repeated_nested_render(self):
+        objects = healthy_objects()
+        self.assertEqual(contract.validate(objects + copy.deepcopy(objects)), [])
+
+    def test_missing_service_is_not_healthy_discovery(self):
+        objects = healthy_objects()
+        del objects[1]
+        self.assertTrue(contract.validate(objects))
+
+    def test_target_port_is_not_service_port(self):
+        objects = healthy_objects()
+        objects[0]["spec"]["endpoints"][0]["port"] = "prometheus"
+        self.assertTrue(contract.validate(objects))
+
+    def test_wrong_service_labels_or_namespace_fail(self):
+        for field in ["labels", "namespace"]:
+            objects = healthy_objects()
+            objects[1]["metadata"][field] = {} if field == "labels" else "gateway"
+            self.assertTrue(contract.validate(objects))
+
+    def test_wrong_monitor_namespace_selection_fails(self):
+        objects = healthy_objects()
+        objects[0]["spec"]["namespaceSelector"]["matchNames"] = ["gateway"]
+        self.assertTrue(contract.validate(objects))
+
+    def test_ignored_helm_resource_values_fail(self):
+        for resources in [None, {}, {"limits": {"memory": "256Mi"}}]:
+            objects = healthy_objects()
+            objects[-1]["spec"]["template"]["spec"]["containers"][0]["resources"] = resources
+            self.assertTrue(contract.validate(objects))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-monitoring-contract.py
+++ b/scripts/validate-monitoring-contract.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Check Cilium scrape discovery and exporter resources in rendered manifests."""
+import argparse
+from pathlib import Path
+
+import yaml
+
+MONITORS = {
+    "cilium-metrics": "cilium-agent",
+    "cilium-operator-metrics": "cilium-operator",
+    "cilium-envoy-metrics": "cilium-envoy",
+}
+ARGO_MONITORS = {
+    "argocd-application-controller", "argocd-applicationset-controller",
+    "argocd-repo-server", "argocd-server",
+}
+
+
+def validate(objects):
+    index = {(o["kind"], o["metadata"].get("namespace", "default"), o["metadata"]["name"]): o
+             for o in objects}
+    errors = []
+    for monitor_name, service_name in MONITORS.items():
+        monitor = index.get(("ServiceMonitor", "prometheus-stack", monitor_name))
+        service = index.get(("Service", "kube-system", service_name))
+        if not monitor or not service:
+            errors.append(f"{monitor_name}: missing monitor or Service kube-system/{service_name}")
+            continue
+        spec = monitor["spec"]
+        if "kube-system" not in spec.get("namespaceSelector", {}).get("matchNames", []):
+            errors.append(f"{monitor_name}: does not select kube-system")
+        selector = spec.get("selector", {})
+        labels = service["metadata"].get("labels", {})
+        if selector.get("matchExpressions") or not selector.get("matchLabels") or any(
+            labels.get(k) != v for k, v in selector.get("matchLabels", {}).items()
+        ):
+            errors.append(f"{monitor_name}: selector does not match its metrics Service")
+        ports = {p.get("name") for p in service["spec"].get("ports", [])}
+        endpoints = spec.get("endpoints", [])
+        if not endpoints or any(e.get("port") not in ports for e in endpoints):
+            errors.append(f"{monitor_name}: endpoint must reference a named Service port")
+    for kind, name in [
+        ("DaemonSet", "kube-prometheus-stack-prometheus-node-exporter"),
+        ("Deployment", "kube-prometheus-stack-kube-state-metrics"),
+    ]:
+        workload = index.get((kind, "prometheus-stack", name))
+        if not workload:
+            errors.append(f"{name}: workload was not rendered")
+            continue
+        for container in workload["spec"]["template"]["spec"]["containers"]:
+            resources = container.get("resources") or {}
+            requests, limits = resources.get("requests") or {}, resources.get("limits") or {}
+            if not requests.get("cpu") or not requests.get("memory") or not limits.get("memory"):
+                errors.append(f"{name}/{container['name']}: CPU/memory requests and memory limit are missing")
+    return errors
+
+
+def load(paths):
+    return [o for path in paths for o in yaml.load_all(path.read_text(), Loader=yaml.BaseLoader)
+            if isinstance(o, dict) and "kind" in o and "metadata" in o]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifests", nargs="+", type=Path)
+    parser.add_argument("--argocd-capabilities", type=Path)
+    args = parser.parse_args()
+    try:
+        errors = validate(load(args.manifests))
+        if args.argocd_capabilities:
+            names = {o["metadata"]["name"] for o in load([args.argocd_capabilities])
+                     if o["kind"] == "ServiceMonitor" and o["metadata"].get("namespace") == "argocd"}
+            if missing := ARGO_MONITORS - names:
+                errors.append(f"Argo capability-aware render is missing monitors: {sorted(missing)}")
+    except (OSError, yaml.YAMLError, KeyError, TypeError, AttributeError) as exc:
+        print(f"ERROR: unable to validate rendered monitoring contract: {type(exc).__name__}")
+        return 1
+    for error in errors:
+        print(f"ERROR: {error}")
+    if not errors:
+        print("Cilium metrics Services match their monitors; exporter resource baselines are present.")
+    return int(bool(errors))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Cilium had no discovered agent, operator, or Envoy scrape targets even though every target Prometheus did discover was up. The custom monitors referenced missing metrics Services, wrong Service port names, and a nonexistent Gateway Service selector. Node-exporter and kube-state-metrics resource settings were also under Helm keys that the subcharts ignore.

Enable the Cilium metrics listeners and Services, connect the monitors to their actual Service ports, and move exporter resources under the subchart keys. The monitoring app continues to own these monitors, so Cilium can bootstrap without Prometheus CRDs.

Add a CI check that rejects those silent discovery/resource failures. It also renders Argo with the monitoring API capability: Argo's four live monitors are correctly owned today, but a plain local Kustomize render omits them.

Validation: all 59 script unit tests pass, including six regression cases; Cilium and Prometheus chart renders pass the new check; the original render fails it as expected. The capability-aware Argo render contains all four monitors. Inline-script validation and diff checks pass.

After merge, Cilium agents/operator and exporters roll to apply the settings. Verify agent, operator, and Envoy targets are discovered and up. VXLAN, Gateway routing, network policies, and the existing rollout strategy are unchanged.
