### PR TITLE
fix(frigate): restore HP scheduling and map Nest live views

### DIFF
--- a/my-apps/home/frigate/README.md
+++ b/my-apps/home/frigate/README.md
@@ -173,12 +173,63 @@ kitchen-nest: nest/webrtc - 9016256 bytes
 living-room-nest: nest/webrtc - 10817595 bytes
 ```
 
-### Current Camera Configuration
+### Camera inventory and live views
 
-All cameras are configured with WebRTC protocol:
-- `backyard-nest`: WebRTC
-- `garage-inside-nest`: WebRTC
-- `garage-outside-nest`: WebRTC
-- `front-porch-nest`: WebRTC
-- `kitchen-nest`: WebRTC
-- `living-room-nest`: WebRTC 
+The operator identified these models; Google's device list confirms the names
+and mappings below. All seven devices advertise only `WEB_RTC` through SDM.
+
+| Google Home name | Operator-reported model / power | Frigate camera |
+| --- | --- | --- |
+| Kitchen camera | Nest Cam Indoor, wired | `kitchen` |
+| Living Room camera | Nest Cam Indoor, wired | `living-room` |
+| Backyard camera | Nest Cam Indoor, wired | `backyard` |
+| Garage Inside | Nest Cam Indoor, wired | `garage-inside` |
+| Garage camera | Nest Cam Battery, external cable power | `garage-outside` |
+| Front Porch doorbell | Nest Doorbell Battery, house doorbell wiring | `front-porch` |
+| Front Porch doorbell 2 | Nest Doorbell Wired, 3rd generation | Not configured |
+
+Each camera's `live.streams` explicitly selects its existing `-sub` stream.
+Without this mapping, Frigate defaults to a stream named after the camera,
+which does not exist in this configuration. Recording and detection already
+use `-sub`, explaining how recordings can work while live viewing fails.
+These derived streams provide video only at 5 FPS; this correction does not
+add audio or increase live resolution. See [Frigate live stream selection](https://docs.frigate.video/configuration/live/#setting-streams-for-live-ui).
+
+The battery doorbell remains battery-operated with house wiring supplying a
+trickle charge. Its zero-day continuous retention setting does not stop the
+active detect/record input. Google's session extension exception for battery
+doorbells also applies despite that wiring. The externally powered garage
+camera is a different case. See [Google power behavior](https://support.google.com/googlehome/answer/11830989?hl=en)
+and [SDM live-session rules](https://developers.google.com/nest/device-access/traits/device/camera-live-stream#extendwebrtcstream).
+
+### Frigate Pending after a VPA eviction
+
+If all feeds stop and the pod is Pending, check scheduling before debugging
+Nest credentials:
+
+```bash
+kubectl -n frigate get pods
+kubectl -n frigate get events --sort-by=.lastTimestamp
+kubectl -n frigate get vpa frigate -o yaml
+kubectl describe node talos-prod-cluster-v2-hp-elite-workers-rgkw5s
+```
+
+A verified outage followed `ResizeDeferred`, `EvictedByVPA`, then
+`FailedScheduling: Insufficient memory`: VPA requested 3,481,230,109 bytes
+when the pinned HP node had only 3,339,704,223 bytes of unreserved memory.
+Actual memory usage was lower; scheduler reservations caused the rejection.
+
+The Frigate policy caps memory requests at 3 GiB, retains `RequestsOnly` and
+the 12 GiB runtime limit, and excludes the fixed-size binary installer.
+Its earlier sync wave applies the policy before the Deployment rollout.
+This cap fits the observed reservations with about 114 MiB remaining; it is
+not a capacity guarantee if other workloads grow. Recheck placement and node
+usage before increasing it or adding another continuously decoded camera.
+
+After merge and sync, expect a Ready replacement with a memory request no
+greater than 3 GiB. If an existing Pending pod retains the old request, wait
+for the new capped VPA recommendation before recreating that Pending pod.
+Then verify camera FPS and fresh recordings across multiple five-minute Nest
+sessions. A Ready pod alone does not prove stream recovery. Roll back policy
+changes through a PR, recognizing that restoring the old ceiling can repeat
+the scheduling outage.

--- a/my-apps/home/frigate/config.yml
+++ b/my-apps/home/frigate/config.yml
@@ -197,7 +197,7 @@ cameras:
       fps: 5
     record:
       enabled: true
-      # Disable continuous recording — doorbell battery can't sustain 24/7 streaming
+      # Zero continuous retention still leaves detect/record streaming active.
       continuous:
         days: 0
       motion:

--- a/my-apps/home/frigate/config.yml
+++ b/my-apps/home/frigate/config.yml
@@ -128,6 +128,8 @@ cameras:
       height: 720
       fps: 5
     live:
+      streams:
+        Camera: backyard-sub
       height: 1080
     objects:
       track:
@@ -150,6 +152,8 @@ cameras:
       height: 720
       fps: 5
     live:
+      streams:
+        Camera: garage-inside-sub
       height: 1080
     objects:
       track:
@@ -170,6 +174,8 @@ cameras:
       height: 720
       fps: 5
     live:
+      streams:
+        Camera: garage-outside-sub
       height: 1080
     objects:
       track:
@@ -203,6 +209,8 @@ cameras:
         retain:
           days: 14
     live:
+      streams:
+        Camera: front-porch-sub
       height: 720
     objects:
       track:
@@ -225,6 +233,8 @@ cameras:
       height: 720
       fps: 5
     live:
+      streams:
+        Camera: living-room-sub
       height: 1080
     objects:
       track:
@@ -246,6 +256,8 @@ cameras:
       height: 720
       fps: 5
     live:
+      streams:
+        Camera: kitchen-sub
       height: 1080
     objects:
       track:

--- a/my-apps/home/frigate/vpa.yaml
+++ b/my-apps/home/frigate/vpa.yaml
@@ -4,6 +4,8 @@ kind: VerticalPodAutoscaler
 metadata:
   name: frigate
   namespace: frigate
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   targetRef:
     apiVersion: apps/v1
@@ -19,7 +21,10 @@ spec:
         controlledValues: RequestsOnly
         maxAllowed:
           cpu: "4"
-          memory: 8Gi
+          # Larger reservations stranded the replacement on the pinned HP node.
+          memory: 3Gi
+      - containerName: install-go2rtc
+        mode: "Off"
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler


### PR DESCRIPTION
Frigate currently has two independent failures: all six live views select nonexistent go2rtc stream names, and a VPA eviction left its replacement Pending on the HP Elite because the recommended memory reservation exceeds available scheduler capacity.

- Map each live view to its existing `-sub` feed, already used for recording and detection. This retains the current video-only 5 FPS feed.
- Cap Frigate's VPA memory request at 3 GiB and apply the policy before the Deployment rollout. Keep the 12 GiB memory limit and exclude the fixed-size go2rtc installer from autoscaling. The config hash change creates a replacement pod.
- Document the seven-device Nest inventory, the unconfigured wired third-generation doorbell, and the battery doorbell's actual continuous-capture behavior. Zero retention does not stop streaming.

The HP node had 3,339,704,223 bytes of unreserved memory; VPA requested 3,481,230,109 bytes. A 3 GiB request fits that snapshot with about 114 MiB remaining, so future workload growth still needs placement/capacity review. This change does not establish long-term Nest media recovery or switch the selected doorbell.

Validation: Kustomize render and all six live stream references passed; the stream mapping was previously parsed successfully with the running Frigate RC2 config model. A fresh garage-inside recording previously decoded 50 H264 frames over 10 seconds while its live mapping was incorrect. The current pod is Pending, preventing further runtime checks. The branch includes the main-branch fix for the unrelated CI documentation parsing failure; all 11 affected checks pass locally. Full cluster CI validates VPA coverage (the aggregate validator cannot validate an isolated app without reporting absent exemptions).

After merge: sync `my-apps-frigate`, verify the replacement requests no more than 3 GiB and becomes Ready, then check actual live playback, nonzero camera FPS, and fresh decodable recordings across multiple five-minute Nest session renewals. If an old Pending pod persists, wait for the capped recommendation before recreating it. Roll back through a PR; restoring the old VPA ceiling can repeat the scheduling outage.
