### PR TITLE
deal-scout: v0.13.1

### DIFF
--- a/my-apps/utility/deal-scout/deployment.yaml
+++ b/my-apps/utility/deal-scout/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: deal-scout
           # Source: github.com/mitchross/deal-scout, dashboard/
-          image: ghcr.io/mitchross/deal-scout:v0.13.0@sha256:974471ea419c0865a3b53dc7833cebc26f28e2fe7ec9535477826036507b3445
+          image: ghcr.io/mitchross/deal-scout:v0.13.1@sha256:a2c3a2c950037937e1b11b961a3569e272ec5846536615ae9af60e9b83b7ced1
           imagePullPolicy: IfNotPresent
           env:
             - name: LITELLM_API_KEY

--- a/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
+++ b/my-apps/utility/deal-scout/temporal-workers/temporal-worker-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: worker
           # Source: deal-scout repo worker/. No personal browser profile is
           # present; eBay authentication is application-only OAuth.
-          image: ghcr.io/mitchross/deal-scout-worker:v0.13.0@sha256:8d5b7cad7d55273f5352d1a440620363feb319df36b1b66cd0800c628e172f7b
+          image: ghcr.io/mitchross/deal-scout-worker:v0.13.1@sha256:0171399f2ce07740c4e6326d909f524698667a9b948f9d2dcc9fa4739ee1881f
           imagePullPolicy: IfNotPresent
           env:
             - name: DEAL_SCOUT_API


### PR DESCRIPTION
Automated bump from mitchross/deal-scout v0.13.1.

Dashboard and worker are pinned by tag + digest. Merge to let ArgoCD sync,
then verify from the LAN with `./scripts/verify-deploy.sh v0.13.1`.