### PR TITLE
Fix snapshot replicas, controller resources, and database VPA coverage

### DIFF
--- a/infrastructure/controllers/external-secrets/values.yaml
+++ b/infrastructure/controllers/external-secrets/values.yaml
@@ -5,3 +5,9 @@ certController:
   create: false
 webhook:
   create: false
+resources:
+  requests:
+    cpu: 25m
+    memory: 128Mi
+  limits:
+    memory: 512Mi

--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -104,6 +104,12 @@ extraConfig:
 
 # Must match the README seed flag, or a fresh bootstrap leaves envoy holding zero listeners.
 envoy:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 128Mi
+    limits:
+      memory: 1Gi
   xdsMode: split
 
 # Gateway API Support

--- a/infrastructure/storage/snapshot-controller/values.yaml
+++ b/infrastructure/storage/snapshot-controller/values.yaml
@@ -1,21 +1,23 @@
-# Standard values for generic snapshot-controller
-# Using Piraeus/Linbit chart which is the standard distribution
-
-replicaCount: 2
-
-image:
-  repository: registry.k8s.io/sig-storage/snapshot-controller
-  tag: v8.6.0
-
-affinity:
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-    - weight: 100
-      podAffinityTerm:
-        labelSelector:
-          matchExpressions:
-          - key: app.kubernetes.io/name
-            operator: In
-            values:
-            - snapshot-controller
-        topologyKey: kubernetes.io/hostname
+controller:
+  replicaCount: 2
+  image:
+    repository: registry.k8s.io/sig-storage/snapshot-controller
+    tag: v8.6.0
+  resources:
+    requests:
+      cpu: 25m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: snapshot-controller
+            topologyKey: topology.kubernetes.io/zone
+  pdb:
+    maxUnavailable: 1
+    unhealthyPodEvictionPolicy: AlwaysAllow

--- a/my-apps/development/gitea/vpa.yaml
+++ b/my-apps/development/gitea/vpa.yaml
@@ -39,7 +39,7 @@ spec:
       # Fixed-size metrics sidecar — not VPA-managed.
       - containerName: postgres-exporter
         mode: "Off"
-      - containerName: "*"
+      - containerName: postgres
         controlledResources: ["cpu", "memory"]
         controlledValues: RequestsOnly
         maxAllowed:

--- a/my-apps/development/temporal/vpa.yaml
+++ b/my-apps/development/temporal/vpa.yaml
@@ -18,7 +18,7 @@ spec:
       # Fixed-size metrics sidecar — not VPA-managed.
       - containerName: postgres-exporter
         mode: "Off"
-      - containerName: "*"
+      - containerName: postgres
         controlledResources: ["cpu", "memory"]
         controlledValues: RequestsOnly
         maxAllowed:

--- a/my-apps/home/paperless-ngx/vpa.yaml
+++ b/my-apps/home/paperless-ngx/vpa.yaml
@@ -17,7 +17,7 @@ spec:
       # Fixed-size metrics sidecar — not VPA-managed.
       - containerName: postgres-exporter
         mode: "Off"
-      - containerName: "*"
+      - containerName: postgres
         controlledResources: ["cpu", "memory"]
         controlledValues: RequestsOnly
         maxAllowed:

--- a/my-apps/media/immich/deployment-machine-learning.yaml
+++ b/my-apps/media/immich/deployment-machine-learning.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: immich

--- a/my-apps/media/immich/vpa.yaml
+++ b/my-apps/media/immich/vpa.yaml
@@ -64,3 +64,25 @@ spec:
         maxAllowed:
           cpu: "1"
           memory: 2Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: immich-postgres
+  namespace: immich
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: immich-postgres
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: postgres
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "2"
+          memory: 2Gi

--- a/scripts/tests/test_monitoring_contract.py
+++ b/scripts/tests/test_monitoring_contract.py
@@ -18,11 +18,21 @@ def healthy_objects():
             {"kind": "Service", "metadata": {"name": service, "namespace": "kube-system", "labels": {"app": service}},
              "spec": {"ports": [{"name": "metrics", "targetPort": "prometheus"}]}},
         ])
