### PR TITLE
Keep Zomboid parked with its data and deployment reference

### DIFF
--- a/my-apps/home/project-zomboid/README.md
+++ b/my-apps/home/project-zomboid/README.md
@@ -1,5 +1,20 @@
 # Project Zomboid Dedicated Server (Build 42 unstable)
 
+**Status: parked.** `deployment.yaml` deliberately sets `replicas: 0`. Keep this
+Application and its manifests as the reference for turning the server back on.
+Both PVCs remain allocated; the `zomboid-data` Kopiur backup remains configured.
+
+To resume, change `spec.replicas` to `1` in Git and merge the change. Check that
+the Deployment reaches `1/1` Ready and that RCON responds to `players` before
+inviting players. Startup updates the Steam installation and copies the
+repository's server configuration into the data volume, so review those files
+and the configured game branch before resuming.
+
+To park it again, commit `replicas: 0`; expect `0/0` Ready with both PVCs still
+Bound. The PDB permits one unavailable pod, so it does not demand a running
+server while parked or prevent a voluntary drain when resumed. A drain of a
+running single server interrupts play.
+
 Self-hosted Zomboid multiplayer server for the homelab. UDP game traffic
 (no HTTPRoute / Cloudflare tunnel — games don't speak HTTP), runs on a
 standard worker node with Longhorn storage.

--- a/my-apps/home/project-zomboid/pdb.yaml
+++ b/my-apps/home/project-zomboid/pdb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: project-zomboid
   namespace: project-zomboid
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: project-zomboid


### PR DESCRIPTION
Keep Project Zomboid parked at its existing zero replicas, with its manifests, both PVCs, and Kopiur backup intact for future use. Document how to resume and park it through Git.

Change the PDB from `minAvailable: 1` to `maxUnavailable: 1`. The old budget requested a healthy server while it was parked and would block a voluntary drain when the single server was running. The new budget permits that interruption.

Validation: Kustomize renders zero replicas, both original claims, all three backup/restore resources, and the corrected PDB. Live inspection confirmed the server is already 0/0 and both claims are Bound. No deletion or storage migration is involved.
