### PR TITLE
deal-scout: v0.13.0

### DIFF
--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -217,7 +217,6 @@ jobs:
           python3 -m unittest discover -s scripts/tests -p test_ai_observability.py -v
           python3 -m unittest discover -s my-apps/ai/presenton/scripts -p 'test_*.py' -v
           python3 -m unittest discover -s my-apps/ai/comfyui/scripts -p 'test_*.py' -v
-          python3 -m unittest discover -s my-apps/utility/deal-scout/tests -v
           python3 -m unittest discover -s my-apps/development/news-reader/tests -v
           python3 -m unittest discover -s monitoring/holmesgpt/tests -v
           node --test my-apps/home/n8n/tests/route-workflows.test.cjs

--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.12.4@sha256:2a5bddfb0bc536fd44d979a572000f9e14d3b18e21e8d878dde048056cb0898d
+          image: ghcr.io/mitchross/deal-scout:v0.13.0@sha256:974471ea419c0865a3b53dc7833cebc26f28e2fe7ec9535477826036507b3445
           imagePullPolicy: IfNotPresent
           env:
             - name: LITELLM_API_KEY

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.12.4@sha256:a418834c39b59d3d92cb90789800f762d299cbb5dda8ee59739cd41fb7fdad93
+          image: ghcr.io/mitchross/deal-scout-worker:v0.13.0@sha256:8d5b7cad7d55273f5352d1a440620363feb319df36b1b66cd0800c628e172f7b
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.13.0.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.13.0`.