### PR TITLE
fix(langfuse): nest hook timeout inside workloadExec

### DIFF
--- a/my-apps/ai/langfuse/kopiur/langfuse-postgres-data.yaml
+++ b/my-apps/ai/langfuse/kopiur/langfuse-postgres-data.yaml
@@ -42,7 +42,7 @@ spec:
         - langfuse
         - -c
         - CHECKPOINT
-      timeout: 2m
+        timeout: 2m
 ---
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotSchedule


### PR DESCRIPTION
## What was broken

`my-apps-langfuse` has been `OutOfSync / Degraded` with its sync operation stuck for ~3 hours on:

> `waiting for healthy state of /PersistentVolumeClaim/langfuse-postgres-data`

| Component | State |
|---|---|
| langfuse-clickhouse | 1/1 Running |
| langfuse-redis | 1/1 Running |
| langfuse-postgres | 0/1 Pending — PVC never bound |
| langfuse-web | never created |
| langfuse-worker | never created |

## Root cause

In `kopiur/langfuse-postgres-data.yaml`, `timeout: 2m` was indented one level too shallow — a sibling of `workloadExec` rather than a field of it. The CRD declares `timeout` inside `workloadExec` (alongside `command`, `container`, `continueOnFailure`, `podSelector`), so strict decoding rejected it:

```
.spec.hooks.beforeSnapshot[0].timeout: field not declared in schema
```

`SnapshotPolicy/langfuse-postgres-data` was therefore never created, which cascaded:

1. No SnapshotPolicy → the `Restore` CR can't resolve `fromPolicy: langfuse-postgres-data`
2. Restore is the PVC's volume populator → `langfuse-postgres-data` stays `Pending`
3. Postgres can't schedule — *"pod has unbound immediate PersistentVolumeClaims"*
4. ArgoCD blocks on that PVC's health in wave 0 → web, worker and the HTTPRoute were never applied

ClickHouse and Redis were unaffected; the ClickHouse stub carries no hook and has been snapshotting hourly throughout.

Restore-before-bind behaved correctly here — it left the PVC `Pending` rather than binding an empty volume behind a broken policy reference.

## The fix

```diff
         - CHECKPOINT
-      timeout: 2m
+        timeout: 2m
```

## Verification

- Checked the field's position against the live `snapshotpolicies.kopiur.home-operations.com` CRD schema
- `kustomize build my-apps/ai/langfuse | kubectl apply --dry-run=server -f -` passes clean (the raw stub alone does not — `spec.repository` is injected by the `kopiur-backup` component)
- Grepped the repo: this was the only occurrence

## Expected after sync

Policy applies → Restore resolves → PVC binds as a fresh empty DB (`onMissingSnapshot: Continue`) → postgres starts → web and worker roll out. First postgres snapshot at :16 past the hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtMtqt1ZetbcaUrGhghKbh