### PR TITLE
fix(argocd): stop stuck syncs from blocking newer fixes

### DIFF
--- a/.github/workflows/argocd-cache-contract.yml
+++ b/.github/workflows/argocd-cache-contract.yml
@@ -6,6 +6,8 @@ on:
       - 'my-apps/common/**'
       - 'scripts/validate-argocd-cache-paths.py'
       - 'scripts/tests/test_argocd_cache_paths.py'
+      - 'scripts/tests/test_argocd_sync_recovery.py'
+      - '.github/workflows/cluster-ci.yml'
       - '.github/workflows/argocd-cache-contract.yml'
   push:
     branches: [main]
@@ -14,6 +16,8 @@ on:
       - 'my-apps/common/**'
       - 'scripts/validate-argocd-cache-paths.py'
       - 'scripts/tests/test_argocd_cache_paths.py'
+      - 'scripts/tests/test_argocd_sync_recovery.py'
+      - '.github/workflows/cluster-ci.yml'
       - '.github/workflows/argocd-cache-contract.yml'
 permissions:
   contents: read
@@ -26,9 +30,22 @@ jobs:
         with:
           python-version: '3.12'
       - run: python -m pip install PyYAML==6.0.3
+      - name: Read the shared render-tool versions
+        run: |
+          python - <<'PYTHON'
+          import os, yaml
+          with open('.github/workflows/cluster-ci.yml') as f:
+              versions = yaml.safe_load(f)['env']
+          with open(os.environ['GITHUB_ENV'], 'a') as f:
+              for key in ('KUSTOMIZE_VERSION', 'HELM_VERSION'):
+                  print(f'{key}={versions[key]}', file=f)
+          PYTHON
       - uses: imranismail/setup-kustomize@v2
         with:
-          kustomize-version: '5.8.1'
+          kustomize-version: ${{ env.KUSTOMIZE_VERSION }}
+      - uses: azure/setup-helm@v4
+        with:
+          version: v${{ env.HELM_VERSION }}
       - name: Test path semantics
         run: python -m unittest discover -s scripts/tests -p test_argocd_cache_paths.py -v
       - name: Validate the rendered registry and bootstrap seed
@@ -36,3 +53,5 @@ jobs:
           set -euo pipefail
           kustomize build infrastructure/controllers/argocd/apps > /tmp/argocd-entrypoints.yaml
           python scripts/validate-argocd-cache-paths.py /tmp/argocd-entrypoints.yaml infrastructure/controllers/argocd/root.yaml
+      - name: Test rendered sync deadlines and retry recovery
+        run: python -m unittest discover -s scripts/tests -p test_argocd_sync_recovery.py -v

--- a/infrastructure/controllers/argocd/apps/kustomization.yaml
+++ b/infrastructure/controllers/argocd/apps/kustomization.yaml
@@ -61,3 +61,18 @@ patches:
       - op: add
         path: /spec/template/metadata/annotations/argocd.argoproj.io~1manifest-generate-paths
         value: .;/my-apps/common
+  # Retry against current Git without changing each app's backoff or storage safety options.
+  - target:
+      group: argoproj.io
+      kind: Application
+    patch: |-
+      - op: add
+        path: /spec/syncPolicy/retry/refresh
+        value: true
+  - target:
+      group: argoproj.io
+      kind: ApplicationSet
+    patch: |-
+      - op: add
+        path: /spec/template/spec/syncPolicy/retry/refresh
+        value: true

--- a/infrastructure/controllers/argocd/root.yaml
+++ b/infrastructure/controllers/argocd/root.yaml
@@ -47,14 +47,9 @@ spec:
     - ServerSideApply=true
     - RespectIgnoreDifferences=true
     retry:
-      # Bounded retry on root (children keep `limit: -1`). A stuck sync op
-      # holds a frozen manifest snapshot; while `limit: -1` is infinite, a
-      # failed child (e.g. otel's CrashLoopBackOff on 2026-04-20) keeps
-      # the op alive forever and wedges every new git push behind the
-      # stale snapshot. With `limit: 10`, the op fails cleanly after
-      # ~10×3m = ~30 min ceiling; `selfHeal: true` then triggers a FRESH
-      # sync op on the next reconcile with CURRENT git — functionally
-      # still infinite, just with manifest-refresh between ops.
+      # Retry count is not a deadline; controller.sync.timeout.seconds bounds operation age.
+      # This seed is applied at bootstrap, not reconciled by the root app itself.
+      refresh: true
       limit: 10
       backoff:
         duration: 5s

