### PR TITLE
Keep Holmes investigations on demand

### DIFF
--- a/monitoring/keep/README.md
+++ b/monitoring/keep/README.md
@@ -1,0 +1,16 @@
+# Keep alert view
+
+Alertmanager sends events to Keep. Critical alerts do not automatically call
+Holmes or the local model. `backend.provision.workflows` is deliberately empty;
+Holmes remains parked until explicitly enabled for an investigation.
+
+The chart includes a workflow checksum in the backend pod template, so changing
+the provisioned list rolls the backend. Keep 0.52.1 removes previously provisioned
+workflows at startup when no workflows directory or inline workflow is configured.
+See its [provisioning code](https://github.com/keephq/keep/blob/v0.52.1/keep/workflowmanager/workflowstore.py)
+and [provisioning guide](https://docs.keephq.dev/deployment/provision/workflow).
+
+After sync, check that the backend rollout completes and `holmes-rca` is absent
+from the workflow list. Confirm alerts still arrive. This removes the automatic
+trigger; it does not deploy the Holmes console or add an investigation interface.
+A Git revert restores the workflow and automatic critical-alert calls.

--- a/monitoring/keep/values.yaml
+++ b/monitoring/keep/values.yaml
@@ -1,4 +1,4 @@
-# Alertmanager webhooks land here; a provisioned workflow asks HolmesGPT to RCA criticals. No chat/text receivers by design.
+# Alertmanager webhooks land here; AI investigations are explicitly requested.
 global:
   # Chart only ships nginx/haproxy/traefik Ingress; this cluster is Gateway
   # API. httproute.yaml replicates the prefix-strip the nginx template does.
@@ -62,33 +62,7 @@ backend:
         authentication:
           api_url: http://llama-cpp-service.llama-cpp.svc.cluster.local:8080/v1
           api_key: none
-    workflows:
-      - id: holmes-rca
-        name: Holmes RCA on critical alerts
-        description: >-
-          Ask HolmesGPT to investigate every critical alert and attach the
-          evidence-based root cause to the alert.
-        triggers:
-          - type: alert
-            filters:
-              - key: severity
-                value: critical
-        actions:
-          - name: holmes-investigate
-            provider:
-              type: http
-              with:
-                url: http://holmes-holmes.holmesgpt.svc.cluster.local/api/chat
-                method: POST
-                body:
-                  ask: >-
-                    Investigate this Kubernetes alert and state the root cause
-                    with the evidence you found, then one recommended fix.
-                    Alert: {{ alert.name }}. Namespace: {{ alert.namespace }}.
-                    Description: {{ alert.description }}.
-            enrich_alert:
-              - key: ai_rca
-                value: "{{ results.body.analysis }}"
+    workflows: []
 
 frontend:
   enabled: true


### PR DESCRIPTION
Keep dispatched every critical alert to Holmes even though Holmes is parked. Remove that automatic workflow. Alert ingestion remains enabled, and investigations remain an explicit operator action.

The chart hashes the workflow list into the backend pod template, so this rolls the backend. Source inspection of the deployed Keep 0.52.1 confirms that startup removes previously provisioned workflows when none remain configured; removing YAML alone is not being assumed sufficient.

Validation: rendered backend has no workflow directory or inline workflow, the `keep-workflows` ConfigMap is absent, and the workflow checksum changes. After merge, verify the old workflow disappears and alert ingestion continues.