-    for kind, name in [("DaemonSet", "kube-prometheus-stack-prometheus-node-exporter"),
-                       ("Deployment", "kube-prometheus-stack-kube-state-metrics")]:
-        objects.append({"kind": kind, "metadata": {"name": name, "namespace": "prometheus-stack"},
+    for kind, namespace, name in [
+        ("DaemonSet", "prometheus-stack", "kube-prometheus-stack-prometheus-node-exporter"),
+        ("Deployment", "prometheus-stack", "kube-prometheus-stack-kube-state-metrics"),
+        ("DaemonSet", "kube-system", "cilium-envoy"),
+        ("Deployment", "external-secrets", "external-secrets"),
+        ("Deployment", "snapshot-controller", "snapshot-controller"),
+    ]:
+        objects.append({"kind": kind, "metadata": {"name": name, "namespace": namespace},
                         "spec": {"template": {"spec": {"containers": [{"name": "exporter", "resources": {
                             "requests": {"cpu": "50m", "memory": "128Mi"}, "limits": {"memory": "256Mi"}}}]}}}})
+    snapshot = objects[-1]["spec"]
+    snapshot["replicas"] = 2
+    snapshot["template"]["spec"]["affinity"] = {"podAntiAffinity": {
+        "preferredDuringSchedulingIgnoredDuringExecution": [{"weight": 100,
+            "podAffinityTerm": {"topologyKey": "topology.kubernetes.io/zone"}}]}}
     return objects
 
 
@@ -51,6 +61,16 @@ class MonitoringContractTests(unittest.TestCase):
         objects = healthy_objects()
         objects[0]["spec"]["namespaceSelector"]["matchNames"] = ["gateway"]
         self.assertTrue(contract.validate(objects))
+
+    def test_ignored_snapshot_replica_or_affinity_values_fail(self):
+        for field in ["replicas", "affinity"]:
+            objects = healthy_objects()
+            spec = objects[-1]["spec"]
+            if field == "replicas":
+                spec["replicas"] = 1
+            else:
+                spec["template"]["spec"].pop("affinity")
+            self.assertTrue(contract.validate(objects))
 
     def test_ignored_helm_resource_values_fail(self):
         for resources in [None, {}, {"limits": {"memory": "256Mi"}}]:

--- a/scripts/validate-monitoring-contract.py
+++ b/scripts/validate-monitoring-contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check Cilium scrape discovery and exporter resources in rendered manifests."""
+"""Check Cilium discovery and core controller baselines in rendered manifests."""
 import argparse
 from pathlib import Path
 
@@ -39,14 +39,26 @@ def validate(objects):
         endpoints = spec.get("endpoints", [])
         if not endpoints or any(e.get("port") not in ports for e in endpoints):
             errors.append(f"{monitor_name}: endpoint must reference a named Service port")
-    for kind, name in [
-        ("DaemonSet", "kube-prometheus-stack-prometheus-node-exporter"),
-        ("Deployment", "kube-prometheus-stack-kube-state-metrics"),
+    for kind, namespace, name in [
+        ("DaemonSet", "prometheus-stack", "kube-prometheus-stack-prometheus-node-exporter"),
+        ("Deployment", "prometheus-stack", "kube-prometheus-stack-kube-state-metrics"),
+        ("DaemonSet", "kube-system", "cilium-envoy"),
+        ("Deployment", "external-secrets", "external-secrets"),
+        ("Deployment", "snapshot-controller", "snapshot-controller"),
     ]:
-        workload = index.get((kind, "prometheus-stack", name))
+        workload = index.get((kind, namespace, name))
         if not workload:
             errors.append(f"{name}: workload was not rendered")
             continue
+        if name == "snapshot-controller":
+            pod_spec = workload["spec"]["template"]["spec"]
+            spread = pod_spec.get("affinity", {}).get("podAntiAffinity", {}).get(
+                "preferredDuringSchedulingIgnoredDuringExecution", [])
+            if str(workload["spec"].get("replicas", 1)) != "2":
+                errors.append("snapshot-controller: expected two rendered replicas")
+            if not any(t.get("podAffinityTerm", {}).get("topologyKey") ==
+                       "topology.kubernetes.io/zone" for t in spread):
+                errors.append("snapshot-controller: physical-host spreading preference is missing")
         for container in workload["spec"]["template"]["spec"]["containers"]:
             resources = container.get("resources") or {}
             requests, limits = resources.get("requests") or {}, resources.get("limits") or {}
@@ -78,7 +90,7 @@ def main():
     for error in errors:
         print(f"ERROR: {error}")
     if not errors:
-        print("Cilium metrics Services match their monitors; exporter resource baselines are present.")
+        print("Cilium metrics discovery and core controller resource/replica baselines pass.")
     return int(bool(errors))
 
 


### PR DESCRIPTION
The replica audit found snapshot-controller configured for two replicas in values but running one: chart 5.2.0 reads replicas, image and affinity under `controller`. Move those settings to the actual chart keys, prefer separate physical-host zones, and allow one voluntary disruption with two controller replicas.

Add explicit resource requests and memory limits for snapshot-controller, External Secrets and Cilium Envoy, which were BestEffort. Initial requests are 25m CPU/128Mi memory; memory limits are 512Mi for the two controllers and 1Gi for Envoy. These are initial baselines to tune against usage, not Guaranteed QoS or new CPU throttles.

Add the missing Immich Postgres VPA within its existing 2Gi memory limit. Name Postgres explicitly in the Gitea, Paperless and Temporal policies; exporters already have Off overrides. Temporal Postgres stays recommendation-only. Use Recreate for Immich ML so rollouts cannot overlap consumers of its RWO cache on different nodes.

Validation: all seven affected apps render; aggregate VPA validation reports zero errors/warnings; seven discovery/baseline regression tests and all script unit tests pass. CI now rejects ignored snapshot replica/affinity settings and missing controller resources. No PVC identity, StorageClass or backup configuration changes.

After merge, verify snapshot-controller is 2/2 on separate hosts, all affected controllers are Ready, Immich receives a recommendation, and its rollout completes. Replica spread is a preference; storage and control-plane availability remain separate constraints.
