### PR TITLE
feat(frigate): enable 0.18 RC2 on HP Elite with OpenVINO

### DIFF
--- a/my-apps/home/frigate/README.md
+++ b/my-apps/home/frigate/README.md
@@ -11,6 +11,59 @@ The setup involves three main components:
 2.  **Frigate Deployment**: The deployment is configured to pass these credentials as environment variables to the Frigate container.
 3.  **Frigate `config.yml`**: The configuration file defines the `go2rtc` streams using the `nest:` provider, which uses the environment variables to authenticate with Google's API.
 
+## Runtime and upgrade
+
+Git declares Frigate **0.18.0-rc2**, pinned by image digest, with one replica on
+`node.vanillax.dev/class: hp-elite-worker` (the HP Elite i5-13500T). Detection
+uses the bundled SSD MobileNet model through **OpenVINO on CPU**. Video decode
+and the existing Nest H.264 re-encode streams also use CPU. The six Nest
+streams retain their keyframe workaround; camera stability on this release
+must be checked after deployment.
+
+The Talos VM currently advertises no Intel GPU device or Intel GPU resource.
+OpenVINO supports Intel integrated GPUs, but switching `device` to `GPU` alone
+will not expose the physical GPU. GPU acceleration requires a separate
+Proxmox passthrough change, Talos Intel driver/firmware support, and container
+access to the render device. Once verified, OpenVINO can use `GPU` and FFmpeg
+can use VAAPI. With FFmpeg 8, go2rtc hardware transcodes also require an explicit
+`go2rtc.ffmpeg.global: "-vaapi_device /dev/dri/renderD128"` (using the verified
+render path).
+
+Sources: [0.18 RC2 release and breaking changes](https://github.com/blakeblackshear/frigate/discussions/24215),
+[OpenVINO support](https://github.com/blakeblackshear/frigate/blob/v0.18.0-rc2/docs/docs/configuration/object_detectors.md#openvino-detector),
+[FFmpeg 8 hardware transcoding](https://github.com/blakeblackshear/frigate/blob/v0.18.0-rc2/docs/docs/troubleshooting/go2rtc.md#hardware-accelerated-transcoding-with-ffmpeg-8).
+
+The ConfigMap remains the Git-owned configuration; make configuration changes
+through PRs. The file declares schema version `0.18-0` and is validated directly
+against the RC image, because Frigate cannot migrate the mounted ConfigMap in
+place. UI configuration writes are not supported with this mount.
+
+Before upgrade, verify a successful `frigate-config` kopiur snapshot (the
+config PVC includes `frigate.db`). The stopped deployment had successful daily
+snapshots before this upgrade was prepared. Keep that pre-upgrade snapshot
+for rollback: a newer database may not work with an older image.
+
+After merge:
+
+```bash
+kubectl -n frigate rollout status deployment/frigate --timeout=180s
+kubectl -n frigate get pods -o wide
+kubectl -n argocd get application my-apps-frigate
+kubectl -n frigate logs deployment/frigate --since=5m
+```
+
+Expect a ready Frigate pod on the HP Elite, ArgoCD Synced/Healthy, a running
+OpenVINO detector, and no repeated MQTT authentication or FFmpeg restart
+errors. Use the stream check below to verify all six cameras receive frames;
+pod readiness alone does not establish that cameras or recordings work.
+
+To stop a failing rollout, submit a PR setting `replicas: 0`. To return to the
+older release, revert the upgrade through a PR and restore the pre-upgrade
+config/database snapshot if database migrations ran; follow the
+[backup/restore architecture](../../../docs/domains/storage/kopiur-backup-architecture.md).
+Do not mount a migrated database into the older image without a compatible
+restore.
+
 ## Credentials and Setup Process
 
 This integration requires a one-time, manual setup process to obtain the necessary credentials from Google.

--- a/my-apps/home/frigate/config.yml
+++ b/my-apps/home/frigate/config.yml
@@ -1,9 +1,10 @@
+version: "0.18-0"
 mqtt:
   host: mosquitto.frigate
   port: 1883
   topic_prefix: frigate
-  user: "${FRIGATE_MQTT_USER}"
-  password: "${FRIGATE_MQTT_PASSWORD}"
+  user: "{FRIGATE_MQTT_USER}"
+  password: "{FRIGATE_MQTT_PASSWORD}"
 database:
   path: /config/frigate.db
 ui:
@@ -50,8 +51,7 @@ model:
   labelmap_path: /openvino-model/coco_91cl_bkgr.txt
 ffmpeg:
   input_args: preset-rtsp-generic
-  # The Dell worker is CPU-only. Omitting hwaccel_args deliberately selects
-  # software decode; detection also remains OpenVINO-on-CPU.
+  # Intel GPU passthrough is not configured; decode and OpenVINO use the HP CPU.
   # Nest streams carry Opus audio; MP4 recordings need AAC. This preset
   # transcodes audio to AAC for the record role (without it, recordings are
   # silent or fail to mux the Opus track).

--- a/my-apps/home/frigate/deployment.yaml
+++ b/my-apps/home/frigate/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: frigate
   namespace: frigate
 spec:
-  replicas: 0
+  replicas: 1
   strategy:
     type: Recreate
   selector:
@@ -15,15 +15,14 @@ spec:
       labels:
         app: frigate
     spec:
-      # Keep Frigate on the Dell because its camera traffic stays in the yard
-      # failure domain. The Dell is CPU-only; decode falls back to software.
+      # The HP Elite exposes its i5-13500T CPU, but no Intel GPU in the Talos VM.
       nodeSelector:
-        node.vanillax.dev/class: dell-worker
+        node.vanillax.dev/class: hp-elite-worker
       containers:
       - name: frigate
-        # Renovate off until the Nest WebRTC keyframe-starvation regression (seen on 0.17.2) is bisected.
+        # Keep the release candidate pinned until Nest streaming is verified.
         # renovate: ignore
-        image: ghcr.io/blakeblackshear/frigate:0.17.2
+        image: ghcr.io/blakeblackshear/frigate:0.18.0-rc2@sha256:9678a83a76e4730ac7d9ea7428370e32ae656d6b312aaad30d6c69f3fef14d35
         imagePullPolicy: IfNotPresent
         env:
         - name: TZ


### PR DESCRIPTION
Enable Frigate with one replica on the HP Elite i5-13500T and upgrade from 0.17.2 to the requested [0.18.0-rc2](https://github.com/blakeblackshear/frigate/discussions/24215), pinned by digest. Keep the existing six-camera Nest re-encode workaround and OpenVINO CPU detector. The HP Talos VM advertises no Intel GPU device/resource, so GPU inference and VAAPI require a separate passthrough/driver change.

Declare the 0.18 config schema explicitly for the Git-owned ConfigMap, and correct MQTT placeholders from `${FRIGATE_*}` to `{FRIGATE_*}`: RC2 otherwise retains a literal dollar sign in the credentials. Document GPU prerequisites, post-merge camera checks, and database-aware rollback.

Validation:
- Actual RC2 image parsed the config with six cameras and asserted correct MQTT substitution using dummy credentials, with networking disabled.
- Bundled SSD MobileNet model compiled and completed OpenVINO CPU inference inside RC2 (local host; not an HP performance measurement).
- Kustomize render and Kubernetes server-side dry-run passed.
- ArgoCD structure, no-inline-script and kopiur coverage checks passed.
- Verified existing bound PVCs, Ready ExternalSecret, and successful pre-upgrade config/database backup. HP currently has low CPU use and roughly 50% free memory.

After merge, verify pod placement/readiness, detector operation, six Nest streams and recording continuity. This prerelease has not yet been run against the live cameras. No live workloads or Proxmox configuration were changed; a Talos device inspection attempt was blocked by expired CLI authentication, so hardware visibility assessment uses Kubernetes NFD/resource evidence and the existing hardware audit.
