### PR TITLE
fix(media): unblock Immich rollout and Karakeep secret sync

### DIFF
--- a/my-apps/media/immich/deployment-machine-learning.yaml
+++ b/my-apps/media/immich/deployment-machine-learning.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: immich-machine-learning
   namespace: immich
+  annotations:
+    # Client-side apply clears legacy rollingUpdate fields when switching to Recreate.
+    argocd.argoproj.io/sync-options: ServerSideApply=false
   labels:
     app.kubernetes.io/name: immich
     app.kubernetes.io/component: machine-learning
@@ -10,6 +13,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app.kubernetes.io/name: immich

--- a/my-apps/media/karakeep/karakeep/externalsecret.yaml
+++ b/my-apps/media/karakeep/karakeep/externalsecret.yaml
@@ -11,6 +11,7 @@ spec:
   target:
     name: karakeep-secret
     creationPolicy: Owner
+  # Omit ignored defaults so ArgoCD does not restore the old data list during sync.
   data:
     - secretKey: OPENAI_API_KEY
       remoteRef:
@@ -21,27 +22,15 @@ spec:
       remoteRef:
         key: karakeep-secret
         property: karakeep-nextauth
-        conversionStrategy: Default
-        decodingStrategy: None
-        metadataPolicy: None
     - secretKey: MEILI_MASTER_KEY
       remoteRef:
         key: karakeep-secret
         property: karakeep-meili
-        conversionStrategy: Default
-        decodingStrategy: None
-        metadataPolicy: None
     - secretKey: WEBHOOK_SECRET
       remoteRef:
         key: karakeep-secret
         property: karakeep-webhook
-        conversionStrategy: Default
-        decodingStrategy: None
-        metadataPolicy: None
     - secretKey: NEXTAUTH_PUBLIC_SECRET
       remoteRef:
         key: karakeep-secret
         property: karakeep-nextauth-public_secret
-        conversionStrategy: Default
-        decodingStrategy: None
-        metadataPolicy: None


### PR DESCRIPTION
Immich machine learning cannot sync because its live RollingUpdate fields survive the switch to Recreate under server-side apply. Use resource-scoped client-side apply and explicitly clear rollingUpdate; the existing pod template and PVCs stay intact.

Karakeep web cannot start because OPENAI_API_KEY is absent from its Secret. ArgoCD 3.5.2 normalization copies the live four-entry ExternalSecret data array over the desired five-entry array when ignored defaults are explicitly present in Git. Remove those redundant defaults so restoreNonIgnoredFields preserves the desired array and ESO can fetch the existing LiteLLM master key.

Validation:
- Both full application Kustomize renders pass.
- Server dry-runs of the rendered resources accept Recreate without rollingUpdate and all five secret references.
- Reproduced the four-entry failure and five-entry fix using restoreNonIgnoredFields extracted from upstream ArgoCD v3.5.2 controller/sync.go.
- ArgoCD structure and no-inline-script checks pass (existing storage namespace wave warnings).

Deployment verification after merge: both Applications should become Synced/Healthy; karakeep-secrets should advance its generation and ESO should populate OPENAI_API_KEY, allowing the waiting web pod to start. No live configuration changes were made during diagnosis.
