### PR TITLE
Align versions and correct the audit follow-up checks

### DIFF
--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -30,13 +30,13 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Match the binaries bundled in Argo CD v3.5.1. A render that only passes
+  # Match the binaries bundled in Argo CD v3.5.2. A render that only passes
   # with newer or older tools is not proof that repo-server can deploy it.
   # v3.5.0 dropped Helm 3 entirely — repo-server renders with Helm 4.
   KUSTOMIZE_VERSION: 5.8.1
   HELM_VERSION: 4.2.1
   KUBECONFORM_VERSION: v0.7.0
-  KUBERNETES_VERSION: 1.36.3
+  KUBERNETES_VERSION: 1.36.4
 
 jobs:
   argocd-structure:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ wait for all the Applications it generates; those reconcile independently. See
 | Kubernetes | `v1.36.4` | `omni/cluster-template/cluster-template-prod-v2.yaml` |
 | Cilium | `1.20.1` | `infrastructure/networking/cilium/kustomization.yaml` |
 | Gateway API CRDs | `v1.6.1` | bootstrap commands below |
-| ArgoCD Helm chart | `10.7.1` (Argo CD `v3.5.2`) | `scripts/bootstrap-argocd.sh` |
+| ArgoCD Helm chart | `10.8.0` (Argo CD `v3.5.2`) | `scripts/bootstrap-argocd.sh` |
 | Proxmox provider | `v0.2.0@sha256:c0d068…` | `omni/proxmox-providers/docker-compose.yml` |
 
 Keep the Omni server and local `omnictl` on the **same** release — mismatched versions fail with obscure gRPC errors.
@@ -307,7 +307,7 @@ kubectl get applications -n argocd -w
 kubectl get applications -n argocd \
   -o custom-columns=NAME:.metadata.name,WAVE:.metadata.annotations.argocd\\.argoproj\\.io/sync-wave,STATUS:.status.sync.status
 
