### PR TITLE
fix(storage): stage Talos SELinux mount context with a GitOps canary

### DIFF
--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Reject inline executable YAML bodies
         run: bash ./scripts/validate-no-inline-scripts.sh
 
+      - name: Test scoped Longhorn PV mount-option migration
+        run: python3 -m unittest discover -s scripts/tests -p test_longhorn_mount_options.py -v
+
   truenas-csi-contract:
     name: TrueNAS CSI Contract
     runs-on: ubuntu-latest

--- a/docs/domains/storage/selinux-mount-context.md
+++ b/docs/domains/storage/selinux-mount-context.md
@@ -1,0 +1,144 @@
+# Talos 1.14 Longhorn SELinux mount context
+
+**Status:** staged remediation, pending a live canary remount. Local tests and
+rendering validate the manifests and migration logic; they do not prove runtime
+mount behavior. All deployment and remount changes go through reviewed GitOps
+PRs. This procedure does not require replacing PVCs or rebuilding the cluster.
+
+## Why the audit log floods
+
+The September 2026 survey found Talos 1.14 running SELinux in permissive mode on
+all six nodes. Busy processes accessing Longhorn filesystems produced audit
+records with `tcontext=system_u:object_r:unlabeled_t:s0`, `permissive=1`, and
+successful syscalls. The GPU worker's PostHog ClickHouse and radar-ng workers
+were prominent sources. The kernel dropped audit records when their rate
+exceeded 4096 messages per second. This is an audit-record limit, not a
+Kubernetes request limit or evidence that the recorded I/O failed.
+
+Talos's [v1.14 container policy](https://github.com/siderolabs/talos/blob/v1.14.0/internal/pkg/selinux/policy/selinux/services/cri.cil)
+allows container access to `ephemeral_t` and explicitly describes using CSI
+StorageClass mount options for this context. The intended mount option is:
+
+```text
+context=system_u:object_r:ephemeral_t:s0
+```
+
+`ephemeral_t` is a policy type name: it does not change volume durability. The
+option supplies the mounted filesystem's effective SELinux context without a
+recursive on-disk relabel. It does not provide separate labels for each pod.
+
+## What Git owns
+
+| Source | Responsibility |
+| --- | --- |
+| `infrastructure/storage/longhorn/storageclass-*.yaml` | Set the context for newly provisioned volumes in all four Longhorn classes. |
+| `infrastructure/storage/longhorn/values.yaml` | Disable the chart's generated StorageClass ConfigMap; ArgoCD directly owns the default `longhorn` class with its existing name and parameters. |
+| `infrastructure/storage/longhorn-selinux/policy.json` | Explicit namespace/claim allowlist and reconciliation mode. Initially only `posthog/clickhouse-data-clickhouse-0`. |
+| `infrastructure/storage/longhorn-selinux/scripts/reconcile.py` | Patch existing bound PV mount options while preserving other options and checking UID/resource version. |
+| Owning application's workload manifest | Stop and start consumers through separate replica-count PRs to obtain a fresh mount. |
+
+The independent `infrastructure-longhorn-selinux` Application is discovered by
+the infrastructure ApplicationSet at wave 4. Its Sync hook runs after its own
+RBAC and generated ConfigMaps exist. It can list and patch PVs; it cannot modify
+PVCs, pods, or workload replica counts. The script enforces the claim allowlist;
+RBAC permits PV patches cluster-wide because PV names change after restores.
+
+The script accepts only reviewed Longhorn classes, ext4 filesystems, and
+`ReadWriteOnce` or `ReadWriteOncePod` access. It preflights all selected volumes
+before writing and fails on conflicting SELinux options. Missing, unbound, and
+deleting claims are skipped, allowing a fresh cluster to provision normally.
+Check the hook's per-claim result: a successful hook can have skipped a target.
+Retries re-read PVs after a resource-version conflict. A multi-PV run is not a
+transaction: if a later API patch fails, earlier successful patches remain.
+
+**PVC immutability does not block this change.** The PVC's storage class,
+identity, binding, and capacity remain unchanged. Kubernetes permits updating
+`PV.spec.mountOptions`. StorageClass changes alone do not update existing PVs.
+
+## Roll out through PRs
+
+Prerequisites: Talos 1.14's policy, Longhorn filesystem volumes, access to ArgoCD
+and Longhorn status/logs, and a maintenance window for the selected application.
+For durable applications, check their existing kopiur backup health before the
+maintenance window. PostHog ClickHouse is intentionally backup-exempt in this
+repository; this procedure preserves its existing volume.
+
+1. **Merge the storage and migration PR after review.** Confirm the Longhorn
+   Application is synced, all four StorageClasses contain the option, and the
+   default class retains its original parameters. Confirm the
+   `infrastructure-longhorn-selinux` hook completes with an `updated` or
+   `unchanged` event for `posthog/clickhouse-data-clickhouse-0`. Inspect the
+   bound PV's manifest to verify the option. Do not proceed if it was skipped
+   or either Application failed to sync.
+2. **Open a canary stop PR.** In
+   `my-apps/development/posthog/data-layer/clickhouse.yaml`, change only the
+   `clickhouse` Deployment's `spec.replicas` from `1` to `0`. After the user
+   merges it and ArgoCD applies it, wait for every pod consuming the claim to
+   terminate and for the volume to fully unmount/unstage. Confirm Longhorn
+   reports it detached. PostHog ingestion/querying is unavailable during this
+   interval; dependent initialization hooks may wait or fail temporarily.
+3. **Open a separate canary start PR after detachment.** Restore `replicas: 1`
+   in the same manifest. Wait for ArgoCD to apply it, a fresh mount to succeed,
+   ClickHouse to become ready, and PostHog's initialization/migration hooks and
+   application operations to recover. Two commits merged before ArgoCD sees
+   the stopped state are insufficient.
+4. **Validate under real traffic.** Inspect the new mount's options and recent
+   audit records through read-only diagnostics. ClickHouse access to this
+   volume should no longer generate `unlabeled_t` AVCs. Confirm reads and
+   writes work. Kernel `audit_lost` is cumulative and will not reset; compare
+   increments over time. Other untreated volumes can still flood the node.
+5. **Expand in follow-up PRs only after the canary passes.** Add a small set
+   of explicit namespace/claim names to `policy.json`, let the hook update
+   their PVs, and repeat the stop/wait/start sequence in their owning apps.
+   For shared claims such as radar-ng tiles, identify every consumer and any
+   autoscaler or worker controller that can recreate pods. All consumers must
+   release the volume before starting any of them again.
+
+A rolling restart or a pod annotation does not guarantee CSI staging unmounts.
+The migration hook intentionally does not restart workloads or fight ArgoCD's
+replica reconciliation. Until the remount phases finish, existing mounted
+volumes can continue emitting the same audit messages.
+
+## Failure and rollback
+
+- **Hook rejects a target:** inspect its structured `failed` event. Correct the
+  allowlist or investigate its filesystem/options in a PR. Do not remove the
+  validation checks just to make the hook succeed.
+- **Volume does not detach:** leave the canary stopped and identify remaining
+  consumers or attachments. Do not force-delete pods, claims, or volumes.
+- **Fresh mount fails or application checks fail:** keep the affected workload
+  stopped through Git, set the migration policy's `mode` to `remove` for those
+  claims in a PR, and wait for the hook to remove this exact context option.
+  It preserves unrelated mount options. Then restore the workload's replica
+  count in another PR so it mounts with the prior options.
+- **Roll back the new-volume default too:** remove the option from the four
+  StorageClass manifests in a PR. Keep the default class directly owned by
+  ArgoCD. This does not undo mount options on already provisioned PVs; include
+  any affected new claims in the rollback allowlist and remount them as above.
+
+Simply deleting or reverting the migration Job does **not** undo its previous
+PV patches. `mode: plan` logs intended additions without writes; `apply` adds
+the context and `remove` removes it. Commit mode and allowlist changes through
+PRs. Stop rollout if the canary does not reduce its corresponding audit events;
+rebuilding the cluster with the same mount configuration would not address the
+cause.
+
+## Local validation and upstream references
+
+Run these commands from the repository root; they do not change the cluster:
+
+```bash
+python3 -m unittest discover -s scripts/tests -p test_longhorn_mount_options.py
+kustomize build infrastructure/storage/longhorn --enable-helm > /tmp/longhorn.yaml
+kustomize build infrastructure/storage/longhorn-selinux > /tmp/longhorn-selinux.yaml
+bash scripts/validate-argocd-apps.sh
+bash scripts/validate-no-inline-scripts.sh
+uv run --with-requirements requirements.txt mkdocs build --strict
+```
+
+- [Longhorn 1.12.1 StorageClass mount options](https://longhorn.io/docs/1.12.1/references/storage-class-parameters/)
+- [Talos v1.14 audit daemon limits](https://github.com/siderolabs/talos/blob/v1.14.0/internal/app/auditd/auditd.go)
+- [Kubernetes v1.37 PV update validation](https://github.com/kubernetes/kubernetes/blob/v1.37.0/pkg/apis/core/validation/validation.go)
+- [Longhorn default StorageClass ConfigMap controller](https://github.com/longhorn/longhorn-manager/blob/v1.12.1/controller/kubernetes_configmap_controller.go)
+- [Storage architecture](../../storage-architecture.md)
+- [kopiur backup architecture](kopiur-backup-architecture.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,7 +110,7 @@ Backups are **kopiur** (Kopia-native operator).
 - **GitOps / ArgoCD**: [argocd](domains/argocd/argocd.md) · [entrypoints & waves](domains/argocd/entrypoints.md)
 - **Enterprise multi-cluster planning**: [roadmap](domains/multicluster/enterprise-gitops-roadmap.md) · [concrete fleet PRD](domains/multicluster/prd.md)
 - **Networking**: [topology](domains/networking/topology.md) · [Dell Proxmox Talos worker](domains/networking/dell-proxmox-talos-worker.md) · [policy](domains/networking/policy.md) · [Technitium `vanillax.me` migration](domains/networking/technitium-vanillax-me-migration.md)
-- **Storage**: [move a PVC to another StorageClass](domains/storage/pvc-storageclass-migration.md) · [kopia maintenance](domains/storage/kopia-maintenance-plan.md) · [RWO/RWX model & sizing](domains/storage/storage-model-rwo-rwx-and-sizing.md) · [RustFS credentials](domains/rustfs/credential-runbook.md) · [future: tiered storage](domains/storage/architecture-future.md)
+- **Storage**: [Talos SELinux audit remediation](domains/storage/selinux-mount-context.md) · [move a PVC to another StorageClass](domains/storage/pvc-storageclass-migration.md) · [kopia maintenance](domains/storage/kopia-maintenance-plan.md) · [RWO/RWX model & sizing](domains/storage/storage-model-rwo-rwx-and-sizing.md) · [RustFS credentials](domains/rustfs/credential-runbook.md) · [future: tiered storage](domains/storage/architecture-future.md)
 - **Observability**: [radar-ng](domains/observability/radar-ng.md)
 - **Scheduling**: [VPA policy ownership and topology](domains/scheduling/vpa-and-topology.md)
 - **Power**: [wall-plug metering, cost model and the power-off lockout](domains/power/metering.md)

--- a/infrastructure/controllers/argocd/apps/appsets/infrastructure-appset.yaml
+++ b/infrastructure/controllers/argocd/apps/appsets/infrastructure-appset.yaml
@@ -59,6 +59,7 @@ spec:
       - path: infrastructure/storage/truenas-csi
       - path: infrastructure/storage/local-storage
       - path: infrastructure/storage/talos-fstrim
+      - path: infrastructure/storage/longhorn-selinux
       # NOTE: longhorn and snapshot-controller are NOT listed here.
       # They have dedicated standalone Applications at Wave 1 (longhorn-app.yaml,
       # snapshot-controller-app.yaml) so storage is healthy before the

--- a/infrastructure/storage/longhorn-selinux/kustomization.yaml
+++ b/infrastructure/storage/longhorn-selinux/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: longhorn-selinux
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - migration-job.yaml
+configMapGenerator:
+  - name: longhorn-selinux-policy
+    files:
+      - policy.json
+  - name: longhorn-selinux-scripts
+    files:
+      - scripts/reconcile.py

--- a/infrastructure/storage/longhorn-selinux/migration-job.yaml
+++ b/infrastructure/storage/longhorn-selinux/migration-job.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: longhorn-selinux-migrate
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 180
+  template:
+    metadata:
+      labels:
+        app: longhorn-selinux
+    spec:
+      serviceAccountName: longhorn-selinux
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: migrate
+          image: python:3.14-slim
+          command: [python, /scripts/reconcile.py, /policy/policy.json]
+          env:
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+            - name: policy
+              mountPath: /policy
+              readOnly: true
+      volumes:
+        - name: scripts
+          configMap:
+            name: longhorn-selinux-scripts
+        - name: policy
+          configMap:
+            name: longhorn-selinux-policy

--- a/infrastructure/storage/longhorn-selinux/namespace.yaml
+++ b/infrastructure/storage/longhorn-selinux/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: longhorn-selinux
+  labels:
+    pod-security.kubernetes.io/enforce: restricted

--- a/infrastructure/storage/longhorn-selinux/policy.json
+++ b/infrastructure/storage/longhorn-selinux/policy.json
@@ -1,0 +1,6 @@
+{
+  "mode": "apply",
+  "claims": [
+    "posthog/clickhouse-data-clickhouse-0"
+  ]
+}

--- a/infrastructure/storage/longhorn-selinux/rbac.yaml
+++ b/infrastructure/storage/longhorn-selinux/rbac.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-selinux
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: longhorn-selinux
+rules:
+  # PV names change after restores; the script limits writes to the committed claim allowlist.
+  - apiGroups: [""]
+    resources: [persistentvolumes]
+    verbs: [list, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-selinux
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-selinux
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-selinux
+    namespace: longhorn-selinux

--- a/infrastructure/storage/longhorn-selinux/scripts/reconcile.py
+++ b/infrastructure/storage/longhorn-selinux/scripts/reconcile.py
@@ -1,0 +1,139 @@
+"""Reconcile mount options for explicitly selected existing Longhorn claims."""
+
+import json
+from pathlib import Path
+import re
+import ssl
+import sys
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+MOUNT_OPTION = "context=system_u:object_r:ephemeral_t:s0"
+STORAGE_CLASSES = {
+    "longhorn", "longhorn-flash", "longhorn-wired-ha", "longhorn-kopiur-staging-local"
+}
+SELINUX_OPTIONS = {"context", "fscontext", "defcontext", "rootcontext"}
+
+
+def emit(event, **fields):
+    print(json.dumps({"event": event, **fields}), flush=True)
+
+
+class KubernetesAPI:
+    def __init__(self):
+        self.credentials = Path("/var/run/secrets/kubernetes.io/serviceaccount")
+        self.tls = ssl.create_default_context(cafile=str(self.credentials / "ca.crt"))
+
+    def request(self, path, patch=None):
+        headers = {"Authorization": "Bearer " + (self.credentials / "token").read_text().strip()}
+        if patch is not None:
+            headers["Content-Type"] = "application/json-patch+json"
+        request = Request(
+            "https://kubernetes.default.svc" + path,
+            data=json.dumps(patch).encode() if patch is not None else None,
+            headers=headers,
+            method="PATCH" if patch is not None else "GET",
+        )
+        with urlopen(request, context=self.tls, timeout=30) as response:
+            return json.load(response)
+
+    def list_volumes(self):
+        volumes = []
+        continuation = ""
+        while True:
+            query = urlencode({"limit": 500, "continue": continuation})
+            page = self.request("/api/v1/persistentvolumes?" + query)
+            volumes.extend(page["items"])
+            continuation = page.get("metadata", {}).get("continue", "")
+            if not continuation:
+                return volumes
+
+    def patch_volume(self, name, operations):
+        return self.request("/api/v1/persistentvolumes/" + quote(name, safe=""), operations)
+
+
+def make_plan(volumes, policy):
+    mode = policy.get("mode")
+    claims = policy.get("claims")
+    if mode not in {"plan", "apply", "remove"}:
+        raise ValueError("mode must be plan, apply, or remove")
+    if not isinstance(claims, list) or not claims or any(
+        not isinstance(c, str) or not re.fullmatch(r"[a-z0-9][a-z0-9.-]*/[a-z0-9][a-z0-9.-]*", c)
+        for c in claims
+    ):
+        raise ValueError("claims must explicitly list namespace/name; wildcards are not supported")
+
+    plan = []
+    found = set()
+    for pv in volumes:
+        metadata = pv["metadata"]
+        spec = pv["spec"]
+        ref = spec.get("claimRef", {})
+        claim = ref.get("namespace", "") + "/" + ref.get("name", "")
+        if claim not in claims:
+            continue
+        if metadata.get("deletionTimestamp") or pv.get("status", {}).get("phase") != "Bound":
+            emit("skipped", claim=claim, pv=metadata["name"], reason="not a live Bound PV")
+            continue
+        if claim in found:
+            raise ValueError(f"Multiple Bound PVs found for {claim}")
+        found.add(claim)
+        csi = spec.get("csi", {})
+        if (
+            csi.get("driver") != "driver.longhorn.io"
+            or csi.get("fsType") != "ext4"
+            or spec.get("storageClassName") not in STORAGE_CLASSES
+            or spec.get("volumeMode", "Filesystem") != "Filesystem"
+            or spec.get("accessModes") not in [["ReadWriteOnce"], ["ReadWriteOncePod"]]
+        ):
+            raise ValueError(f"{claim}: target must be an ext4 Longhorn RWO/RWOP filesystem in a reviewed class")
+
+        existing = spec.get("mountOptions") or []
+        if not isinstance(existing, list) or any(not isinstance(o, str) for o in existing):
+            raise ValueError(f"{claim}: invalid mountOptions")
+        for option in existing:
+            # A mount option may contain comma-separated flags; reject hidden context overrides too.
+            for flag in option.split(","):
+                if flag.strip().split("=", 1)[0] in SELINUX_OPTIONS and option != MOUNT_OPTION:
+                    raise ValueError(f"{claim}: conflicting SELinux mount option {option!r}")
+        desired = [o for o in existing if o != MOUNT_OPTION]
+        if mode != "remove":
+            desired.append(MOUNT_OPTION)
+        if desired == existing:
+            emit("unchanged", claim=claim, pv=metadata["name"])
+            continue
+
+        operations = [
+            {"op": "test", "path": "/metadata/uid", "value": metadata["uid"]},
+            {"op": "test", "path": "/metadata/resourceVersion", "value": metadata["resourceVersion"]},
+        ]
+        if desired:
+            operations.append({"op": "add", "path": "/spec/mountOptions", "value": desired})
+        else:
+            operations.append({"op": "remove", "path": "/spec/mountOptions"})
+        plan.append({"pv": metadata["name"], "claim": claim, "before": existing, "after": desired, "patch": operations})
+    for claim in sorted(set(claims) - found):
+        emit("skipped", claim=claim, reason="no live Bound PV; new volumes inherit their StorageClass options")
+    return plan
+
+
+def reconcile(api, policy):
+    # Validate every selected target before sending the first write; retries re-read resource versions.
+    plan = make_plan(api.list_volumes(), policy)
+    for change in plan:
+        emit("planned", **{key: value for key, value in change.items() if key != "patch"})
+    if policy["mode"] != "plan":
+        for change in plan:
+            api.patch_volume(change["pv"], change["patch"])
+            emit("updated", pv=change["pv"], claim=change["claim"], remount_required=True)
+    emit("complete", mode=policy["mode"], changes=len(plan))
+    return plan
+
+
+if __name__ == "__main__":
+    try:
+        reconcile(KubernetesAPI(), json.loads(Path(sys.argv[1]).read_text()))
+    except Exception as error:
+        emit("failed", error=str(error))
+        sys.exit(1)

--- a/infrastructure/storage/longhorn/kustomization.yaml
+++ b/infrastructure/storage/longhorn/kustomization.yaml
@@ -7,13 +7,14 @@ resources:
   # (deploys at wave 4 alongside the Gateway)
   - volumesnapshotclass.yaml
   - node-failure-settings.yaml
+  - storageclass-default.yaml
   # Fast local flash tier — enterprise-SSD Longhorn disk (tag `flash`).
   - storageclass-flash.yaml
   # Two-copy critical-state tier; provisioning fails closed until wired Longhorn node tags exist.
   - storageclass-wired-ha.yaml
   # Disposable kopiur snapshot clones. WFFC lets the mover pick the node before the clone is provisioned (avoids V1 clone attach race).
   - storageclass-kopiur-staging.yaml
-  # Chart-created `longhorn` StorageClass is V1-engine; do NOT route it to dataEngine:v2 (retired, see values.yaml).
+  # All StorageClasses use Talos's pod-writable SELinux context; see docs/domains/storage/selinux-mount-context.md.
 helmCharts:
   - name: longhorn
     repo: https://charts.longhorn.io

--- a/infrastructure/storage/longhorn/storageclass-default.yaml
+++ b/infrastructure/storage/longhorn/storageclass-default.yaml
@@ -1,0 +1,22 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+mountOptions:
+  - context=system_u:object_r:ephemeral_t:s0
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+  fromBackup: ""
+  fsType: "ext4"
+  dataLocality: "best-effort"
+  disableRevisionCounter: "true"
+  dataEngine: "v1"
+  unmapMarkSnapChainRemoved: "ignored"
+  backupTargetName: "default"

--- a/infrastructure/storage/longhorn/storageclass-flash.yaml
+++ b/infrastructure/storage/longhorn/storageclass-flash.yaml
@@ -10,6 +10,8 @@ provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
+mountOptions:
+  - context=system_u:object_r:ephemeral_t:s0
 parameters:
   numberOfReplicas: "1"
   staleReplicaTimeout: "30"

--- a/infrastructure/storage/longhorn/storageclass-kopiur-staging.yaml
+++ b/infrastructure/storage/longhorn/storageclass-kopiur-staging.yaml
@@ -12,6 +12,8 @@ provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
+mountOptions:
+  - context=system_u:object_r:ephemeral_t:s0
 parameters:
   numberOfReplicas: "1"
   staleReplicaTimeout: "30"

--- a/infrastructure/storage/longhorn/storageclass-wired-ha.yaml
+++ b/infrastructure/storage/longhorn/storageclass-wired-ha.yaml
@@ -10,6 +10,8 @@ provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
+mountOptions:
+  - context=system_u:object_r:ephemeral_t:s0
 parameters:
   numberOfReplicas: "2"
   staleReplicaTimeout: "30"

--- a/infrastructure/storage/longhorn/values.yaml
+++ b/infrastructure/storage/longhorn/values.yaml
@@ -45,17 +45,8 @@ defaultSettings:
 preUpgradeChecker:
   jobEnabled: false
 persistence:
-  # -- The chart-created `longhorn` StorageClass, cluster default. NEVER rename it —
-  # 40+ PVCs, the kopiur backup contract and CLAUDE.md reference `storageClassName: longhorn`.
-  defaultClass: true
-  # -- Default replica count. Stay at 1 until a second trustworthy wired storage
-  # worker exists and is measured; off-cluster durability is kopiur backups to RustFS.
-  defaultClassReplicaCount: 1
-  # -- Default filesystem type.
-  defaultFsType: ext4
-  defaultDataLocality: best-effort
-  # -- Reclaim policy for the default storage class.
-  reclaimPolicy: Delete
+  # The chart's ConfigMap generator cannot set mountOptions; ArgoCD owns storageclass-default.yaml instead.
+  createStorageClass: false
 # -- Disable the default ingress creation, as you are managing it with a
 # separate HTTPRoute resource.
 ingress:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
       - Root entrypoints & sync waves: domains/argocd/entrypoints.md
   - Storage:
       - Storage architecture (source of truth): storage-architecture.md
+      - Talos SELinux audit remediation: domains/storage/selinux-mount-context.md
       - Storage model (RWO/RWX & sizing): domains/storage/storage-model-rwo-rwx-and-sizing.md
       - NAS hardware & performance reference: nas-performance.md
       - TrueNAS special-vdev stall runbook: truenas-special-vdev-stall-runbook.md

--- a/scripts/tests/test_longhorn_mount_options.py
+++ b/scripts/tests/test_longhorn_mount_options.py
@@ -1,0 +1,175 @@
+"""Exercise the PV migration without connecting to Kubernetes."""
+
+import copy
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "infrastructure/storage/longhorn-selinux/scripts/reconcile.py"
+CONTEXT = "context=system_u:object_r:ephemeral_t:s0"
+CLAIM = "posthog/clickhouse-data-clickhouse-0"
+
+
+def volume(name="pv-clickhouse", claim=CLAIM, options=None):
+    namespace, claim_name = claim.split("/")
+    obj = {
+        "metadata": {"name": name, "uid": "uid-" + name, "resourceVersion": "10"},
+        "spec": {
+            "storageClassName": "longhorn-flash",
+            "volumeMode": "Filesystem",
+            "accessModes": ["ReadWriteOnce"],
+            "claimRef": {"namespace": namespace, "name": claim_name, "uid": "claim-uid"},
+            "csi": {"driver": "driver.longhorn.io", "fsType": "ext4", "volumeHandle": name},
+            "persistentVolumeReclaimPolicy": "Delete",
+        },
+        "status": {"phase": "Bound"},
+    }
+    if options is not None:
+        obj["spec"]["mountOptions"] = options
+    return obj
+
+
+class MemoryAPI:
+    def __init__(self, *volumes):
+        self.volumes = {v["metadata"]["name"]: copy.deepcopy(v) for v in volumes}
+        self.patches = []
+        self.concurrent_change = False
+
+    def list_volumes(self):
+        return copy.deepcopy(list(self.volumes.values()))
+
+    def patch_volume(self, name, operations):
+        current = self.volumes[name]
+        if self.concurrent_change:
+            current["metadata"]["resourceVersion"] = "11"
+        result = copy.deepcopy(current)
+        for op in operations:
+            parent, key = op["path"].strip("/").split("/")
+            if op["op"] == "test":
+                if result[parent].get(key) != op["value"]:
+                    raise RuntimeError("concurrent change")
+            elif op["op"] == "add":
+                result[parent][key] = op["value"]
+            elif op["op"] == "remove":
+                del result[parent][key]
+            else:
+                raise AssertionError("Unexpected JSON patch operation")
+        self.volumes[name] = result
+        self.patches.append((name, operations))
+
+
+class MigrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if SCRIPT.exists():
+            spec = importlib.util.spec_from_file_location("mount_reconcile", SCRIPT)
+            cls.module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(cls.module)
+        else:
+            cls.module = None
+
+    def run_migration(self, api, mode="apply", claims=None):
+        self.assertIsNotNone(self.module, "PV migration script has not been implemented")
+        return self.module.reconcile(api, {"mode": mode, "claims": claims or [CLAIM]})
+
+    def test_changes_only_allowlisted_pv_and_preserves_other_fields(self):
+        original = volume(options=["noatime"])
+        other = volume("pv-other", "other/data", ["context=other"])
+        api = MemoryAPI(original, other)
+        self.run_migration(api)
+        expected = copy.deepcopy(original)
+        expected["spec"]["mountOptions"] = ["noatime", CONTEXT]
+        self.assertEqual(api.volumes["pv-clickhouse"], expected)
+        self.assertEqual(api.volumes["pv-other"], other)
+
+    def test_adds_missing_options_and_second_run_is_noop(self):
+        api = MemoryAPI(volume())
+        self.run_migration(api)
+        self.run_migration(api)
+        self.assertEqual(api.volumes["pv-clickhouse"]["spec"]["mountOptions"], [CONTEXT])
+        self.assertEqual(len(api.patches), 1)
+
+    def test_other_selinux_mount_controls_abort_before_any_patch(self):
+        for option in ["context=other", "fscontext=other", "defcontext=other", "rootcontext=other"]:
+            with self.subTest(option=option):
+                api = MemoryAPI(volume(), volume("pv-second", "second/data", [option]))
+                with self.assertRaisesRegex(ValueError, "SELinux"):
+                    self.run_migration(api, claims=[CLAIM, "second/data"])
+                self.assertEqual(api.patches, [])
+
+    def test_refuses_incompatible_target_instead_of_silently_migrating(self):
+        changes = [
+            {"csi": {"driver": "nfs.csi.k8s.io", "fsType": "ext4"}},
+            {"csi": {"driver": "driver.longhorn.io", "fsType": "xfs"}},
+            {"csi": {"driver": "driver.longhorn.io"}},
+            {"storageClassName": "unreviewed-longhorn"},
+            {"volumeMode": "Block"},
+            {"accessModes": ["ReadWriteMany"]},
+            {"accessModes": ["ReadOnlyMany"]},
+        ]
+        for change in changes:
+            with self.subTest(change=change):
+                obj = volume()
+                obj["spec"].update(change)
+                api = MemoryAPI(obj)
+                with self.assertRaises(ValueError):
+                    self.run_migration(api)
+                self.assertEqual(api.patches, [])
+
+    def test_allows_read_write_once_pod(self):
+        obj = volume()
+        obj["spec"]["accessModes"] = ["ReadWriteOncePod"]
+        api = MemoryAPI(obj)
+        self.run_migration(api)
+        self.assertEqual(api.volumes["pv-clickhouse"]["spec"]["mountOptions"], [CONTEXT])
+
+    def test_missing_claim_is_safe_on_fresh_cluster(self):
+        api = MemoryAPI()
+        self.run_migration(api)
+        self.assertEqual(api.patches, [])
+
+    def test_released_or_deleting_pv_is_not_modified(self):
+        for deleting in [False, True]:
+            obj = volume()
+            if deleting:
+                obj["metadata"]["deletionTimestamp"] = "2026-09-06T00:00:00Z"
+            else:
+                obj["status"]["phase"] = "Released"
+            api = MemoryAPI(obj)
+            self.run_migration(api)
+            self.assertEqual(api.patches, [])
+
+    def test_plan_mode_does_not_write(self):
+        api = MemoryAPI(volume())
+        result = self.run_migration(api, mode="plan")
+        self.assertEqual(api.patches, [])
+        self.assertEqual(len(result), 1)
+
+    def test_rollback_removes_only_our_context_and_is_idempotent(self):
+        for options, expected in [(["noatime", CONTEXT], ["noatime"]), ([CONTEXT], None)]:
+            api = MemoryAPI(volume(options=options))
+            self.run_migration(api, mode="remove")
+            self.run_migration(api, mode="remove")
+            self.assertEqual(api.volumes["pv-clickhouse"]["spec"].get("mountOptions"), expected)
+            self.assertEqual(len(api.patches), 1)
+
+    def test_concurrent_update_fails_without_overwriting_options(self):
+        original = volume(options=["noatime"])
+        api = MemoryAPI(original)
+        api.concurrent_change = True
+        with self.assertRaisesRegex(RuntimeError, "concurrent change"):
+            self.run_migration(api)
+        self.assertEqual(api.volumes["pv-clickhouse"]["spec"], original["spec"])
+
+    def test_invalid_policy_never_writes(self):
+        self.assertIsNotNone(self.module, "PV migration script has not been implemented")
+        for policy in [{"mode": "apply", "claims": "all"}, {"mode": "apply", "claims": ["*"]}, {"mode": "typo", "claims": [CLAIM]}]:
+            api = MemoryAPI(volume())
+            with self.assertRaises(ValueError):
+                self.module.reconcile(api, policy)
+            self.assertEqual(api.patches, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-truenas-csi.sh
+++ b/scripts/validate-truenas-csi.sh
@@ -82,7 +82,7 @@ check "Argo CD no longer deploys Democratic CSI" \
 check "Democratic CSI directory has been removed" \
   test ! -d infrastructure/storage/democratic-csi
 check "Longhorn remains the default StorageClass" \
-  grep -qE '^[[:space:]]*defaultClass:[[:space:]]*true' infrastructure/storage/longhorn/values.yaml
+  grep -qE '^[[:space:]]+storageclass\.kubernetes\.io/is-default-class: "true"$' infrastructure/storage/longhorn/storageclass-default.yaml
 check "TrueNAS API TCP 443 is allowed by the LAN egress policy" \
   bash -c "awk '/ALLOW: TrueNAS/,/ALLOW: Wyze/' '$POLICY' | grep -qE 'port: \"443\"'"
 check "iSCSI TCP 3260 is not opened in the TrueNAS policy block" \


### PR DESCRIPTION
Talos 1.14 audit logs show busy containers accessing Longhorn filesystems as `unlabeled_t`. On the GPU worker this exceeded the kernel audit rate limit. Set `context=system_u:object_r:ephemeral_t:s0`, the pod-writable filesystem context documented in Talos's container policy.

- Set mount options on all four Longhorn StorageClasses for new volumes. Adopt the default `longhorn` class directly in ArgoCD because the chart's generated ConfigMap does not expose mount options; preserve its existing name and parameters.
- Add an independent wave-4 ArgoCD Sync hook that patches mutable **PV mount options**, keeping PVCs, data, and bindings intact. Initially allowlist only `posthog/clickhouse-data-clickhouse-0` as the canary. It validates ext4/RWO or RWOP Longhorn targets, preserves other options, rejects conflicting SELinux options, checks UID/resource version, and supports plan/removal modes.
- Update the TrueNAS contract check to inspect the directly managed default class; add migration tests to CI and a GitOps rollout/rollback runbook: `docs/domains/storage/selinux-mount-context.md`.

Existing mounted volumes require a complete unmount/unstage before the setting takes effect. **This PR does not restart workloads or immediately stop the live audit flood.** After the hook succeeds, use separate reviewed PRs to set ClickHouse replicas to 0, wait for detachment, then restore replicas to 1. Verify the canary under traffic before expanding the claim allowlist. Shared claims require all consumers to stop. Reverting the hook alone does not undo prior PV patches; the runbook covers explicit removal and remount.

The hook's RBAC grants only PV list/patch, with claim scoping enforced in the script. No live mutations were made while preparing this PR. No PVC replacement or cluster reinstall is needed for this migration.

Validation:
- 11 migration tests passed, including allowlist isolation, conflict preflight, idempotence, rollback, and concurrent-update protection.
- Longhorn, migration, and ArgoCD app Kustomize renders passed.
- kubeconform (Kubernetes 1.37): 38 valid resources, 0 invalid/errors; 34 resources skipped for unavailable schemas.
- TrueNAS CSI contract, ArgoCD structure, and no-inline-script validators passed (two existing namespace wave warnings).
- Strict MkDocs build and git diff whitespace checks passed.
- Runtime efficacy remains pending the canary remount. Local Helm is 4.2.4; CI renders with the repository's pinned 4.2.1.

Upstream: [Talos v1.14 CSI mount context policy](https://github.com/siderolabs/talos/blob/v1.14.0/internal/pkg/selinux/policy/selinux/services/cri.cil), [Longhorn StorageClass mount options](https://longhorn.io/docs/1.12.1/references/storage-class-parameters/).
