### PR TITLE
ci: validate CRs against the CRDs this repo renders

### DIFF
--- a/.github/workflows/backup-contract-tests.yml
+++ b/.github/workflows/backup-contract-tests.yml
@@ -6,6 +6,7 @@ on:
       - 'scripts/tests/test_kopiur_coverage.py'
       - 'scripts/generate-crd-schemas.py'
       - 'scripts/tests/test_crd_schemas.py'
+      - 'scripts/tests/fixtures/crd-schema-*.yaml'
       - 'my-apps/common/kopiur-backup/**'
       - '.github/workflows/backup-contract-tests.yml'
   push:
@@ -15,6 +16,7 @@ on:
       - 'scripts/tests/test_kopiur_coverage.py'
       - 'scripts/generate-crd-schemas.py'
       - 'scripts/tests/test_crd_schemas.py'
+      - 'scripts/tests/fixtures/crd-schema-*.yaml'
       - 'my-apps/common/kopiur-backup/**'
       - '.github/workflows/backup-contract-tests.yml'
 permissions:
@@ -27,6 +29,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: python -m pip install PyYAML==6.0.3
+      - run: python -m pip install PyYAML==6.0.3 jsonschema==4.26.0
       - run: python -m unittest discover -s scripts/tests -p test_kopiur_coverage.py -v
       - run: python -m unittest discover -s scripts/tests -p test_crd_schemas.py -v

--- a/.github/workflows/backup-contract-tests.yml
+++ b/.github/workflows/backup-contract-tests.yml
@@ -4,6 +4,8 @@ on:
     paths:
       - 'scripts/validate-kopiur-coverage.py'
       - 'scripts/tests/test_kopiur_coverage.py'
+      - 'scripts/generate-crd-schemas.py'
+      - 'scripts/tests/test_crd_schemas.py'
       - 'my-apps/common/kopiur-backup/**'
       - '.github/workflows/backup-contract-tests.yml'
   push:
@@ -11,6 +13,8 @@ on:
     paths:
       - 'scripts/validate-kopiur-coverage.py'
       - 'scripts/tests/test_kopiur_coverage.py'
+      - 'scripts/generate-crd-schemas.py'
+      - 'scripts/tests/test_crd_schemas.py'
       - 'my-apps/common/kopiur-backup/**'
       - '.github/workflows/backup-contract-tests.yml'
 permissions:
@@ -25,3 +29,4 @@ jobs:
           python-version: '3.12'
       - run: python -m pip install PyYAML==6.0.3
       - run: python -m unittest discover -s scripts/tests -p test_kopiur_coverage.py -v
+      - run: python -m unittest discover -s scripts/tests -p test_crd_schemas.py -v

--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -129,13 +129,23 @@ jobs:
             echo "---" >> /tmp/all-manifests.yaml
           done
 
+      - name: Generate CRD schemas
+        # Without these, every CR whose CRD the datree catalog does not carry is
+        # silently skipped by -ignore-missing-schemas below (kopiur, longhorn,
+        # temporal, holmesgpt, coroot...). Schemas come from the same rendered
+        # stream, so they track the chart versions in git automatically.
+        run: |
+          set -euo pipefail
+          python3 -c "import yaml" 2>/dev/null || pip3 install --quiet pyyaml
+          python3 ./scripts/generate-crd-schemas.py \
+            /tmp/all-manifests.yaml /tmp/crd-schemas --min-schemas 100
+
       - name: Validate Kubernetes schemas
         run: |
           set -euo pipefail
           # Filter a known kubeconform false positive:
           # - Gitea Helm-rendered Service gitea-http: targetPort triggers a
           #   oneOf ambiguity in the Kubernetes Service schema.
-          # (kopiur CRDs are skipped via -ignore-missing-schemas below.)
           csplit -z -f /tmp/doc- /tmp/all-manifests.yaml '/^---$/' '{*}' > /dev/null
           : > /tmp/filtered-manifests.yaml
           for f in /tmp/doc-*; do
@@ -145,14 +155,35 @@ jobs:
             cat "$f" >> /tmp/filtered-manifests.yaml
           done
 
+          # Generated schemas first: they are the exact CRDs this repo deploys,
+          # so they win over the catalog's copy where both exist.
           kubeconform \
             -summary \
             -strict \
             -ignore-missing-schemas \
             -kubernetes-version "${KUBERNETES_VERSION}" \
+            -schema-location '/tmp/crd-schemas/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
             -schema-location default \
             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
             /tmp/filtered-manifests.yaml
+
+      - name: Verify CRD schema canary is rejected
+        # A generator that emits unpruned schemas still validates field types, so
+        # the suite above would pass while missing misplaced fields entirely.
+        # This known-bad manifest must fail, or the check is only pretending.
+        run: |
+          set -euo pipefail
+          if kubeconform \
+            -strict \
+            -ignore-missing-schemas \
+            -kubernetes-version "${KUBERNETES_VERSION}" \
+            -schema-location '/tmp/crd-schemas/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            -schema-location default \
+            ./scripts/tests/fixtures/crd-schema-canary.yaml; then
+            echo "ERROR: canary passed validation - CRD schemas are not pruning unknown fields."
+            exit 1
+          fi
+          echo "Canary correctly rejected."
 
       - name: Validate kopiur backup coverage
         # Replaces the retired pvc-plumber validate-restore-contract.sh and the

