### PR TITLE
fix(frigate): allow longer recovery for garage and kitchen Nest feeds

### DIFF
--- a/.github/workflows/cluster-ci.yml
+++ b/.github/workflows/cluster-ci.yml
@@ -217,7 +217,6 @@ jobs:
           python3 -m unittest discover -s scripts/tests -p test_ai_observability.py -v
           python3 -m unittest discover -s my-apps/ai/presenton/scripts -p 'test_*.py' -v
           python3 -m unittest discover -s my-apps/ai/comfyui/scripts -p 'test_*.py' -v
-          python3 -m unittest discover -s my-apps/utility/deal-scout/tests -v
           python3 -m unittest discover -s my-apps/development/news-reader/tests -v
           python3 -m unittest discover -s monitoring/holmesgpt/tests -v
           node --test my-apps/home/n8n/tests/route-workflows.test.cjs

--- a/my-apps/home/frigate/README.md
+++ b/my-apps/home/frigate/README.md
@@ -202,13 +202,14 @@ doorbells also applies despite that wiring. The externally powered garage
 camera is a different case. See [Google power behavior](https://support.google.com/googlehome/answer/11830989?hl=en)
 and [SDM live-session rules](https://developers.google.com/nest/device-access/traits/device/camera-live-stream#extendwebrtcstream).
 
-### Garage outside recovery trial
+### Garage outside and kitchen recovery trial
 
-The externally powered battery-model garage camera uses a 90-second FFmpeg
-retry interval as a single-camera recovery trial. On the deployed Nest bridge,
+The externally powered battery-model garage camera and wired kitchen camera
+use a 90-second FFmpeg retry interval as a recovery trial. On the deployed Nest bridge,
 an independent reader took 40.33 seconds to decode its first frame and then
 decoded 50 frames without errors, while Frigate repeatedly restarted its reader
-after 20 seconds and produced no fresh recordings.
+after 20 seconds and produced no fresh recordings. A kitchen reader separately
+decoded ten frames without errors in 68.18 seconds during the same failure.
 
 In Frigate RC2, `retry_interval` gates watchdog restarts as well as initial
 watchdog startup. It does not change the hard-coded 20-second stale-frame
@@ -216,10 +217,10 @@ threshold, so an offline status or stale-frame message can precede an actual
 restart. This trial trades slower retries of genuine failures for more time to
 finish Nest recovery; it does not fix session negotiation or keyframe delivery.
 
-After merge and sync, verify `garage-outside` reaches its configured 5 FPS and
-creates fresh, decodable recordings across at least two session renewals.
+After merge and sync, verify `garage-outside` and `kitchen` reach their
+configured 5 FPS and create fresh, decodable recordings across at least two session renewals.
 Check live playback after reopening the viewer as well. If it remains offline
-or recovery regresses, remove this camera's `retry_interval` through a PR to
+or recovery regresses, remove the affected camera's `retry_interval` through a PR to
 restore the default 10-second interval. Keep the other cameras at their current
 intervals until this trial establishes a benefit.
 

--- a/my-apps/home/frigate/README.md
+++ b/my-apps/home/frigate/README.md
@@ -202,6 +202,27 @@ doorbells also applies despite that wiring. The externally powered garage
 camera is a different case. See [Google power behavior](https://support.google.com/googlehome/answer/11830989?hl=en)
 and [SDM live-session rules](https://developers.google.com/nest/device-access/traits/device/camera-live-stream#extendwebrtcstream).
 
+### Garage outside recovery trial
+
+The externally powered battery-model garage camera uses a 90-second FFmpeg
+retry interval as a single-camera recovery trial. On the deployed Nest bridge,
+an independent reader took 40.33 seconds to decode its first frame and then
+decoded 50 frames without errors, while Frigate repeatedly restarted its reader
+after 20 seconds and produced no fresh recordings.
+
+In Frigate RC2, `retry_interval` gates watchdog restarts as well as initial
+watchdog startup. It does not change the hard-coded 20-second stale-frame
+threshold, so an offline status or stale-frame message can precede an actual
+restart. This trial trades slower retries of genuine failures for more time to
+finish Nest recovery; it does not fix session negotiation or keyframe delivery.
+
+After merge and sync, verify `garage-outside` reaches its configured 5 FPS and
+creates fresh, decodable recordings across at least two session renewals.
+Check live playback after reopening the viewer as well. If it remains offline
+or recovery regresses, remove this camera's `retry_interval` through a PR to
+restore the default 10-second interval. Keep the other cameras at their current
+intervals until this trial establishes a benefit.
+
 ### Frigate Pending after a VPA eviction
 
 If all feeds stop and the pod is Pending, check scheduling before debugging

--- a/my-apps/home/frigate/config.yml
+++ b/my-apps/home/frigate/config.yml
@@ -162,6 +162,8 @@ cameras:
   garage-outside:
     enabled: true
     ffmpeg:
+      # This Nest feed took 40 seconds to decode after attachment; avoid restart churn.
+      retry_interval: 90
       input_args: -avoid_negative_ts make_zero -fflags +genpts+discardcorrupt -rtsp_transport tcp -rtsp_flags prefer_tcp
       inputs:
       - path: rtsp://127.0.0.1:8554/garage-outside-sub

--- a/my-apps/home/frigate/config.yml
+++ b/my-apps/home/frigate/config.yml
@@ -246,6 +246,8 @@ cameras:
   kitchen:
     enabled: true
     ffmpeg:
+      # A separate reader decoded successfully after 68 seconds during recovery.
+      retry_interval: 90
       input_args: -avoid_negative_ts make_zero -fflags +genpts+discardcorrupt -rtsp_transport tcp -rtsp_flags prefer_tcp
       inputs:
       - path: rtsp://127.0.0.1:8554/kitchen-sub


### PR DESCRIPTION
During diagnosis, garage-outside and kitchen stayed at zero FPS while Frigate repeatedly restarted their readers after 20 seconds. Separate readers attached to the existing go2rtc streams succeeded when given more time:

- Garage outside: first decoded frame after 40.33 seconds, 50 frames completed without errors after 53.28 seconds.
- Kitchen: ten frames completed without errors after 68.18 seconds.

Kitchen later recovered without a config change after 20 reconnects and produced a fresh decodable recording; garage-outside remained offline. The intermittent recovery does not establish the proposed change's effectiveness.

Set `ffmpeg.retry_interval: 90` for these two cameras as a recovery trial. RC2 uses this interval to gate watchdog restarts and initial watchdog startup; it does not change the hard-coded 20-second stale-frame threshold. Genuine failures may therefore take longer to retry. The other four camera intervals remain at 10 seconds.

Validation: Kustomize render and whitespace checks passed. Parsed the proposed configuration using the deployed Frigate RC2 model: only garage-outside and kitchen resolve to 90 seconds. The live configuration has not been changed; production improvement remains to be verified after merge.

Acceptance: both affected cameras reach approximately 5 FPS, generate fresh decodable recordings through at least two Nest session renewals, and play after reopening live views. If recovery remains unsuccessful or slower, remove the affected per-camera interval through a PR. This is a timing trial; it does not establish that the battery doorbell's separate problems are resolved.

CI prerequisite: remove the obsolete test-discovery command for `my-apps/utility/deal-scout/tests`, which was already deleted on main. The retained AI observability suite still validates the native Deal Scout integration. Workflow YAML parses and every remaining unittest discovery directory exists.

Final observation: garage-outside also recovered without a config change. All five non-doorbell cameras now receive approximately 5 FPS and have fresh decodable recordings; the battery doorbell remains offline. This trial aims to reduce the demonstrated extended restart churn on garage-outside and kitchen. All seven CI checks passed for e46ffef31.
