### PR TITLE
Stop Headlamp from reading cluster-wide Secrets

### DIFF
--- a/my-apps/development/headlamp/README.md
+++ b/my-apps/development/headlamp/README.md
@@ -1,0 +1,22 @@
+# Headlamp access
+
+Headlamp is served through the internal Gateway. The `headlamp-admin` ServiceAccount
+name is historical; `metrics-role.yaml` grants read-only workload, metrics, and
+infrastructure visibility. Its explicit core resource list excludes Secrets and
+proxy subresources. The Secrets screen is therefore unavailable to this identity.
+
+After syncing the role change, verify from the operator workstation:
+
+```bash
+kubectl auth can-i get secrets --all-namespaces --as=system:serviceaccount:kube-system:headlamp-admin
+kubectl auth can-i get pods --all-namespaces --as=system:serviceaccount:kube-system:headlamp-admin
+kubectl auth can-i get pods --subresource=log --all-namespaces --as=system:serviceaccount:kube-system:headlamp-admin
+```
+
+Expected results: `no`, `yes`, `yes`. Existing login remains usable. The current
+`token-secret.yaml` still supplies a long-lived login token; replacing that login
+method is separate work and must not strand the operator without access.
+
+A Git revert restores the previous role, including its broad Secret access. Fix
+an accidentally omitted read permission explicitly rather than restoring the
+core wildcard as a convenience.

--- a/my-apps/development/headlamp/metrics-role.yaml
+++ b/my-apps/development/headlamp/metrics-role.yaml
@@ -15,7 +15,20 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - "*"
+  - configmaps
+  - endpoints
+  - events
+  - limitranges
+  - namespaces
+  - nodes
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - resourcequotas
+  - serviceaccounts
+  - services
   verbs:
   - get
   - list


### PR DESCRIPTION
Headlamp's read-only role used `resources: ["*"]` in the core API group, allowing its login identity to read every Secret in the cluster. Replace that wildcard with the workload and infrastructure resources the dashboard needs, including pod logs. Proxy subresources are also excluded.

Existing login is preserved. The long-lived service-account token remains a separate follow-up; this change does not claim to replace authentication.

Validation: the Headlamp chart renders successfully; the resulting role has only get/list/watch and no core Secret or proxy grants. After merge, verify Secret reads are denied while pod and log reads still work using the commands in the app README.