--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -167,23 +167,28 @@ jobs:
             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
             /tmp/filtered-manifests.yaml
 
-      - name: Verify CRD schema canary is rejected
-        # A generator that emits unpruned schemas still validates field types, so
-        # the suite above would pass while missing misplaced fields entirely.
-        # This known-bad manifest must fail, or the check is only pretending.
+      - name: Verify CRD schema controls
+        # Require a real pass and the exact timeout error; crashes/skips do not count.
         run: |
           set -euo pipefail
-          if kubeconform \
-            -strict \
-            -ignore-missing-schemas \
-            -kubernetes-version "${KUBERNETES_VERSION}" \
-            -schema-location '/tmp/crd-schemas/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
-            -schema-location default \
-            ./scripts/tests/fixtures/crd-schema-canary.yaml; then
-            echo "ERROR: canary passed validation - CRD schemas are not pruning unknown fields."
-            exit 1
-          fi
-          echo "Canary correctly rejected."
+          schema='/tmp/crd-schemas/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+          kubeconform -strict -summary -output json -schema-location "$schema" \
+            ./scripts/tests/fixtures/crd-schema-valid.yaml > /tmp/crd-valid.json
+          jq -e '.summary == {valid: 1, invalid: 0, errors: 0, skipped: 0}' /tmp/crd-valid.json
+
+          status=0
+          kubeconform -strict -summary -output json -schema-location "$schema" \
+            ./scripts/tests/fixtures/crd-schema-canary.yaml > /tmp/crd-canary.json || status=$?
+          cat /tmp/crd-canary.json
+          test "$status" -eq 1
+          jq -e --arg message "additional properties 'timeout' not allowed" '
+            .summary == {valid: 0, invalid: 1, errors: 0, skipped: 0} and
+            (.resources | length) == 1 and
+            .resources[0].status == "statusInvalid" and
+            .resources[0].validationErrors == [{
+              path: "/spec/hooks/beforeSnapshot/0", msg: $message
+            }]
+          ' /tmp/crd-canary.json
 
       - name: Validate kopiur backup coverage
         # Replaces the retired pvc-plumber validate-restore-contract.sh and the

