### PR TITLE
Add mcp-grafana so power questions can be asked instead of dashboarded

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,101 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink pre-read"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink pre-write"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink pre-write"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink post-read"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink post-write"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink post-write"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink post-tool"
+          }
+        ]
+      },
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink post-tool"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink session-start"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mink session-stop 1>&2 && printf '%s\\n' '{}'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/my-apps/development/mcp-grafana/README.md
+++ b/my-apps/development/mcp-grafana/README.md
@@ -1,0 +1,54 @@
+# mcp-grafana
+
+Grafana Labs' official [MCP server](https://github.com/grafana/mcp-grafana).
+It lets an MCP client (Claude Code, Claude Desktop) query this cluster's
+Grafana — and through it, Prometheus — in plain language, instead of opening a
+dashboard.
+
+Every Tapo plug's power, energy and cost already lands in Prometheus as
+`homeassistant_sensor_*` with `friendly_name` labels, so questions like "which
+box cost the most this month" are answerable without building a panel first.
+
+## Before it will start
+
+Two values must exist in the 1Password `homelab-prod` vault, in an item named
+**`mcp-grafana`**. The ExternalSecret will stay unresolved and the pod will not
+start until both are there.
+
+| Property | What it is |
+|---|---|
+| `grafana_service_account_token` | Grafana → Administration → Users and access → Service accounts. **Viewer** role is enough |
+| `server_token` | Any long random string you invent, e.g. `openssl rand -hex 32`. Callers must present it |
+
+Viewer is deliberate: the server also runs `--disable-write`, so the token
+cannot be used to change dashboards even if it leaks.
+
+## Connecting a client
+
+```bash
+claude mcp add --transport http mcp-grafana \
+  https://mcp-grafana.vanillax.me \
+  --header "Authorization: Bearer <server_token>"
+```
+
+## Why it is shaped this way
+
+**Internal route only.** This hands out query access to every Grafana
+datasource. It is parented to `gateway-internal-technitium` and must never be
+moved to `gateway-external`.
+
+**`--address=0.0.0.0:8000`.** The binary defaults to `localhost:8000`, which in
+a pod accepts nothing. Without this flag the readiness probe never passes.
+
+**`command` is overridden.** The image bakes `--transport sse --address
+0.0.0.0:8000` into its ENTRYPOINT, so setting `args` alone appends a second,
+conflicting `--transport`. Owning the whole argv avoids relying on which
+duplicate flag Go's parser happens to keep.
+
+**`--allowed-hosts` is enumerated.** The server validates the `Host` header.
+Adding a new hostname for this service means adding it to that list too, or
+requests arrive and are rejected.
+
+**Origin validation is left at its default** (reject anything sending an
+`Origin` header). MCP clients are not browsers; if a browser-based client is
+ever needed, that is when `--allowed-origins` gets set.

--- a/my-apps/development/mcp-grafana/deployment.yaml
+++ b/my-apps/development/mcp-grafana/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-grafana
+  namespace: mcp-grafana
+  labels:
+    app: mcp-grafana
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: mcp-grafana
+  template:
+    metadata:
+      labels:
+        app: mcp-grafana
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 999
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mcp-grafana
+          image: grafana/mcp-grafana:1.3.0@sha256:5114852743e450fe5186b6c1712419843eb4bd295e47e64c452c3aa0fab3c42e
+          # The image bakes `--transport sse --address 0.0.0.0:8000` into its
+          # ENTRYPOINT, so `args` alone would append a second conflicting
+          # --transport. Override command to own the whole argv.
+          command: ["/app/mcp-grafana"]
+          args:
+            - --transport=streamable-http
+            # Default is localhost:8000, which accepts nothing from outside the pod.
+            - --address=0.0.0.0:8000
+            - --disable-write
+            # Empty default rejects any request carrying an Origin header, which
+            # is what we want: MCP clients are not browsers.
+            - --allowed-hosts=mcp-grafana.vanillax.me,mcp-grafana.vanillax.me:80,mcp-grafana.mcp-grafana.svc.cluster.local:8000,localhost:8000,127.0.0.1:8000
+            - --log-level=info
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: GRAFANA_URL
+              value: "http://kube-prometheus-stack-grafana.prometheus-stack.svc.cluster.local"
+          envFrom:
+            - secretRef:
+                name: mcp-grafana
+          # No documented health endpoint, and /metrics is off by default, so
+          # probe the listener itself.
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi

--- a/my-apps/development/mcp-grafana/externalsecret.yaml
+++ b/my-apps/development/mcp-grafana/externalsecret.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mcp-grafana
+  namespace: mcp-grafana
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: mcp-grafana
+    creationPolicy: Owner
+  data:
+    # Grafana service account token (Administration > Users and access >
+    # Service accounts). Viewer role is enough — the server runs --disable-write.
+    - secretKey: GRAFANA_SERVICE_ACCOUNT_TOKEN
+      remoteRef:
+        key: mcp-grafana
+        property: grafana_service_account_token
+    # Bearer token every MCP client must send. Without it, anything on the LAN
+    # that can reach the route can query Grafana.
+    - secretKey: MCP_GRAFANA_SERVER_TOKEN
+      remoteRef:
+        key: mcp-grafana
+        property: server_token

