### PR TITLE
fix(langfuse): redirect HTTP sign-in to HTTPS

### DIFF
--- a/my-apps/ai/langfuse/httproute.yaml
+++ b/my-apps/ai/langfuse/httproute.yaml
@@ -10,6 +10,7 @@ spec:
   - kind: Gateway
     name: gateway-internal-technitium
     namespace: gateway
+    sectionName: https
   hostnames:
   - langfuse.vanillax.me
   rules:
@@ -23,3 +24,25 @@ spec:
     backendRefs:
     - name: langfuse-web
       port: 3000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: langfuse-http-redirect
+  namespace: langfuse
+  annotations:
+    argocd.argoproj.io/sync-wave: '3'
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: gateway-internal-technitium
+    namespace: gateway
+    sectionName: http
+  hostnames:
+  - langfuse.vanillax.me
+  rules:
+  - filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 301


### PR DESCRIPTION
Langfuse currently serves its sign-in page over HTTP even though NEXTAUTH_URL is HTTPS. It issues Secure CSRF/session cookies, which clients cannot send over HTTP, leaving sign-in unable to complete.

Bind the application route to the HTTPS listener and add an HTTP-only 301 redirect to HTTPS. Both resources stay in the existing application and sync wave.

Validation: the existing admin credentials authenticated successfully over certificate-validated HTTPS and returned an authenticated session. An unauthenticated HTTP check confirmed the CSRF cookie is Secure and excluded from HTTP requests. Kustomize rendering, Kubernetes server-side dry-run, and git diff whitespace checks passed. No live routing changes have been applied.