-# (Optional) ArgoCD UI — admin password is pre-configured via the bootstrap Helm values
+# (Optional) ArgoCD UI — bootstrap preserves the configured password stored in 1Password
 kubectl port-forward svc/argocd-server -n argocd 8080:443
 # open https://localhost:8080
 ```

--- a/docs/audits/2026-09-05-architecture-audit.md
+++ b/docs/audits/2026-09-05-architecture-audit.md
@@ -27,9 +27,31 @@ map, evidence limits, documentation inventory, and downloadable resource lists.
 | [#2238](https://github.com/mitchross/talos-argocd-proxmox/pull/2238) | Retire Fizzy and Mailpit | Merged; removal reconciled |
 | [#2241](https://github.com/mitchross/talos-argocd-proxmox/pull/2241) | Cilium metrics and exporter resources | Merged; 14 Cilium targets up |
 | [#2242](https://github.com/mitchross/talos-argocd-proxmox/pull/2242) | Retain parked Zomboid, correct PDB | Merged; zero replicas and both claims retained |
-| [#2243](https://github.com/mitchross/talos-argocd-proxmox/pull/2243) | Remove Headlamp Secret read permission | Prepared; verify authorization after merge |
-| [#2244](https://github.com/mitchross/talos-argocd-proxmox/pull/2244) | Remove automatic Keep-to-Holmes calls | Prepared; verify workflow deprovisioning after merge |
-| [#2245](https://github.com/mitchross/talos-argocd-proxmox/pull/2245) | Snapshot replicas, controller resources, VPA coverage | Prepared; verify rollout and placement after merge |
+| [#2243](https://github.com/mitchross/talos-argocd-proxmox/pull/2243) | Remove Headlamp Secret read permission | Merged; explicit authorization reviews deny Secrets and allow pods/logs |
+| [#2244](https://github.com/mitchross/talos-argocd-proxmox/pull/2244) | Remove automatic Keep-to-Holmes calls | Merged; previous Holmes workflow is marked deleted in Keep |
+| [#2245](https://github.com/mitchross/talos-argocd-proxmox/pull/2245) | Snapshot replicas, controller resources, VPA coverage | Merged; snapshot controller has two healthy pods on separate hosts |
+
+The dependency pass merged 15 of the 16 requested updates. PostHog
+[#2249](https://github.com/mitchross/talos-argocd-proxmox/pull/2249) is held because
+the proposed feature-flags image queries a database column that is absent in the
+running database. Its application and schema need a coordinated upgrade.
+[#2237](https://github.com/mitchross/talos-argocd-proxmox/pull/2237) now includes the
+GPU replacement disk finding and the single-control-plane recovery correction.
+Talos remains 1.13.9 and Kubernetes remains 1.36.4 until the separate live rollout.
+
+After these merges, Grafana is healthy on `13.2.1-distroless`, all 97 Prometheus
+targets are up (including 14 Cilium targets), and VPA has 120 recommendations
+across 124 policies. Immich Postgres now has a recommendation. These are live
+checks at this checkpoint, not availability guarantees.
+
+PostHog's pinned monolith image was built June 15 and its pinned node image
+March 31; the proposed Rust images were built September 4. The new feature-flags
+query references `feature_flags_teamfeatureflagsconfig.property_matching_version`.
+The live schema lacks that column, and its feature-flags migration history ends
+at `0010`. A coordinated upgrade must bring the monolith, node services and
+schema into agreement; a green manifest render does not validate that contract.
+See the [application upgrade checklist](https://github.com/mitchross/talos-argocd-proxmox/blob/main/my-apps/development/posthog/UPGRADE.md)
+before resuming that PR. No production migration was run.
 
 Original findings below refer to the dated evidence snapshot unless marked
 resolved. Further work includes bootstrap failure handling, narrowed Argo diff
@@ -190,12 +212,14 @@ behavior, so adopting them is not a harmless annotation cleanup.
 
 **Priority: P2.** `scripts/bootstrap-argocd.sh` accepts any Helm failure if an
 existing argocd-server Deployment is Available. An old healthy server does not
-prove the requested installation succeeded. The same script seeds a fixed bcrypt
-admin-password hash. A hash is not a plaintext password disclosure, but it is a
-reusable bootstrap credential and allows offline guessing.
+prove the requested installation succeeded.
 
-**Fix:** remove the committed credential override, use a fresh per-install secret
-or the existing documented 1Password path, and preserve the actual Helm failure.
+**Owner clarification:** the bootstrap password setting intentionally preserves
+the login stored in 1Password across rebuilds, and Argo is internal-only. The
+initial proposal to replace it with a generated password was withdrawn from
+PR #2247. Preserve this authentication behavior.
+
+**Fix:** distinguish actual Helm failures from the known rerun ownership conflict.
 If tolerating a known SSA ownership conflict, match that specific error and verify
 the intended resources/version before proceeding. Exercise first install,
 successful rerun, known conflict, and an unrelated failure with shell-command

--- a/docs/domains/argocd/argocd.md
+++ b/docs/domains/argocd/argocd.md
@@ -216,7 +216,7 @@ repo-server. With Argo CD `v3.5.2`, Cluster CI currently pins:
 | Kustomize | `5.8.1` |
 | Helm | `4.2.1` |
 | Kubeconform | `0.7.0` |
-| Kubernetes schema | `1.36.3` |
+| Kubernetes schema | `1.36.4` |
 
 Argo CD 3.5 already uses Helm 4. Keep CI and local tooling aligned when
 upgrading it. The Kubernetes schema pin above is separate from the cluster's

--- a/infrastructure/controllers/argocd/kustomization.yaml
+++ b/infrastructure/controllers/argocd/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 helmCharts:
   - name: argo-cd
     repo: https://argoproj.github.io/argo-helm
-    version: "10.8.0" # Pinned chart; appVersion v3.5.1
+    version: "10.8.0"
     releaseName: argocd
     namespace: argocd
     valuesFile: values.yaml

--- a/infrastructure/controllers/kopiur-operator/kustomization.yaml
+++ b/infrastructure/controllers/kopiur-operator/kustomization.yaml
@@ -23,7 +23,7 @@ helmCharts:
     valuesFile: values.yaml
     # Chart kubeVersion floor is >=1.32; without this, helm templates with default capabilities (v1.31) and the render fails.
     # Keep loosely in step with the real cluster version (omni/cluster-template/cluster-template.yaml).
-    kubeVersion: "1.36.3"
+    kubeVersion: "1.36.4"
 
 # Upstream RBAC gap: kopiur-mover gets `*/status` but not the parent resources, so movers 403 and a
 # Restore sits in "Restoring" with no status. Drop once upstream fixes it.

--- a/my-apps/development/headlamp/README.md
+++ b/my-apps/development/headlamp/README.md
@@ -5,15 +5,19 @@ name is historical; `metrics-role.yaml` grants read-only workload, metrics, and
 infrastructure visibility. Its explicit core resource list excludes Secrets and
 proxy subresources. The Secrets screen is therefore unavailable to this identity.
 
-After syncing the role change, verify from the operator workstation:
+After syncing the role change, verify from the repository root:
 
 ```bash
