### PR TITLE
fix(ci): reconcile the pi-agent doc with the test that reads it

### DIFF
--- a/docs/domains/ai-gpu/pi-agent-local-dev.md
+++ b/docs/domains/ai-gpu/pi-agent-local-dev.md
@@ -20,7 +20,7 @@ custom provider ID never appears in the list. Supply the LiteLLM key from
 1Password (`homelab-prod/litellm/master_key`) through the provider's `apiKey`
 field, which resolves `"$VAR"` and `"!command"` values as well as literals:
 
-```json
+```text
 "apiKey": "$LITELLM_API_KEY"
 ```
 

--- a/scripts/tests/test_ai_observability.py
+++ b/scripts/tests/test_ai_observability.py
@@ -86,7 +86,9 @@ class AIObservabilityTests(unittest.TestCase):
         blocks = [json.loads(b) for b in re.findall(r'```json\n(.*?)\n```', guide, re.S)]
         provider = next(b['providers']['vanillax-vllm'] for b in blocks if 'providers' in b)
         self.assertEqual(provider['baseUrl'], 'https://litellm.vanillax.me/v1')
-        self.assertNotIn('apiKey', provider)
+        # /login cannot configure a custom provider, so the key is supplied
+        # here; it must stay an indirection, never a literal secret.
+        self.assertRegex(provider['apiKey'], r'^[$!]')
         model = provider['models'][0]
         config = read('my-apps/ai/litellm/config.yaml')
         route = next(m for m in config['model_list'] if m['model_name'] == model['id'])


### PR DESCRIPTION
Cluster CI currently fails on **every** PR that touches `my-apps/` or `scripts/`. Two problems, both from #2295, both in `test_pi_and_webui_use_gateway_without_changing_backend_context`.

## 1. A fragment fenced as `json`

The test parses every ```json block out of `docs/domains/ai-gpu/pi-agent-local-dev.md`. #2295 added this one:

````
```json
"apiKey": "$LITELLM_API_KEY"
```
````

That's a single field, not a document, so `json.loads` raises `Extra data: line 1 column 9`. Re-fenced as `text` — it's prose illustrating one line, and the two real config blocks still parse as JSON.

## 2. The test asserts a rule the doc no longer follows

#2295 established that `/login` cannot configure a custom provider, so `vanillax-vllm` must now supply `apiKey` itself. The test still asserted `assertNotIn('apiKey', provider)` — the superseded rule. Doc and test contradicted each other.

The point of that assertion was keeping credentials out of Git, not banning the field, so it now asserts the value is a `$VAR` or `!command` indirection:

```python
self.assertRegex(provider['apiKey'], r'^[$!]')
```

A literal key pasted into the doc still fails, which is the behaviour worth protecting.

## Why this reached main

`cluster-ci.yml` triggers on `infrastructure/**`, `monitoring/**`, `my-apps/**`, `scripts/**` and two config files. #2295 was docs-only, so Cluster CI never ran on it — even though this test reads a file under `docs/`. Adding `docs/domains/**` to the trigger paths would close the gap; left out of this PR since it changes when CI runs for every docs change, which is your call.

## Verification

- [x] `python3 -m unittest test_ai_observability` — 11 tests, OK (fails on `main` without this)
- [x] both remaining ```json blocks parse

Unblocks #2296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCrSapt6oTLCacsKcK5kBr