--- a/my-apps/development/mcp-grafana/httproute.yaml
+++ b/my-apps/development/mcp-grafana/httproute.yaml
@@ -1,0 +1,30 @@
+# INTERNAL route only — this hands out query access to every Grafana datasource,
+# so it must never reach gateway-external.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp-grafana
+  namespace: mcp-grafana
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-internal-technitium
+      namespace: gateway
+  hostnames:
+    - "mcp-grafana.vanillax.me"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      timeouts:
+        # Streamable-HTTP holds a long-lived session open.
+        request: 30m
+        backendRequest: 30m
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: mcp-grafana
+          port: 8000
+          weight: 1

--- a/my-apps/development/mcp-grafana/kustomization.yaml
+++ b/my-apps/development/mcp-grafana/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mcp-grafana
+
+# List EVERY file here — unlisted YAML is never deployed (Kustomize only renders what's listed).
+resources:
+  - namespace.yaml
+  - externalsecret.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - vpa.yaml

--- a/my-apps/development/mcp-grafana/namespace.yaml
+++ b/my-apps/development/mcp-grafana/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-grafana

--- a/my-apps/development/mcp-grafana/service.yaml
+++ b/my-apps/development/mcp-grafana/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-grafana
+  namespace: mcp-grafana
+spec:
+  selector:
+    app: mcp-grafana
+  ports:
+    # Named "http" so the HTTPRoute can bind to it — unnamed ports fail silently.
+    - name: http
+      port: 8000
+      targetPort: http
+      protocol: TCP

--- a/my-apps/development/mcp-grafana/vpa.yaml
+++ b/my-apps/development/mcp-grafana/vpa.yaml
@@ -1,0 +1,22 @@
+# VPA policy is owned with this application so Argo prunes it with the target.
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: mcp-grafana
+  namespace: mcp-grafana
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mcp-grafana
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        controlledResources: ["cpu", "memory"]
+        controlledValues: RequestsOnly
+        maxAllowed:
+          cpu: "1"
+          memory: 512Mi


### PR DESCRIPTION
## What

Deploys Grafana Labs' official [MCP server](https://github.com/grafana/mcp-grafana) as a normal `my-apps` application, so an MCP client (Claude Code) can query Grafana — and through it, Prometheus — in plain language instead of opening a dashboard.

Every Tapo plug's power, energy and cost already lands in Prometheus as `homeassistant_sensor_*` with `friendly_name` labels, so "which box cost the most this month" becomes answerable without building a panel for it first.

## Four things the binary does that are easy to get wrong

These drove most of the manifest, so they're worth calling out for review:

1. **It listens on `localhost:8000` by default** — which inside a pod accepts nothing, and leaves readiness failing forever with no obvious error. Hence `--address=0.0.0.0:8000`.
2. **Its ENTRYPOINT already carries `--transport sse --address 0.0.0.0:8000`.** Supplying only `args` appends a *second* conflicting `--transport`, leaving the outcome to whichever duplicate Go's flag parser keeps. `command` is overridden so this manifest owns the whole argv.
3. **It validates the `Host` header** against `--allowed-hosts`. Any future hostname for this service has to be added there as well as to the HTTPRoute, or requests arrive and get rejected.
4. **Its default Origin policy rejects any request carrying an `Origin` header.** That's correct for non-browser MCP clients, so it's left alone deliberately.

Flags and the image entrypoint were verified by running `grafana/mcp-grafana:1.3.0 --help` and `docker image inspect`, not from the docs — the published docs page still describes 0.17.2.

## Security posture

- **Internal gateway only** (`gateway-internal-technitium`). This is query access to every Grafana datasource; it must never move to `gateway-external`.
- `--disable-write` is set, and the Grafana service account is expected to be **Viewer**, so the token can't mutate dashboards even if it leaks.
- A separate bearer token (`MCP_GRAFANA_SERVER_TOKEN`) gates the endpoint itself — reaching the route is not enough to use it.
- Runs as uid 1000 / gid 999 (the image's own user), non-root, read-only rootfs, all capabilities dropped.

## Before this will start

A 1Password item named **`mcp-grafana`** must exist with two properties:

| Property | What |
|---|---|
| `grafana_service_account_token` | Grafana → Administration → Users and access → Service accounts, **Viewer** role |
| `server_token` | Any long random string, e.g. `openssl rand -hex 32` |

Until then the ExternalSecret stays unresolved and the pod doesn't start. Setup and client-connection steps are in the app README.

## Validation

- `kubectl kustomize my-apps/development/mcp-grafana` builds clean (6 resources).
- `scripts/validate-argocd-apps.sh` passes; the warnings it prints are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEu8ct3Tw4s3WjU11SpmTx