--- a/infrastructure/controllers/argocd/values.yaml
+++ b/infrastructure/controllers/argocd/values.yaml
@@ -6,6 +6,8 @@ configs:
     controller.status.processors: "50"
     # Performance: increase concurrent sync operations (default 10)
     controller.operation.processors: "25"
+    # Bound the whole sync operation, including retries and health waits; polling is separate.
+    controller.sync.timeout.seconds: "1800"
     # Performance: limit concurrent manifest generations to prevent OOM
     reposerver.parallelism.limit: "5"
     # Redis manifest-cache TTL (default 24h). 2026-07-19: repo-server cached

--- a/scripts/tests/test_argocd_sync_recovery.py
+++ b/scripts/tests/test_argocd_sync_recovery.py
@@ -1,0 +1,119 @@
+"""Check source policy and the actual Helm/Kustomize output; never contact a cluster."""
+from copy import deepcopy
+from pathlib import Path
+import subprocess
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+ARGO = ROOT / "infrastructure/controllers/argocd"
+TIMEOUT_KEY = "controller.sync.timeout.seconds"
+TIMEOUT_ENV = "ARGOCD_APPLICATION_CONTROLLER_SYNC_TIMEOUT"
+
+
+def load(path):
+    with path.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def render(path, *args):
+    result = subprocess.run(
+        ["kustomize", "build", str(path), *args],
+        cwd=ROOT, capture_output=True, text=True, timeout=300,
+    )
+    if result.returncode:
+        raise AssertionError(f"Render failed for {path}:\n{result.stderr}")
+    return [doc for doc in yaml.safe_load_all(result.stdout) if isinstance(doc, dict)]
+
+
+def policy(doc):
+    spec = doc["spec"]
+    if doc["kind"] == "ApplicationSet":
+        spec = spec["template"]["spec"]
+    return spec["syncPolicy"]
+
+
+class SourceSyncRecoveryTests(unittest.TestCase):
+    def test_deadline_is_a_command_parameter_not_a_polling_setting(self):
+        values = load(ARGO / "values.yaml")
+        self.assertEqual(values["configs"]["params"][TIMEOUT_KEY], "1800")
+        self.assertNotIn(TIMEOUT_KEY, values["configs"]["cm"])
+        for arg in values.get("controller", {}).get("extraArgs", []):
+            self.assertFalse(arg.startswith("--sync-timeout"), "CLI overrides the ConfigMap")
+        for entry in values.get("controller", {}).get("env", []):
+            self.assertNotEqual(entry["name"], TIMEOUT_ENV, "Do not shadow the chart's env wiring")
+
+    def test_bootstrap_seed_has_bounded_refreshing_retries(self):
+        root = load(ARGO / "root.yaml")
+        retry = policy(root)["retry"]
+        self.assertIs(retry["refresh"], True)
+        self.assertEqual(retry["limit"], 10)
+        self.assertEqual(retry["backoff"], {"duration": "5s", "factor": 2, "maxDuration": "3m"})
+
+    def test_root_remains_bootstrap_only(self):
+        for path in (ARGO / "kustomization.yaml", ARGO / "apps/kustomization.yaml"):
+            resources = load(path)["resources"]
+            self.assertFalse(any(Path(item).name == "root.yaml" for item in resources))
+
+
+class RenderedSyncRecoveryTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Missing tools or broken renders must fail CI, not silently skip these checks.
+        cls.entrypoints = render(ARGO / "apps")
+        cls.controller_resources = render(ARGO, "--enable-helm")
+
+    def test_all_entrypoints_and_generated_apps_refresh_retries(self):
+        apps = [d for d in self.entrypoints if d["kind"] == "Application"]
+        appsets = [d for d in self.entrypoints if d["kind"] == "ApplicationSet"]
+        self.assertGreater(len(apps), 0)
+        self.assertEqual(
+            {d["metadata"]["name"] for d in appsets},
+            {"infrastructure", "database", "monitoring", "my-apps"},
+        )
+        for doc in apps + appsets:
+            with self.subTest(kind=doc["kind"], name=doc["metadata"]["name"]):
+                retry = policy(doc)["retry"]
+                self.assertIs(retry["refresh"], True)
+                self.assertGreater(retry["limit"], 0)
+                self.assertIn("maxDuration", retry["backoff"])
+
+    def test_refresh_patch_preserves_existing_sync_safety_and_backoff(self):
+        rendered = {(d["kind"], d["metadata"]["name"]): d for d in self.entrypoints}
+        checked = 0
+        for resource in load(ARGO / "apps/kustomization.yaml")["resources"]:
+            with (ARGO / "apps" / resource).open(encoding="utf-8") as handle:
+                for doc in yaml.safe_load_all(handle):
+                    if not isinstance(doc, dict) or doc.get("kind") not in ("Application", "ApplicationSet"):
+                        continue
+                    key = (doc["kind"], doc["metadata"]["name"])
+                    with self.subTest(resource=resource, name=key[1]):
+                        before = deepcopy(policy(doc))
+                        after = deepcopy(policy(rendered[key]))
+                        before["retry"].pop("refresh", None)
+                        after["retry"].pop("refresh", None)
+                        self.assertEqual(after, before)
+                    checked += 1
+        self.assertGreater(checked, 0)
+
+    def test_rendered_deadline_reaches_the_controller_and_rolls_its_pod(self):
+        resources = {(d["kind"], d["metadata"]["name"]): d for d in self.controller_resources}
+        params = resources[("ConfigMap", "argocd-cmd-params-cm")]
+        self.assertEqual(params["data"][TIMEOUT_KEY], "1800")
+        controller = resources[("StatefulSet", "argocd-application-controller")]
+        template = controller["spec"]["template"]
+        containers = template["spec"]["containers"]
+        main = next(c for c in containers if c["name"] == "application-controller")
+        refs = [e for e in main["env"] if e["name"] == TIMEOUT_ENV]
+        self.assertEqual(len(refs), 1)
+        self.assertNotIn("value", refs[0])
+        ref = refs[0]["valueFrom"]["configMapKeyRef"]
+        self.assertEqual((ref["name"], ref["key"]), ("argocd-cmd-params-cm", TIMEOUT_KEY))
+        self.assertFalse(any(a.startswith("--sync-timeout") for a in main["args"]))
+        self.assertRegex(template["metadata"]["annotations"]["checksum/cmd-params"], r"^[0-9a-f]{64}$")
+        self.assertEqual(controller["spec"].get("updateStrategy", {}).get("type", "RollingUpdate"), "RollingUpdate")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this fixes