-kubectl auth can-i get secrets --all-namespaces --as=system:serviceaccount:kube-system:headlamp-admin
-kubectl auth can-i get pods --all-namespaces --as=system:serviceaccount:kube-system:headlamp-admin
-kubectl auth can-i get pods --subresource=log --all-namespaces --as=system:serviceaccount:kube-system:headlamp-admin
+python3 scripts/check-headlamp-access.py
 ```
 
-Expected results: `no`, `yes`, `yes`. Existing login remains usable. The current
+Expected results: Secrets denied, pods allowed, pod logs allowed. The script
+sends non-persistent SubjectAccessReviews naming the ServiceAccount explicitly.
+Through this cluster's Omni proxy, `kubectl auth can-i --as` returned the
+operator's permission instead of testing the requested identity; do not use
+that result as evidence that Headlamp can read Secrets.
+
+Existing login remains usable. The current
 `token-secret.yaml` still supplies a long-lived login token; replacing that login
 method is separate work and must not strand the operator without access.
 

--- a/scripts/check-headlamp-access.py
+++ b/scripts/check-headlamp-access.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Check Headlamp's RBAC through explicit, non-persistent SubjectAccessReviews."""
+import json
+import subprocess
+
+
+def main():
+    failures = 0
+    for resource, subresource, expected in [
+        ("secrets", "", False), ("pods", "", True), ("pods", "log", True)
+    ]:
+        attributes = {"group": "", "verb": "get", "resource": resource}
+        if subresource:
+            attributes["subresource"] = subresource
+        review = {
+            "apiVersion": "authorization.k8s.io/v1",
+            "kind": "SubjectAccessReview",
+            "spec": {
+                "user": "system:serviceaccount:kube-system:headlamp-admin",
+                "groups": ["system:serviceaccounts", "system:serviceaccounts:kube-system",
+                           "system:authenticated"],
+                "resourceAttributes": attributes,
+            },
+        }
+        result = subprocess.run(
+            ["kubectl", "create", "--raw",
+             "/apis/authorization.k8s.io/v1/subjectaccessreviews", "-f", "-"],
+            input=json.dumps(review), capture_output=True, text=True, check=True,
+        )
+        status = json.loads(result.stdout)["status"]
+        allowed = status["allowed"]
+        name = resource + ("/" + subresource if subresource else "")
+        print(f"get {name}: {'allowed' if allowed else 'denied'}")
+        failures += allowed != expected or bool(status.get("evaluationError"))
+    return int(bool(failures))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Bring the README, bootstrap references and render versions into agreement after the dependency updates. Argo uses chart 10.8.0; CI and the kopiur render target the running Kubernetes 1.36.4. The Talos/Kubernetes upgrade remains in #2237.

Correct the audit's password advice: preserve the existing Argo login stored in 1Password. Also replace Headlamp's misleading impersonation check with explicit authorization reviews that work through the Omni proxy.

Record the live results and why PostHog #2249 is held: its new feature-flags image requires a database column that is missing.

Validation: 60 script tests, strict docs build, kopiur render, and live Headlamp authorization checks pass. Grafana is healthy, all 97 scrape targets are up, and Keep's former Holmes workflow is marked deleted.