--- a/scripts/generate-crd-schemas.py
+++ b/scripts/generate-crd-schemas.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Convert rendered CustomResourceDefinitions into kubeconform JSON schemas.
+
+kubeconform runs with -ignore-missing-schemas and sources CRD schemas from the
+datree CRDs-catalog, which does not carry niche charts (kopiur among them). Every
+such CR was therefore unvalidated in CI: a field name typo only failed later, at
+the API server, as an ArgoCD sync error. This closes that gap using the CRDs the
+repo already renders, so the schemas always match the chart version in git.
+
+    python3 scripts/generate-crd-schemas.py /tmp/all-manifests.yaml /tmp/crd-schemas
+
+Writes <out>/<group>/<kind lowercased>_<version>.json, the layout kubeconform's
+'{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' template resolves.
+
+THE CONVERSION IS THE WHOLE POINT: a CRD's openAPIV3Schema lists the fields that
+exist but never says "and nothing else". Rejecting unknown fields is structural
+pruning, an API server behaviour that is absent from the schema document. Handing
+kubeconform a raw extraction produces a check that validates field *types* and
+happily passes a misplaced field -- the exact bug class this exists to catch. So
+additionalProperties:false is injected recursively, except under
+x-kubernetes-preserve-unknown-fields, where the API server also stops pruning.
+
+Limits worth knowing: this is a strict subset of `kubectl apply --dry-run=server`.
+Admission webhooks and x-kubernetes-validations CEL rules are not evaluated, so a
+CR can pass here and still be rejected by the cluster.
+"""
+
+import json
+import pathlib
+import sys
+
+import yaml
+
+# A free-form object (no properties, no declared map value type) must stay open;
+# forcing additionalProperties:false there would reject all of its content.
+def _prune(node):
+    if isinstance(node, list):
+        for item in node:
+            _prune(item)
+        return
+    if not isinstance(node, dict):
+        return
+
+    # Where the API server stops pruning, so do we.
+    if node.get("x-kubernetes-preserve-unknown-fields"):
+        return
+
+    props = node.get("properties")
+    if isinstance(props, dict):
+        node.setdefault("additionalProperties", False)
+        for sub in props.values():
+            _prune(sub)
+
+    # Map value schemas (map[string]T) arrive here as a dict, not a bool.
+    extra = node.get("additionalProperties")
+    if isinstance(extra, dict):
+        _prune(extra)
+
+    for key in ("items", "not"):
+        if key in node:
+            _prune(node[key])
+    for key in ("allOf", "anyOf", "oneOf"):
+        if key in node:
+            _prune(node[key])
+
+
+def convert(schema):
+    """One CRD version's openAPIV3Schema -> a whole-document kubeconform schema."""
+    doc = json.loads(json.dumps(schema))  # never mutate the caller's copy
+    _prune(doc)
+    props = doc.setdefault("properties", {})
+    props.setdefault("apiVersion", {"type": "string"})
+    props.setdefault("kind", {"type": "string"})
+    # ObjectMeta is validated by the API server, not by the CRD's own schema.
+    props["metadata"] = {"type": "object", "x-kubernetes-preserve-unknown-fields": True}
+    doc.setdefault("additionalProperties", False)
+    return doc
+
+
+def iter_crds(stream):
+    # A bare `=` in a CRD enum (Prometheus Operator matchType) parses as the
+    # rarely-used value tag, which SafeLoader rejects. Same shim as
+    # validate-kopiur-coverage.py.
+    yaml.SafeLoader.add_constructor(
+        "tag:yaml.org,2002:value", lambda loader, node: loader.construct_scalar(node)
+    )
+    for doc in yaml.safe_load_all(stream):
+        if isinstance(doc, dict) and doc.get("kind") == "CustomResourceDefinition":
+            yield doc
+
+
+def generate(manifests_path, out_dir):
+    out_dir = pathlib.Path(out_dir)
+    with open(manifests_path, encoding="utf-8") as handle:
+        crds = list(iter_crds(handle))
+
+    written = []
+    for crd in crds:
+        spec = crd.get("spec", {})
+        group = spec.get("group")
+        kind = spec.get("names", {}).get("kind")
+        if not group or not kind:
+            continue
+        for version in spec.get("versions", []):
+            schema = version.get("schema", {}).get("openAPIV3Schema")
+            if not schema or not version.get("served", True):
+                continue
+            target = out_dir / group / f"{kind.lower()}_{version['name']}.json"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps(convert(schema)), encoding="utf-8")
+            written.append(target)
+    return written
+
+
+def main(argv):
+    if len(argv) < 3:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    manifests, out_dir = argv[1], argv[2]
+    minimum = 1
+    if "--min-schemas" in argv:
+        minimum = int(argv[argv.index("--min-schemas") + 1])
+
+    written = generate(manifests, out_dir)
+    print(f"Generated {len(written)} CRD schemas into {out_dir}")
+
+    # Without this the check rots silently: a moved chart path yields zero
+    # schemas, kubeconform validates nothing, and CI stays green.
+    if len(written) < minimum:
+        print(
+            f"ERROR: expected at least {minimum} CRD schemas, got {len(written)}. "
+            "The render stream is probably missing its CRD-bearing charts.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/generate-crd-schemas.py
+++ b/scripts/generate-crd-schemas.py
@@ -1,86 +1,85 @@
 #!/usr/bin/env python3
-"""Convert rendered CustomResourceDefinitions into kubeconform JSON schemas.
+"""Convert rendered CRDs into strict kubeconform JSON schemas.
 
-kubeconform runs with -ignore-missing-schemas and sources CRD schemas from the
-datree CRDs-catalog, which does not carry niche charts (kopiur among them). Every
-such CR was therefore unvalidated in CI: a field name typo only failed later, at
-the API server, as an ArgoCD sync error. This closes that gap using the CRDs the
-repo already renders, so the schemas always match the chart version in git.
+Usage: generate-crd-schemas.py MANIFESTS OUT_DIR [--min-schemas N]
+Writes <out>/<group>/<kind lowercased>_<version>.json.
 
-    python3 scripts/generate-crd-schemas.py /tmp/all-manifests.yaml /tmp/crd-schemas
-
-Writes <out>/<group>/<kind lowercased>_<version>.json, the layout kubeconform's
-'{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' template resolves.
-
-THE CONVERSION IS THE WHOLE POINT: a CRD's openAPIV3Schema lists the fields that
-exist but never says "and nothing else". Rejecting unknown fields is structural
-pruning, an API server behaviour that is absent from the schema document. Handing
-kubeconform a raw extraction produces a check that validates field *types* and
-happily passes a misplaced field -- the exact bug class this exists to catch. So
-additionalProperties:false is injected recursively, except under
-x-kubernetes-preserve-unknown-fields, where the API server also stops pruning.
-
-Limits worth knowing: this is a strict subset of `kubectl apply --dry-run=server`.
-Admission webhooks and x-kubernetes-validations CEL rules are not evaluated, so a
-CR can pass here and still be rejected by the cluster.
+This is an offline field/type check, not an API-server dry run. Admission,
+CEL, defaulting and full ObjectMeta validation still require the cluster.
 """
 
+import copy
 import json
 import pathlib
 import sys
 
 import yaml
 
-# A free-form object (no properties, no declared map value type) must stay open;
-# forcing additionalProperties:false there would reject all of its content.
-def _prune(node):
+
+def _resource_fields(node: dict) -> None:
+    props = node.setdefault("properties", {})
+    props.setdefault("apiVersion", {"type": "string"})
+    props.setdefault("kind", {"type": "string"})
+    # CRD schemas do not describe the full ObjectMeta contract.
+    props["metadata"] = {"type": "object", "x-kubernetes-preserve-unknown-fields": True}
+
+
+def _convert_node(node: object, *, structural: bool = True) -> None:
     if isinstance(node, list):
         for item in node:
-            _prune(item)
+            _convert_node(item, structural=structural)
         return
     if not isinstance(node, dict):
         return
 
-    # Where the API server stops pruning, so do we.
-    if node.get("x-kubernetes-preserve-unknown-fields"):
-        return
+    if structural and node.get("x-kubernetes-embedded-resource"):
+        _resource_fields(node)
 
     props = node.get("properties")
     if isinstance(props, dict):
-        node.setdefault("additionalProperties", False)
+        # Logical branches constrain fields; only the structural schema closes them.
+        if structural and not node.get("x-kubernetes-preserve-unknown-fields"):
+            node.setdefault("additionalProperties", False)
+        # Preservation applies here, not to explicitly declared child schemas.
         for sub in props.values():
-            _prune(sub)
+            _convert_node(sub, structural=structural)
 
-    # Map value schemas (map[string]T) arrive here as a dict, not a bool.
     extra = node.get("additionalProperties")
     if isinstance(extra, dict):
-        _prune(extra)
-
-    for key in ("items", "not"):
+        _convert_node(extra, structural=structural)
+    if "items" in node:
+        _convert_node(node["items"], structural=structural)
+    for key in ("allOf", "anyOf", "oneOf", "not"):
         if key in node:
-            _prune(node[key])
-    for key in ("allOf", "anyOf", "oneOf"):
-        if key in node:
-            _prune(node[key])
+            _convert_node(node[key], structural=False)
+
+    if node.get("x-kubernetes-int-or-string") or node.get("format") == "int-or-string":
+        node["type"] = ["integer", "string"]
+        if node.get("format") == "int-or-string":
+            del node["format"]
+
+    if node.pop("nullable", False):
+        value_type = node.get("type")
+        if isinstance(value_type, str):
+            node["type"] = [value_type, "null"]
+        elif isinstance(value_type, list) and "null" not in value_type:
+            node["type"] = [*value_type, "null"]
+        # Kubernetes checks nullable nulls against type/enum, not logical branches.
+        constraints = {key: node.pop(key) for key in ("allOf", "anyOf", "oneOf", "not") if key in node}
+        if constraints:
+            node["allOf"] = [{"anyOf": [{"type": "null"}, constraints]}]
 
 
-def convert(schema):
-    """One CRD version's openAPIV3Schema -> a whole-document kubeconform schema."""
-    doc = json.loads(json.dumps(schema))  # never mutate the caller's copy
-    _prune(doc)
-    props = doc.setdefault("properties", {})
-    props.setdefault("apiVersion", {"type": "string"})
-    props.setdefault("kind", {"type": "string"})
-    # ObjectMeta is validated by the API server, not by the CRD's own schema.
-    props["metadata"] = {"type": "object", "x-kubernetes-preserve-unknown-fields": True}
-    doc.setdefault("additionalProperties", False)
+def convert(schema: dict) -> dict:
+    """Convert one CRD version without mutating its source schema."""
+    doc = copy.deepcopy(schema)
+    _resource_fields(doc)
+    _convert_node(doc)
     return doc
 
 
 def iter_crds(stream):
-    # A bare `=` in a CRD enum (Prometheus Operator matchType) parses as the
-    # rarely-used value tag, which SafeLoader rejects. Same shim as
-    # validate-kopiur-coverage.py.
+    # Prometheus Operator's bare '=' enum value uses PyYAML's value tag.
     yaml.SafeLoader.add_constructor(
         "tag:yaml.org,2002:value", lambda loader, node: loader.construct_scalar(node)
     )
@@ -124,8 +123,7 @@ def main(argv):
     written = generate(manifests, out_dir)
     print(f"Generated {len(written)} CRD schemas into {out_dir}")
 
-    # Without this the check rots silently: a moved chart path yields zero
-    # schemas, kubeconform validates nothing, and CI stays green.
+    # Missing CRD-bearing charts must not silently remove all local validation.
     if len(written) < minimum:
         print(
             f"ERROR: expected at least {minimum} CRD schemas, got {len(written)}. "

--- a/scripts/tests/fixtures/crd-schema-canary.yaml
+++ b/scripts/tests/fixtures/crd-schema-canary.yaml
@@ -1,0 +1,26 @@
+# Deliberately invalid. CI asserts kubeconform REJECTS this, proving the generated
+# CRD schemas are wired in and actually pruning; without it a broken generator
+# yields zero schemas and the whole check passes silently.
+# `timeout` belongs inside workloadExec — this is the real langfuse-postgres-data
+# defect that wedged the app in wave 0 (PR #2281).
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: crd-schema-canary
+  namespace: default
+spec:
+  repository:
+    kind: ClusterRepository
+    name: cluster-kopia
+  sources:
+  - pvc:
+      name: canary
+  hooks:
+    beforeSnapshot:
+    - workloadExec:
+        podSelector:
+          matchLabels:
+            app: canary
+        container: postgres
+        command: [psql, -c, CHECKPOINT]
+      timeout: 2m

--- a/scripts/tests/fixtures/crd-schema-valid.yaml
+++ b/scripts/tests/fixtures/crd-schema-valid.yaml
@@ -1,0 +1,22 @@
+# Positive control: the canary with timeout in its correct location.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: crd-schema-canary
+  namespace: default
+spec:
+  repository:
+    kind: ClusterRepository
+    name: cluster-kopia
+  sources:
+  - pvc:
+      name: canary
+  hooks:
+    beforeSnapshot:
+    - workloadExec:
+        podSelector:
+          matchLabels:
+            app: canary
+        container: postgres
+        command: [psql, -c, CHECKPOINT]
+        timeout: 2m

--- a/scripts/tests/test_crd_schemas.py
+++ b/scripts/tests/test_crd_schemas.py
@@ -1,15 +1,21 @@
-"""Offline regression cases; these fixtures are not deployable applications."""
-from pathlib import Path
+"""Offline schema-generation and resource-validation regressions."""
+from copy import deepcopy
+import importlib.util
 import json
+from pathlib import Path
 import subprocess
 import sys
 import tempfile
 import unittest
 
+from jsonschema import Draft4Validator
 import yaml
 
 SCRIPT = Path(__file__).parents[1] / "generate-crd-schemas.py"
 GROUP = "example.com"
+MODULE_SPEC = importlib.util.spec_from_file_location("crd_schemas", SCRIPT)
+MODULE = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(MODULE)
 
 
 def crd(schema, kind="Widget", version="v1"):
@@ -25,17 +31,6 @@ def crd(schema, kind="Widget", version="v1"):
     }
 
 
-def generate(*docs, extra=()):
-    directory = tempfile.mkdtemp()
-    path = Path(directory) / "rendered.yaml"
-    path.write_text(yaml.safe_dump_all(docs))
-    out = Path(directory) / "schemas"
-    result = subprocess.run(
-        [sys.executable, str(SCRIPT), str(path), str(out), *extra], capture_output=True, text=True
-    )
-    return result, out
-
-
 OBJECT = {
     "type": "object",
     "properties": {"spec": {"type": "object", "properties": {"size": {"type": "string"}}}},
@@ -43,70 +38,186 @@ OBJECT = {
 
 
 class GenerateCrdSchemasTest(unittest.TestCase):
-    def load(self, out, kind="widget", version="v1"):
-        return json.loads((out / GROUP / f"{kind}_{version}.json").read_text())
+    def generate(self, *docs, extra=()):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / "rendered.yaml"
+        path.write_text(yaml.safe_dump_all(docs), encoding="utf-8")
+        out = Path(directory.name) / "schemas"
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), str(path), str(out), *extra],
+            capture_output=True, text=True, check=False,
+        )
+        return result, out
+
+    def validator(self, schema):
+        result, out = self.generate(crd(schema))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        generated = json.loads((out / GROUP / "widget_v1.json").read_text())
+        Draft4Validator.check_schema(generated)
+        return Draft4Validator(generated)
 
     def test_prunes_unknown_fields(self):
