### PR TITLE
Give workers clear roles and prefer the HPs for tunnels

### DIFF
--- a/docs/domains/scheduling/vpa-and-topology.md
+++ b/docs/domains/scheduling/vpa-and-topology.md
@@ -105,12 +105,44 @@ The active Omni template uses physical-host zone labels:
 | Threadripper | GPU worker | `house` |
 | Shed HP | Worker behind the media bridge | `shed` |
 
-Cloudflared uses soft `ScheduleAnyway` hostname spread. Kubernetes hostnames
-identify VMs, so the SFF's two nodes are distinct hostnames but the same physical
-failure domain. Use physical-host placement when replicas must survive a chassis
-loss. Soft spread prefers distribution without guaranteeing it or overriding
-storage, affinity and capacity constraints. Check live labels after syncing Omni;
-a Git edit alone does not update them.
+Cloudflared uses soft `ScheduleAnyway` spread and preferred anti-affinity over
+`topology.kubernetes.io/zone`, so two VMs on the SFF count as one physical host.
+Its preferred node affinity favors the `general` worker pool. These are preferences:
+other eligible workers remain usable when the HPs lack room, and several tunnel
+pods can share a surviving host. Verify actual placement; this is not a guarantee
+that every replica occupies a different chassis.
+
+### What each worker is for
+
+The Omni template declares a separate `node.vanillax.dev/pool` label:
+
+| Worker | Pool | Intended job |
+|---|---|---|
+| HP SFF and HP Elite | `general` | Everyday services and selected application state |
+| Threadripper | `gpu` | GPU workloads and selected heavy jobs |
+| Shed HP Micro | `edge` | Attached devices and permitted edge jobs |
+| Dell | `disposable` | Temporary, restartable work after required state is relocated |
+
+These labels describe intent; existing apps and Longhorn replicas are not moved
+by a label alone. In particular, the Dell still holds real data. Cloudflared is
+the first consumer and uses a soft preference. No new taints, hard app constraints,
+storage tags or control-plane scheduling changes accompany these labels.
+
+Check live labels after syncing the Omni template; merging Git does not itself
+change allocated machines. Finish the active Talos upgrade before applying another
+template change. Confirm the Omni sync preview contains the expected label changes
+without machine replacement, then check:
+
+```sh
+kubectl get nodes -L node.vanillax.dev/pool,topology.kubernetes.io/zone
+kubectl -n cloudflared get pods -o wide
+```
+
+Expected labels match the table, and all three tunnel replicas become Ready after
+the ordinary Deployment rollout. If the labels are not applied yet, preferred
+affinity still allows the tunnel pods to schedule. Rolling back the Deployment
+preference is independent of reverting the Omni labels. A label change is not a
+request to drain workers or re-provision disks.
 
 Replicated critical workloads should pair spread with a
 `PodDisruptionBudget` using `maxUnavailable: 1` and

--- a/infrastructure/networking/cloudflared/deployment.yaml
+++ b/infrastructure/networking/cloudflared/deployment.yaml
@@ -15,11 +15,10 @@ spec:
       labels:
         app: cloudflared
     spec:
-      # Soft spread keeps ingress replicas balanced while still permitting all
-      # three to run during a node outage.
+      # Spread across physical hosts; permit co-location when a host is unavailable.
       topologySpreadConstraints:
         - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
+          topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: ScheduleAnyway
           # Compare only pods from the same rollout. Old/new ReplicaSets
           # otherwise distort skew while a Deployment is replacing pods.
@@ -32,6 +31,14 @@ spec:
             matchLabels:
               app: cloudflared
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node.vanillax.dev/pool
+                    operator: In
+                    values: [general]
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -42,7 +49,7 @@ spec:
                       operator: In
                       values:
                         - cloudflared
-                topologyKey: kubernetes.io/hostname
+                topologyKey: topology.kubernetes.io/zone
       containers:
         - name: cloudflared
           image: cloudflare/cloudflared:2026.8.3 # renovate: docker=cloudflare/cloudflared

--- a/omni/cluster-template/cluster-template-prod-v2.yaml
+++ b/omni/cluster-template/cluster-template-prod-v2.yaml
@@ -138,6 +138,7 @@ patches:
       # removed gpu-network-dhcp note under gpu-workers.
       nodeLabels:
         node.vanillax.dev/class: hp-micro-worker
+        node.vanillax.dev/pool: edge
         # Own failure domain: the shed's wifi link, shared with nothing else.
         topology.kubernetes.io/zone: shed
         node.vanillax.dev/link: wifi
@@ -208,6 +209,7 @@ patches:
       # see the removed gpu-network-dhcp note under gpu-workers.
       nodeLabels:
         node.vanillax.dev/class: hp-sff-worker
+        node.vanillax.dev/pool: general
         # Own failure domain: a separate box from the Threadripper (house).
         topology.kubernetes.io/zone: hp-sff
         node.vanillax.dev/link: wired
@@ -273,6 +275,7 @@ patches:
     machine:
       nodeLabels:
         node.vanillax.dev/class: hp-elite-worker
+        node.vanillax.dev/pool: general
         topology.kubernetes.io/zone: hp-elite
         node.vanillax.dev/link: wired
       kubelet:
@@ -333,6 +336,7 @@ patches:
       # hang bug. Plain DHCP-on-all-links; never pin a NIC name.
       nodeLabels:
         node.vanillax.dev/class: dell-worker
+        node.vanillax.dev/pool: disposable
         # Own failure domain: a separate box from the Threadripper and the HPs.
         topology.kubernetes.io/zone: dell
         node.vanillax.dev/link: wired
@@ -398,6 +402,7 @@ patches:
         gpu-worker: "true"
         nvidia.com/gpu: "true"
         node.vanillax.dev/gpu-class: rtx-3090
+        node.vanillax.dev/pool: gpu
         topology.kubernetes.io/zone: house
 - name: longhorn-node-disks
   inline:


### PR DESCRIPTION
Give the workers simple job labels: SFF and Elite are general, Threadripper is GPU, the shed is edge, and Dell is disposable. Cloudflared prefers the general workers and spreads by physical-host zone, so the SFF control plane and worker count as one box.

These are soft preferences. All three tunnel replicas can still use other eligible workers when needed. The labels do not relocate existing applications or Longhorn data. Dell still holds real data, and GPU-hosted flash volumes still need a separate availability plan.

The Talos 1.14 / Kubernetes 1.37 upgrade is now complete, so the upgrade hold is removed. All PR checks pass. Live pre-merge checks found three healthy tunnel replicas on SFF, Elite and Dell; the new pool labels are not applied yet.

After merge, Argo rolls out the tunnel Deployment. Preview and sync the Omni template separately to apply worker labels, checking that the diff contains the intended changes. Then verify live labels and tunnel placement. No new taints, machine replacements or disk moves are part of this PR.

Validation: 12 Omni contract tests, production template validation, Cloudflared render/schema validation and strict docs build passed. Post-merge placement verification remains to be done.
