### PR TITLE
Document the /mcp endpoint path and read the token from 1Password

### DIFF
--- a/my-apps/development/mcp-grafana/README.md
+++ b/my-apps/development/mcp-grafana/README.md
@@ -27,9 +27,12 @@ cannot be used to change dashboards even if it leaks.
 
 ```bash
 claude mcp add --transport http mcp-grafana \
-  https://mcp-grafana.vanillax.me \
-  --header "Authorization: Bearer <server_token>"
+  https://mcp-grafana.vanillax.me/mcp \
+  --header "Authorization: Bearer $(op read 'op://homelab-prod/mcp-grafana/server_token')"
 ```
+
+The path matters: the server serves MCP at **`/mcp`**, not at the root. A bare
+hostname returns 404 and the client reports only that it could not connect.
 
 ## Why it is shaped this way
 


### PR DESCRIPTION
Small correction found while bringing mcp-grafana up for real.

**The server serves MCP at `/mcp`, not at the root** — confirmed from its own startup log:

```
msg="Starting Grafana MCP server using StreamableHTTP transport" address=0.0.0.0:8000 endpointPath=/mcp
```

The connect example in the README pointed at the bare hostname. That returns 404, and the MCP client surfaces it only as "could not connect" — so the mistake is invisible from the client side and would have cost real debugging time.

Also switches the example to read the bearer token with `op read` instead of telling you to paste it, now that the item exists at `op://homelab-prod/mcp-grafana`.

## Verified live

The app is deployed and working:

- `initialize` over streamable-http through the internal route returns the server capabilities and tool list.
- No bearer token → **401**. Wrong bearer token → **401**.
- Hostname does not resolve through a public resolver → **403**, so it is not externally exposed.
- Pod `1/1 Running`, Application `Synced / Healthy`.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEu8ct3Tw4s3WjU11SpmTx