-        """The point of the tool: a CRD lists fields but never forbids others."""
-        _, out = generate(crd(OBJECT))
-        schema = self.load(out)
-        self.assertIs(schema["properties"]["spec"]["additionalProperties"], False)
+        validator = self.validator(OBJECT)
+        self.assertTrue(validator.is_valid({"spec": {"size": "small"}}))
+        self.assertFalse(validator.is_valid({"spec": {"szie": "small"}}))
+        self.assertFalse(validator.is_valid({"spec": {"size": 3}}))
+        self.assertFalse(validator.is_valid({"typo": True}))
 
     def test_preserve_unknown_subtree_stays_open(self):
-        """Where the API server stops pruning (embedded PodSpec/JobSpec), so do we."""
-        body = {
-            "type": "object",
-            "properties": {
-                "spec": {
-                    "type": "object",
-                    "properties": {"job": {"type": "object", "x-kubernetes-preserve-unknown-fields": True}},
-                }
-            },
+        body = deepcopy(OBJECT)
+        body["properties"]["job"] = {
+            "type": "object", "x-kubernetes-preserve-unknown-fields": True,
         }
-        _, out = generate(crd(body))
-        job = self.load(out)["properties"]["spec"]["properties"]["job"]
-        self.assertNotIn("additionalProperties", job)
+        validator = self.validator(body)
+        self.assertTrue(validator.is_valid({"job": {"arbitrary": {"nested": True}}}))
+        self.assertFalse(validator.is_valid({"job": "not-an-object"}))
+
+    def test_preserved_parent_still_checks_declared_children(self):
+        body = deepcopy(OBJECT)
+        body["x-kubernetes-preserve-unknown-fields"] = True
+        validator = self.validator(body)
+        self.assertTrue(validator.is_valid({"arbitrary": True, "spec": {"size": "small"}}))
+        self.assertFalse(validator.is_valid({"arbitrary": True, "spec": {"szie": "small"}}))
+
+    def test_preserved_map_checks_values(self):
+        body = {
+            "type": "object", "x-kubernetes-preserve-unknown-fields": True,
+            "additionalProperties": deepcopy(OBJECT["properties"]["spec"]),
+        }
+        validator = self.validator({"type": "object", "properties": {"entries": body}})
+        self.assertTrue(validator.is_valid({"entries": {"anything": {"size": "small"}}}))
+        self.assertFalse(validator.is_valid({"entries": {"anything": {"szie": "small"}}}))
+
+    def test_root_preservation_without_declared_properties(self):
+        validator = self.validator({"type": "object", "x-kubernetes-preserve-unknown-fields": True})
+        self.assertTrue(validator.is_valid({"anything": {"nested": 1}}))
 
     def test_map_value_schema_is_not_closed(self):
-        """map[string]string carries additionalProperties as a schema, not a bool."""
         body = {
             "type": "object",
             "properties": {"labels": {"type": "object", "additionalProperties": {"type": "string"}}},
         }
-        _, out = generate(crd(body))
-        labels = self.load(out)["properties"]["labels"]
-        self.assertEqual(labels["additionalProperties"], {"type": "string"})
+        validator = self.validator(body)
+        self.assertTrue(validator.is_valid({"labels": {"arbitrary": "value"}}))
+        self.assertFalse(validator.is_valid({"labels": {"arbitrary": 3}}))
 
     def test_metadata_left_open(self):
-        """A CRD that narrows metadata must not make us reject labels/annotations."""
         body = {"type": "object", "properties": {"metadata": {"type": "object", "properties": {}}}}
-        _, out = generate(crd(body))
-        self.assertTrue(self.load(out)["properties"]["metadata"]["x-kubernetes-preserve-unknown-fields"])
+        validator = self.validator(body)
+        self.assertTrue(validator.is_valid({"metadata": {"labels": {"app": "test"}, "annotations": {"x": "y"}}}))
+        self.assertFalse(validator.is_valid({"metadata": "wrong-type"}))
+
+    def test_embedded_resource_keeps_implicit_fields(self):
+        embedded = deepcopy(OBJECT)
+        embedded["x-kubernetes-embedded-resource"] = True
+        validator = self.validator({"type": "object", "properties": {"template": embedded}})
+        resource = {"apiVersion": "example.com/v1", "kind": "Widget", "metadata": {"name": "x"}, "spec": {"size": "small"}}
+        self.assertTrue(validator.is_valid({"template": resource}))
+        resource["spec"]["szie"] = "small"
+        self.assertFalse(validator.is_valid({"template": resource}))
+
+    def test_composition_does_not_close_partial_branches(self):
+        for keyword in ("allOf", "anyOf", "oneOf", "not"):
+            with self.subTest(keyword=keyword):
+                body = deepcopy(OBJECT)
+                spec = body["properties"]["spec"]
+                spec["properties"]["other"] = {"type": "string"}
+                constraint = {"properties": {"size": {"enum": ["bad" if keyword == "not" else "good"]}}}
+                spec[keyword] = constraint if keyword == "not" else [constraint]
+                validator = self.validator(body)
+                self.assertTrue(validator.is_valid({"spec": {"size": "good", "other": "allowed"}}))
+                self.assertFalse(validator.is_valid({"spec": {"size": "bad", "other": "allowed"}}))
+                self.assertFalse(validator.is_valid({"spec": {"size": "good", "typo": "rejected"}}))
+
+    def test_nested_composition_does_not_close_children(self):
+        body = deepcopy(OBJECT)
+        spec = body["properties"]["spec"]
+        spec["properties"]["other"] = {"type": "string"}
+        body["allOf"] = [{"properties": {"spec": {"properties": {"size": {"minLength": 2}}}}}]
+        validator = self.validator(body)
+        self.assertTrue(validator.is_valid({"spec": {"size": "ok", "other": "allowed"}}))
+        self.assertFalse(validator.is_valid({"spec": {"size": "x", "other": "allowed"}}))
+        self.assertFalse(validator.is_valid({"spec": {"size": "ok", "typo": "rejected"}}))
+
+    def test_array_items_are_strict(self):
+        body = {"type": "object", "properties": {"entries": {"type": "array", "items": deepcopy(OBJECT["properties"]["spec"])}}}
+        validator = self.validator(body)
+        self.assertTrue(validator.is_valid({"entries": [{"size": "ok"}]}))
+        self.assertFalse(validator.is_valid({"entries": [{"szie": "bad"}]}))
+
+    def test_nullable_types(self):
+        for field, valid, invalid in (
+            ({"type": "string", "minLength": 2}, "ok", 5),
+            ({"type": "integer", "minimum": 1}, 2, "bad"),
+            (deepcopy(OBJECT["properties"]["spec"]), {"size": "ok"}, {"szie": "bad"}),
+            ({"type": "array", "items": {"type": "string"}}, ["ok"], [5]),
+        ):
+            with self.subTest(field=field):
+                field["nullable"] = True
+                validator = self.validator({"type": "object", "properties": {"value": field}, "required": ["value"]})
+                self.assertTrue(validator.is_valid({"value": None}))
+                self.assertTrue(validator.is_valid({"value": valid}))
+                self.assertFalse(validator.is_valid({"value": invalid}))
+                self.assertFalse(validator.is_valid({}))
+
+    def test_int_or_string(self):
+        for field in (
+            {"x-kubernetes-int-or-string": True},
+            {"format": "int-or-string", "type": "string"},
+            {"x-kubernetes-int-or-string": True, "anyOf": [{"type": "integer"}, {"type": "string"}]},
+            {"x-kubernetes-int-or-string": True, "allOf": [{"anyOf": [{"type": "integer"}, {"type": "string"}]}]},
+        ):
+            with self.subTest(field=field):
+                validator = self.validator({"type": "object", "properties": {"port": field}})
+                for value in (8080, "http"):
+                    self.assertTrue(validator.is_valid({"port": value}))
+                for value in (True, 1.5, {}, [], None):
+                    self.assertFalse(validator.is_valid({"port": value}))
+
+    def test_nullable_int_or_string_with_composition(self):
+        field = {"x-kubernetes-int-or-string": True, "nullable": True, "anyOf": [{"type": "integer"}, {"type": "string"}]}
+        validator = self.validator({"type": "object", "properties": {"port": field}})
+        for value in (None, 8080, "http"):
+            self.assertTrue(validator.is_valid({"port": value}))
+        self.assertFalse(validator.is_valid({"port": True}))
+
+    def test_nullable_does_not_bypass_enum(self):
+        field = {"type": "string", "nullable": True, "enum": ["allowed"]}
+        validator = self.validator({"type": "object", "properties": {"value": field}})
+        self.assertFalse(validator.is_valid({"value": None}))
+        self.assertTrue(validator.is_valid({"value": "allowed"}))
+
+    def test_conversion_does_not_mutate_input(self):
+        original = deepcopy(OBJECT)
+        MODULE.convert(OBJECT)
+        self.assertEqual(OBJECT, original)
+
+    def test_canary_pair_differs_only_in_timeout_placement(self):
+        fixtures = Path(__file__).parent / "fixtures"
+        broken = yaml.safe_load((fixtures / "crd-schema-canary.yaml").read_text())
+        fixed = yaml.safe_load((fixtures / "crd-schema-valid.yaml").read_text())
+        hook = broken["spec"]["hooks"]["beforeSnapshot"][0]
+        hook["workloadExec"]["timeout"] = hook.pop("timeout")
+        self.assertEqual(broken, fixed)
 
     def test_unserved_version_skipped(self):
         doc = crd(OBJECT)
         doc["spec"]["versions"][0]["served"] = False
-        result, out = generate(doc, extra=["--min-schemas", "0"])
+        result, out = self.generate(doc, extra=["--min-schemas", "0"])
         self.assertEqual(result.returncode, 0)
         self.assertFalse((out / GROUP).exists())
 
     def test_min_schemas_guard_fails_loudly(self):
-        """Without this the check rots silently: no CRDs found, nothing validated."""
-        result, _ = generate({"apiVersion": "v1", "kind": "Namespace", "metadata": {"name": "x"}},
-                             extra=["--min-schemas", "1"])
+        result, _ = self.generate({"apiVersion": "v1", "kind": "Namespace", "metadata": {"name": "x"}}, extra=["--min-schemas", "1"])
         self.assertEqual(result.returncode, 1)
         self.assertIn("expected at least", result.stderr)
 
     def test_value_tag_in_crd_enum_parses(self):
-        """A bare `=` in an enum is the YAML value tag; SafeLoader rejects it raw."""
         body = {"type": "object", "properties": {"op": {"type": "string", "enum": ["=", "!="]}}}
-        directory = tempfile.mkdtemp()
-        path = Path(directory) / "rendered.yaml"
-        path.write_text(yaml.safe_dump_all([crd(body)]).replace("- '='", "- ="))
-        out = Path(directory) / "schemas"
-        result = subprocess.run([sys.executable, str(SCRIPT), str(path), str(out)],
-                                capture_output=True, text=True)
-        self.assertEqual(result.returncode, 0, result.stderr)
+        stream = yaml.safe_dump_all([crd(body)]).replace("- '='", "- =")
+        parsed = list(MODULE.iter_crds(stream))
+        self.assertEqual(parsed[0]["spec"]["versions"][0]["schema"]["openAPIV3Schema"], body)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_crd_schemas.py
+++ b/scripts/tests/test_crd_schemas.py
@@ -1,0 +1,113 @@
+"""Offline regression cases; these fixtures are not deployable applications."""
+from pathlib import Path
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+SCRIPT = Path(__file__).parents[1] / "generate-crd-schemas.py"
+GROUP = "example.com"
+
+
+def crd(schema, kind="Widget", version="v1"):
+    return {
+        "apiVersion": "apiextensions.k8s.io/v1",
+        "kind": "CustomResourceDefinition",
+        "metadata": {"name": f"{kind.lower()}s.{GROUP}"},
+        "spec": {
+            "group": GROUP,
+            "names": {"kind": kind},
+            "versions": [{"name": version, "served": True, "schema": {"openAPIV3Schema": schema}}],
+        },
+    }
+
+
+def generate(*docs, extra=()):
+    directory = tempfile.mkdtemp()
+    path = Path(directory) / "rendered.yaml"
+    path.write_text(yaml.safe_dump_all(docs))
+    out = Path(directory) / "schemas"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(path), str(out), *extra], capture_output=True, text=True
+    )
+    return result, out
+
+
+OBJECT = {
+    "type": "object",
+    "properties": {"spec": {"type": "object", "properties": {"size": {"type": "string"}}}},
+}
+
+
+class GenerateCrdSchemasTest(unittest.TestCase):
+    def load(self, out, kind="widget", version="v1"):
+        return json.loads((out / GROUP / f"{kind}_{version}.json").read_text())
+
+    def test_prunes_unknown_fields(self):
+        """The point of the tool: a CRD lists fields but never forbids others."""
+        _, out = generate(crd(OBJECT))
+        schema = self.load(out)
+        self.assertIs(schema["properties"]["spec"]["additionalProperties"], False)
+
+    def test_preserve_unknown_subtree_stays_open(self):
+        """Where the API server stops pruning (embedded PodSpec/JobSpec), so do we."""
+        body = {
+            "type": "object",
+            "properties": {
+                "spec": {
+                    "type": "object",
+                    "properties": {"job": {"type": "object", "x-kubernetes-preserve-unknown-fields": True}},
+                }
+            },
+        }
+        _, out = generate(crd(body))
+        job = self.load(out)["properties"]["spec"]["properties"]["job"]
+        self.assertNotIn("additionalProperties", job)
+
+    def test_map_value_schema_is_not_closed(self):
+        """map[string]string carries additionalProperties as a schema, not a bool."""
+        body = {
+            "type": "object",
+            "properties": {"labels": {"type": "object", "additionalProperties": {"type": "string"}}},
+        }
+        _, out = generate(crd(body))
+        labels = self.load(out)["properties"]["labels"]
+        self.assertEqual(labels["additionalProperties"], {"type": "string"})
+
+    def test_metadata_left_open(self):
+        """A CRD that narrows metadata must not make us reject labels/annotations."""
+        body = {"type": "object", "properties": {"metadata": {"type": "object", "properties": {}}}}
+        _, out = generate(crd(body))
+        self.assertTrue(self.load(out)["properties"]["metadata"]["x-kubernetes-preserve-unknown-fields"])
+
+    def test_unserved_version_skipped(self):
+        doc = crd(OBJECT)
+        doc["spec"]["versions"][0]["served"] = False
+        result, out = generate(doc, extra=["--min-schemas", "0"])
+        self.assertEqual(result.returncode, 0)
+        self.assertFalse((out / GROUP).exists())
+
+    def test_min_schemas_guard_fails_loudly(self):
+        """Without this the check rots silently: no CRDs found, nothing validated."""
+        result, _ = generate({"apiVersion": "v1", "kind": "Namespace", "metadata": {"name": "x"}},
+                             extra=["--min-schemas", "1"])
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("expected at least", result.stderr)
+
+    def test_value_tag_in_crd_enum_parses(self):
+        """A bare `=` in an enum is the YAML value tag; SafeLoader rejects it raw."""
+        body = {"type": "object", "properties": {"op": {"type": "string", "enum": ["=", "!="]}}}
+        directory = tempfile.mkdtemp()
+        path = Path(directory) / "rendered.yaml"
+        path.write_text(yaml.safe_dump_all([crd(body)]).replace("- '='", "- ="))
+        out = Path(directory) / "schemas"
+        result = subprocess.run([sys.executable, str(SCRIPT), str(path), str(out)],
+                                capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #2281: catch mistakes like the misplaced Langfuse backup hook `timeout` before ArgoCD tries to deploy them.

## Changes

- Generate kubeconform schemas from the CRDs already rendered by this repo. Keep the existing catalog fallback and minimum-schema guard.
- Reject unknown fields without incorrectly closing `allOf`/`anyOf`/`oneOf`/`not` constraint branches. Preserve open objects while still checking their declared children, including map values and embedded resources.
- Translate nullable and IntOrString fields into JSON Schema constraints.
- Require the corrected canary to pass and the broken canary to fail specifically at `/spec/hooks/beforeSnapshot/0` for the misplaced `timeout`. Missing schemas, skipped checks, crashes and unrelated validation failures do not count as success.

## Verification

- 20 local Draft-4 behavioral regression tests pass, covering valid and invalid resources rather than just inspecting generated schema structure.
- Both edited workflows pass YAML parsing and shell syntax checks.
- The actual canary shell block passes eight local controlled-process scenarios, including skipped schemas, wrong errors and validator crashes. These use a stub executable, not the real kubeconform binary.
- Full-repo rendering and real kubeconform validation remain in Cluster CI; check the latest commit's Actions results.

This remains an offline field/type check, not an API-server dry run. Admission webhooks, CEL, defaulting and full ObjectMeta validation are not covered. No workload manifests or cluster configuration are changed.