Langfuse's sync waited roughly 14 hours for storage and blocked newer Git fixes until an administrator stopped the operation. A retry count did not help because a health wait never returned a failure.

## Changes

- Set Argo CD's built-in **30-minute whole-operation deadline** (`controller.sync.timeout.seconds: "1800"`). This is separate from polling, hard refresh and repo-server rendering timeouts.
- Set `retry.refresh: true` on the existing rendered Application entrypoints and all four ApplicationSet templates. Retries can resolve current Git without changing each app's retry count, backoff, pruning, shared-resource checks or PVC ignore rules.
- Update the root bootstrap seed and remove its incorrect comment claiming retry backoff imposed a time limit.
- Add six source/render regression tests to the existing Argo contract workflow. They check the effective command ConfigMap, controller environment binding and rollout checksum, all entrypoint retry policies, and preservation of existing sync settings. Render-tool versions come from Cluster CI rather than a second set of pins.

No watchdog, new operator, storage deletion, restore bypass, workload changes or additional alerts.

## Important behavior and rollout

The deadline covers the **entire operation, including retries**, not 30 minutes per attempt. Argo terminates the expired operation; it does not guarantee unlimited automatic retries of a failed SHA. Once that operation ends, a newer OutOfSync revision can start normally. `retry.refresh` helps returned failures; it does not interrupt a health wait on its own.

After merge/sync, the chart's command-parameter checksum rolls the application-controller so it reads the new setting. Argo can clean up its own hooks on termination. Ordinary PVCs and Kopiur restore resources are not removed by this change and restore-before-bind stays intact.

The supplied read-only investigation's 99 completed operations had a maximum successful sync of 662 seconds. Thirty minutes allows headroom over that sample, **not a proven cold-disaster-recovery upper bound**. Raise the finite deadline in Git before a known longer restore, bootstrap or migration. Revert this PR to restore the previous behavior if the deadline disrupts legitimate operations.

`root.yaml` is deliberately a bootstrap seed, not a self-managed resource. Its new retry-refresh field only reaches an existing root if the seed is deliberately reapplied; it must not be added to Argo's own kustomization. The global controller deadline still covers the existing root without that reapply.

## Verification

- Three local source-policy tests pass; Python compilation, edited YAML parsing, shell syntax and whitespace checks pass.
- The other three tests run actual Helm/Kustomize renders in GitHub Actions and fail rather than skip when rendering/tools are unavailable.
- Full Cluster CI also runs on this PR. Check the latest Actions result before merging.
- No live-cluster actions performed; leave this PR unmerged for review.

Implementation checked against Argo CD v3.5.2 `controller/appcontroller.go` (`processRequestedAppOperation`, `autoSync`) and argo-cd chart 10.8.1's application-controller StatefulSet template.