### PR TITLE
Let Longhorn finish copying volumes so Talos can upgrade

### DIFF
--- a/docs/audits/2026-09-05-upgrade-and-disks.md
+++ b/docs/audits/2026-09-05-upgrade-and-disks.md
@@ -88,7 +88,7 @@ healthy. The V1 volume controller waits for all scheduled, non-failed replicas
 to run before updating the engine's replica address map; the replica controller
 counts started, not-yet-healthy replicas against the concurrency limit.
 
-The [rebuild setting](../../infrastructure/storage/longhorn/node-failure-settings.yaml)
+The [rebuild setting](https://github.com/mitchross/talos-argocd-proxmox/blob/main/infrastructure/storage/longhorn/node-failure-settings.yaml)
 is raised from one to two slots per node to release this observed circular
 wait. This keeps the last-replica drain protection in place. It is a rollout
 recovery change, not proof that a full restore can sustain two simultaneous

--- a/docs/audits/2026-09-05-upgrade-and-disks.md
+++ b/docs/audits/2026-09-05-upgrade-and-disks.md
@@ -73,3 +73,33 @@ Kopiur snapshot for affected application data, and choose either a verified VM
 disk migration or a tested restore to new storage. Keep the source until the
 replacement passes application checks. Do not combine disk migration with the
 Talos rollout: finish one change and verify it before starting the other.
+
+## Live rollout: Longhorn rebuild queue
+
+During the rollout, the Dell drain stopped at its Longhorn instance-manager
+PDB. Application pods had left the node, but Longhorn's eviction tickets kept
+five volumes attached while their replacement replicas waited to start.
+
+Two parked SwarmUI volumes formed a circular wait: `swarmui-dlbackend` held the
+GPU node's only rebuild slot while waiting for a replica on the Elite;
+`swarmui-output` held the Elite's only slot while waiting for the GPU node.
+Both engines reported no active rebuild. Their original Dell replicas remained
+healthy. The V1 volume controller waits for all scheduled, non-failed replicas
+to run before updating the engine's replica address map; the replica controller
+counts started, not-yet-healthy replicas against the concurrency limit.
+
+The [rebuild setting](../../infrastructure/storage/longhorn/node-failure-settings.yaml)
+is raised from one to two slots per node to release this observed circular
+wait. This keeps the last-replica drain protection in place. It is a rollout
+recovery change, not proof that a full restore can sustain two simultaneous
+rebuilds or that every possible queue deadlock is eliminated.
+
+After syncing, expect the new replicas to join their engines, complete rebuilding,
+and release the eviction tickets. The Dell should then finish its normal Omni
+upgrade. Watch volume health and disk latency while this happens. If extra
+concurrency causes faults or excessive latency, revert the setting through Git,
+pause the rollout, and inspect the affected engine before retrying. Reverting to
+one while the circular wait still exists can restore the blockage.
+
+Sources: [Longhorn 1.12.1 replica concurrency controller](https://github.com/longhorn/longhorn-manager/blob/v1.12.1/controller/replica_controller.go#L525),
+[volume startup gating](https://github.com/longhorn/longhorn-manager/blob/v1.12.1/controller/volume_controller.go#L2887).

--- a/infrastructure/storage/longhorn/node-failure-settings.yaml
+++ b/infrastructure/storage/longhorn/node-failure-settings.yaml
@@ -30,14 +30,14 @@ metadata:
 value: "block-for-eviction-if-contains-last-replica"
 
 ---
-# INTENTIONALLY 1: a mass-restore bootstrap overloads any engine on this hardware and faults
-# volumes faster than rebuilds drain them. Raise to 2-3 only after a passed DR drill shows headroom.
+# Two slots break the observed cross-node replica startup deadlock during drains.
+# Keep this bounded; mass-restore capacity still needs a separate drill.
 apiVersion: longhorn.io/v1beta2
 kind: Setting
 metadata:
   name: concurrent-replica-rebuild-per-node-limit
   namespace: longhorn-system
-value: "1"
+value: "2"
 
 ---
 apiVersion: longhorn.io/v1beta2


### PR DESCRIPTION
The Talos upgrade is stuck draining the Dell. Two parked SwarmUI volumes each hold a rebuild slot on one node and wait for a slot on the other. Longhorn keeps the original disks attached, so the applications and upgrade cannot move forward.

Allow two replica rebuilds per node to release that circular wait. Keep the existing protection that prevents draining the last healthy data copy. The audit note records the evidence, expected recovery, and rollback.

Validation: all CI checks passed, including manifest rendering/schema validation and the strict docs build. Argo synced the setting; blocked copies completed, all five Dell-held volume attachments cleared, and Longhorn released its PDB without manual deletion. Omni then upgraded the Dell, which returned Ready on Talos 1.14.0. A full restore at this concurrency has not been tested; that remains a separate check.
