### PR TITLE
Record the finished upgrade and refresh the lab map

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,10 +383,14 @@ Normal application PVC backups use **[kopiur](https://github.com/home-operations
 
 ## Cluster Upgrades & Talos 1.14 Notes
 
-The templates target Talos **1.14.0** and Kubernetes **1.37.0**. Committing or
-merging these files does not upgrade the running machines; Omni performs the
-rollout separately. See the [upgrade and disk review](docs/audits/2026-09-05-upgrade-and-disks.md)
-before applying the template to an existing cluster or using it for a rebuild.
+All six nodes were verified Ready on Talos **1.14.0** and Kubernetes **1.37.0**
+at **2026-09-06 01:48 UTC** (September 5 evening in Detroit). The templates,
+kopiur rendering target and Cluster CI already match those versions.
+
+The [upgrade results and disk review](docs/audits/2026-09-05-upgrade-and-disks.md)
+record the Longhorn fix and recovery checks. Merging a version change still
+does not upgrade the machines; Omni performs that rollout separately. The
+fresh GPU installation problem below remains open after this successful upgrade.
 
 ### Fresh GPU provisioning needs a disk-selection fix
 

--- a/docs/assets/lab-explorer.js
+++ b/docs/assets/lab-explorer.js
@@ -8,6 +8,7 @@
     root.dataset.ready = "true";
     const state = {host: "sff", tab: "disks", proposed: false, outage: "sff", network: "private"};
     const hosts = data.hosts;
+    const versionsChecked = data.runtimeVersionsCheckedAt.slice(0, 16).replace("T", " ") + " UTC";
     const getHost = id => hosts.find(h => h.id === id);
     const button = (action, value, text, active) => `<button type="button" data-action="${action}" data-value="${escape(value)}" aria-pressed="${active}">${escape(text)}</button>`;
     root.innerHTML = `
@@ -23,12 +24,12 @@
       <div class="lab-machines" id="lab-machines" aria-label="Choose a physical machine"></div>
       <section class="lab-detail" aria-label="Selected machine" id="lab-detail"></section>
       <section class="lab-detail" id="lab-network" aria-label="Network paths and addresses"></section>
-      <div class="lab-footer"><button type="button" class="lab-action" data-action="download">Download full inventory</button><span>Snapshot: ${escape(data.date)} · VM and physical-host IPs are separate.</span></div>`;
+      <div class="lab-footer"><button type="button" class="lab-action" data-action="download">Download full inventory</button><span>Hardware snapshot: ${escape(data.date)} · Versions checked: ${escape(versionsChecked)} · VM and physical-host IPs are separate.</span></div>`;
     const $ = selector => root.querySelector(selector);
 
     function renderNav() {
       $("#lab-role-toggle").innerHTML = button("mode","current","Audit snapshot",!state.proposed)+button("mode","proposed","Suggested jobs",state.proposed);
-      $("#lab-role-caption").textContent = state.proposed ? "Suggested roles only. These placement changes have not been applied." : "September 5 snapshot, before the Talos upgrade. Choose a machine to look inside.";
+      $("#lab-role-caption").textContent = state.proposed ? "Suggested roles only. These placement changes have not been applied." : "September 5 hardware snapshot, with node versions checked after the upgrade. Choose a machine to look inside.";
       $("#lab-machines").innerHTML = hosts.map(h => `
         <button type="button" class="lab-machine" data-action="host" data-value="${escape(h.id)}" data-kind="${escape(h.kind)}" aria-pressed="${h.id===state.host}">
           <span class="lab-machine-name">${escape(h.name)}</span>

--- a/docs/assets/lab-inventory-data.js
+++ b/docs/assets/lab-inventory-data.js
@@ -2,6 +2,7 @@ window.HOMELAB_INVENTORY = {
   "date": "2026-09-05",
   "assembledAt": "2026-09-05T21:34:13.664744+00:00",
   "sourceCommit": "cbda78a0",
+  "runtimeVersionsCheckedAt": "2026-09-06T01:48:49.025993+00:00",
   "hosts": [
     {
       "id": "sff",
@@ -59,8 +60,8 @@ window.HOMELAB_INVENTORY = {
               "size": "690 GiB"
             }
           ],
-          "talos": "Talos (v1.13.9)",
-          "kubernetes": "v1.36.4",
+          "talos": "Talos (v1.14.0)",
+          "kubernetes": "v1.37.0",
           "namespaces": [
             {
               "name": "1passwordconnect",
@@ -198,8 +199,8 @@ window.HOMELAB_INVENTORY = {
               "size": "100 GiB"
             }
           ],
-          "talos": "Talos (v1.13.9)",
-          "kubernetes": "v1.36.4",
+          "talos": "Talos (v1.14.0)",
+          "kubernetes": "v1.37.0",
           "namespaces": [
             {
               "name": "cert-manager",
@@ -302,8 +303,8 @@ window.HOMELAB_INVENTORY = {
               "size": "440 GiB"
             }
           ],
-          "talos": "Talos (v1.13.9)",
-          "kubernetes": "v1.36.4",
+          "talos": "Talos (v1.14.0)",
+          "kubernetes": "v1.37.0",
           "namespaces": [
             {
               "name": "cloudflared",
@@ -491,8 +492,8 @@ window.HOMELAB_INVENTORY = {
               "size": "120 GiB"
             }
           ],
-          "talos": "Talos (v1.13.9)",
-          "kubernetes": "v1.36.4",
+          "talos": "Talos (v1.14.0)",
+          "kubernetes": "v1.37.0",
           "namespaces": [
             {
               "name": "1passwordconnect",
@@ -743,8 +744,8 @@ window.HOMELAB_INVENTORY = {
               "size": "400 GiB"
             }
           ],
-          "talos": "Talos (v1.13.9)",
-          "kubernetes": "v1.36.4",
+          "talos": "Talos (v1.14.0)",
+          "kubernetes": "v1.37.0",
           "namespaces": [
             {
               "name": "1passwordconnect",
@@ -943,8 +944,8 @@ window.HOMELAB_INVENTORY = {
               "size": "850 GiB"
             }
           ],
-          "talos": "Talos (v1.13.9)",
-          "kubernetes": "v1.36.4",
+          "talos": "Talos (v1.14.0)",
+          "kubernetes": "v1.37.0",
           "namespaces": [
             {
               "name": "csi-driver-nfs",
@@ -1960,7 +1961,7 @@ window.HOMELAB_INVENTORY = {
     }
   ],
   "notes": [
-    "Host/disks from the September 5 SSH inventory; Kubernetes IPs were rechecked before page preparation; pod namespace placement is from the earlier audit snapshot.",
+    "Host/disks from the September 5 SSH inventory; Kubernetes IPs and node versions were rechecked at runtimeVersionsCheckedAt after the upgrade. Pod namespace placement and claims remain from the earlier audit snapshot.",
     "Disk capacity uses decimal GB/TB; VM allocations and RAM use GiB/MiB. Capacity bars are not disk-use measurements.",
     "NAS pool percentages use the SSH snapshot; the later dashboard uses different usable-capacity accounting.",
     "Suggested roles and outage walkthroughs are explanations, not applied policy or measured recovery tests."

--- a/docs/audits/2026-09-05-upgrade-and-disks.md
+++ b/docs/audits/2026-09-05-upgrade-and-disks.md
@@ -1,13 +1,55 @@
 # Talos upgrade and disk review
 
-Status: upgrade preparation, with a fresh-provisioning problem still open.
-No disks have been moved and no live Omni or Talos upgrade was performed during
-this review. The [physical inventory](2026-09-05-inventory.md) records the host
-and disk measurements; these recommendations do not change the running layout.
+Status: the live Talos 1.14.0 and Kubernetes 1.37.0 upgrades are complete.
+Fresh GPU provisioning still needs a disk-selection fix. No disks were moved.
+The [physical inventory](2026-09-05-inventory.md) records the host and disk
+measurements; the [interactive lab map](../lab.md) includes the verified versions.
+
+## Verified upgrade results
+
+Omni reported Talos complete at **00:55 UTC** and Kubernetes complete at
+**00:58 UTC on September 6, 2026**. The owner subsequently rebooted the GPU
+machine again. The following checks were taken after it returned, at
+**01:48 UTC** (September 5 evening in Detroit).
+
+| Check | Observed result |
+|---|---|
+| Nodes | All six Ready on Talos 1.14.0 and Kubernetes 1.37.0 |
+| Longhorn | 66 attached volumes healthy; 12 detached with unknown robustness; none faulted or degraded |
+| Networking | Cilium and Envoy each 6/6; all three Gateways accepted and programmed |
+| Storage controllers | TrueNAS CSI nodes 6/6 and controller 1/1; snapshot controller 2/2 |
+| GPU | One allocatable NVIDIA GPU; device plugin and llama.cpp Ready |
+| Metrics | All 97 Prometheus `up` series were 1, including etcd, Cilium, node-exporter and kube-state-metrics |
+| Applications | PostHog, Radar, Loki, Prometheus and Redlib recovered; Flatnotes remains the previously deferred Nomad issue |
+
+Argo reported 96 healthy Applications and one progressing Application
+(`my-apps-project-nomad`). `my-apps-immich` and `root` were healthy but OutOfSync;
+these checks do not claim every Application has converged. Readiness and storage
+health also do not substitute for a full data-integrity check or restore drill.
+
+The last GPU worker lock was removed after its first recovery. All machine sets
+then reported zero locked updates. An Omni worker lock did **not** cancel a
+Talos upgrade request already in flight; use it to hold subsequent work, and
+check the current machine operation before assuming maintenance has stopped.
+
+For a read-only recheck from an authenticated workstation:
+
+```bash
+kubectl get nodes -o wide
+kubectl get --raw /readyz
+kubectl -n longhorn-system get volumes.longhorn.io
+omnictl get talosupgradestatuses -o yaml
+omnictl get kubernetesupgradestatuses -o yaml
+```
+
+Expect Ready nodes, `ok` from the API, healthy attached volumes, and Omni's
+`lastupgradeversion` at the intended version with no upgrade error. If a node
+or volume regresses, inspect that failure before starting another rollout.
+The [recovery runbook](../disaster-recovery.md) owns recovery procedures.
 
 ## Upgrade findings
 
-The target is Omni/omnictl 1.11.0, provider `v0.2.0-3-g7cefedd`, Talos 1.14.0,
+The reviewed target is Omni/omnictl 1.11.0, provider `v0.2.0-3-g7cefedd`, Talos 1.14.0,
 and Kubernetes 1.37.0. Upgrade Omni before the provider that uses its new
 installation-media API. Check Omni's compatible Kubernetes versions, upgrade
 Talos while retaining the current Kubernetes version, verify node readiness,
@@ -45,7 +87,7 @@ state that a customized metrics listener keeps its configured endpoint.
 
 ## Disk placement follow-up
 
-The GPU VM's current ephemeral filesystem reports about 447.6 GiB total and
+The pre-upgrade GPU filesystem sample reported about 447.6 GiB total and
 272.9 GiB free, with 283 GiB of Longhorn volume capacity scheduled there.
 Simply changing its boot disk to 128 GiB would not preserve that layout. A
 smaller boot disk needs a separate allocation and restore plan for those volumes.
@@ -89,17 +131,39 @@ to run before updating the engine's replica address map; the replica controller
 counts started, not-yet-healthy replicas against the concurrency limit.
 
 The [rebuild setting](https://github.com/mitchross/talos-argocd-proxmox/blob/main/infrastructure/storage/longhorn/node-failure-settings.yaml)
-is raised from one to two slots per node to release this observed circular
-wait. This keeps the last-replica drain protection in place. It is a rollout
-recovery change, not proof that a full restore can sustain two simultaneous
+was raised from one to two slots per node in
+[PR #2268](https://github.com/mitchross/talos-argocd-proxmox/pull/2268). This
+released the observed circular wait and kept last-replica drain protection in
+place. It is a rollout recovery change, not proof that a full restore can sustain two simultaneous
 rebuilds or that every possible queue deadlock is eliminated.
 
-After syncing, expect the new replicas to join their engines, complete rebuilding,
-and release the eviction tickets. The Dell should then finish its normal Omni
-upgrade. Watch volume health and disk latency while this happens. If extra
-concurrency causes faults or excessive latency, revert the setting through Git,
-pause the rollout, and inspect the affected engine before retrying. Reverting to
-one while the circular wait still exists can restore the blockage.
+After Argo synced, the five held attachments cleared. Longhorn removed its own
+instance-manager PDB at **23:16:41 UTC on September 5**; Omni retried and the Dell
+returned Ready on Talos 1.14.0 at **23:17:47 UTC**. No PDB, replica, PVC or VM was
+manually deleted to make this happen.
+
+If extra concurrency causes faults or excessive latency in a later rollout,
+pause further work, inspect the affected engine, and revert the setting through
+Git when appropriate. Reverting to one while the circular wait still exists can
+restore the blockage. A full Kopiur restore at concurrency two remains untested.
 
 Sources: [Longhorn 1.12.1 replica concurrency controller](https://github.com/longhorn/longhorn-manager/blob/v1.12.1/controller/replica_controller.go#L525),
 [volume startup gating](https://github.com/longhorn/longhorn-manager/blob/v1.12.1/controller/volume_controller.go#L2887).
+
+## GPU maintenance still affects ordinary services
+
+The GPU worker's last flash replicas blocked its drain. Thirteen flash-tagged
+claims had no eligible second host, including storage used by PostHog, Radar,
+Prometheus and Loki. Some of those pods ran elsewhere: moving a pod does not
+move the only copy of its data off the GPU host.
+
+The owner rebooted the existing machine. It returned on Talos 1.14.0, and the
+temporary Longhorn faults cleared as storage services returned. A later owner
+reboot also recovered. No additional drain-policy PR was needed to finish this
+upgrade. These recoveries do not establish uninterrupted service during GPU
+maintenance or make a forced stop the maintenance procedure.
+
+The remaining work is to give selected ordinary services another eligible
+storage host, or define an intentional shutdown and restart sequence for their
+consumers. Keep this separate from the fresh-install disk-selection problem:
+the successful upgrade reused the existing installation.

--- a/docs/lab.md
+++ b/docs/lab.md
@@ -32,9 +32,11 @@ the application, route, volume and documentation CSVs. The
 ## What this page knows
 
 This is the **September 5, 2026 audit snapshot**, not a live monitoring screen.
-Host hardware and disks came from read-only SSH inspection; node IPs were checked
-again while this page was prepared. Pod placement and claims use the earlier
-audit snapshot, which includes applications subsequently retired. The
+Host hardware and disks came from read-only SSH inspection. Node IPs and software
+versions were checked again at **2026-09-06 01:48 UTC** after the
+[Talos and Kubernetes upgrade](audits/2026-09-05-upgrade-and-disks.md).
+Pod placement and claims still use the earlier audit snapshot, which includes
+applications subsequently retired. The
 "what if" view explains dependencies; it does not switch machines off or prove
 a measured recovery time.
 
@@ -47,5 +49,6 @@ change after reconnecting hardware.
 The complete sanitized page inventory is downloadable inside the explorer.
 Its source is [`lab-inventory-data.js`](assets/lab-inventory-data.js); it contains
 no disk serial numbers, credentials or raw diagnostic dumps. Update that snapshot
-and its date together after hardware moves. Keep measured state separate from
+and its date together after hardware moves; `runtimeVersionsCheckedAt` records
+the separate node-version check. Keep measured state separate from
 suggestions, and check the page at desktop and phone widths before publishing.

--- a/omni/README.md
+++ b/omni/README.md
@@ -165,7 +165,7 @@ currently in **beta**. Expect some limitations and potential bugs. Please
 report issues to the [upstream
 repository](https://github.com/siderolabs/omni-infra-provider-proxmox).
 
-### Concrete beta limitations (as of Talos 1.13 / Omni 1.9)
+### Proxmox provider and machine lifecycle
 
 These are things that hit me in practice — the generic "it's beta" line
 isn't enough to plan around.
@@ -179,17 +179,18 @@ isn't enough to plan around.
   Longhorn capacity. You can still plan
   storage as Longhorn replicas or use external storage (NFS to TrueNAS,
   RustFS S3) for stateful data.
-- **Extensions must be baked into the Talos image OR declared in the
-  cluster template.** You can't "install an extension" at runtime the
-  way you would a package. Changing extensions = image rebuild in Omni +
-  node replacement. This is especially relevant for NVIDIA driver
-  swaps (production → OSS), which require rebuilding the Talos image and
-  replacing the affected nodes.
-- **`machine.install.disk` is mandatory on Talos 1.13.** Without it,
-  fresh VMs provision but stay stuck in `UPGRADING` forever (see root
-  README). This is a Talos 1.13 LifecycleService change, not a provider
-  bug, but it surfaces through the provider first. The patch is already
-  in `omni/cluster-template/cluster-template.yaml`.
+- **Manage extensions through the cluster template.** They belong to the
+  Talos image, not a runtime package installation. Omni can update extensions
+  on an existing machine; a driver change does not inherently require deleting
+  its VM. Plan for the image rollout and check driver compatibility. See
+  [Omni extension management](https://docs.siderolabs.com/omni/infrastructure-and-extensions/install-talos-linux-extensions).
+- **Omni 1.11 owns install-disk selection.** Legacy `machine.install.disk`
+  patches no longer select it. An installed machine keeps its detected system
+  disk; fresh machines default to the smallest eligible disk. With this GPU
+  class that selects the 300 GB flash disk. Do not delete/reprovision the GPU VM
+  until selection is deterministic for a replacement UUID. The
+  [upgrade and disk review](../docs/audits/2026-09-05-upgrade-and-disks.md)
+  explains the resolver, machine-specific overrides and remaining fix.
 - **No VM migration on node failure.** If a Proxmox host dies, its VMs
   don't auto-migrate to another host. You'll need Proxmox HA separately
   (cluster-level, not Omni-level) for that.


### PR DESCRIPTION
The upgrade is finished: all six nodes run Talos 1.14.0 and Kubernetes 1.37.0. The README and lab map still described the preparation stage and showed the old node versions.

This updates the versions from the recovered cluster, records how #2268 unstuck Longhorn, and explains what happened during the GPU reboots. It also corrects the Omni README: extension changes do not require deleting a VM, and the old install-disk patch no longer selects the disk in Omni 1.11. Fresh GPU provisioning still needs its own fix.

Checked after recovery: all six nodes Ready, 66 attached Longhorn volumes healthy, all 97 Prometheus targets up, and the GPU, Cilium and CSI healthy. Argo, llama.cpp, Prometheus and Redlib returned HTTP 200; PostHog returned its login redirect. Flatnotes remains the known Nomad issue. The existing hardware and pod-placement snapshot keeps its original date; the version check has a separate timestamp.

Validation: strict MkDocs build, JavaScript syntax checks, and Brave rendering at desktop and phone widths. This PR changes documentation only; GitHub Pages publishes it after merge.
