### PR TITLE
fix(codex): return valid JSON from Mink stop hook

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,101 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink pre-read"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink pre-write"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink pre-write"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink post-read"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink post-write"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink post-write"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink post-tool"
+          }
+        ]
+      },
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink post-tool"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink session-start"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink session-stop 1>&2 && printf '%s\\n' '{}'"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Codex reports `hook returned invalid stop hook JSON output` because the existing local Stop handler invokes `mink session-stop`, which emits no JSON response and can print reflection diagnostics to stdout.

Track the existing Codex hook configuration and change only the Stop command: send Mink output to stderr, then emit `{}` on stdout after a successful exit. Failures retain their nonzero exit code; Mink session capture remains enabled.

Validation: isolated stub checks cover silent success, text output with diagnostics, and exit-code propagation. JSON parsing and `git diff --check` passed. The real session finalizer was not invoked during tests.
