### PR TITLE
pi-agent doc: /login cannot configure a custom provider

### DIFF
--- a/docs/domains/ai-gpu/pi-agent-local-dev.md
+++ b/docs/domains/ai-gpu/pi-agent-local-dev.md
@@ -14,10 +14,22 @@ cloud providers. The audit found a stale `qwen3.6-27b` default and the built-in
 
 Back up `~/.pi/agent/models.json`, `settings.json`, and `AGENTS.md` before editing.
 Merge this provider into `models.json`; do not overwrite other providers or
-credentials. Use `/login` for `vanillax-vllm` and enter the LiteLLM key from
-1Password (`homelab-prod/litellm/master_key`). Pi stores it in workstation
-`auth.json`; omit `apiKey` from the provider JSON. A placeholder key fails
-against this authenticated gateway. Keep credentials out of Git.
+credentials. `vanillax-vllm` is a custom `models.json` provider, so `/login`
+cannot configure it -- that picker offers only Pi's built-in providers, and a
+custom provider ID never appears in the list. Supply the LiteLLM key from
+1Password (`homelab-prod/litellm/master_key`) through the provider's `apiKey`
+field, which resolves `"$VAR"` and `"!command"` values as well as literals:
+
+```json
+"apiKey": "$LITELLM_API_KEY"
+```
+
+Export that variable from a file outside Git (the workstation uses `~/.ai-keys`,
+sourced by `.zshrc`), or read it directly with
+`"apiKey": "!op read 'op://homelab-prod/litellm/master_key'"`. Resolution order
+is CLI `--api-key`, `auth.json`, environment variable, then the `models.json`
+value. A placeholder key fails against this authenticated gateway. Keep
+credentials out of Git.
 
 ```json
 {
@@ -25,6 +37,7 @@ against this authenticated gateway. Keep credentials out of Git.
     "vanillax-vllm": {
       "baseUrl": "https://litellm.vanillax.me/v1",
       "api": "openai-completions",
+      "apiKey": "$LITELLM_API_KEY",
       "compat": {
         "supportsDeveloperRole": false,
         "supportsReasoningEffort": false,


### PR DESCRIPTION
The provider setup step said to run `/login` for `vanillax-vllm` and omit `apiKey` from the provider JSON. That picker only lists Pi's built-in providers — a custom `models.json` provider ID never appears in it, so following the step leaves Pi with an empty `auth.json` and no usable models.

Hit this for real on `vanillax-gaming-linux` today: the dotfiles repo had copied this instruction into its own setup guide, and a `chezmoi apply` that removed the inline key left pi with nothing to authenticate with.

Points `apiKey` at `$LITELLM_API_KEY` instead. The field resolves `"$VAR"` and `"!command"` values as well as literals, so the key still never lands in Git — it comes from `~/.ai-keys` or `op read`. Also adds the line to the example provider block so the JSON matches the prose.

Verified after the change:

```
provider          model        context  max-out  thinking  images
vanillax-litellm  kimi-k3      1M       131.1K   yes       yes
vanillax-vllm     qwen3.8-27b  262.1K   32.8K    yes       yes
```

Corresponding dotfiles change: mitchross/dotfiles#5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbLw6QRc95yGuJopfqXJPR