### PR TITLE
feat(frigate): enable the attached USB Coral detector

### DIFF
--- a/my-apps/home/frigate/README.md
+++ b/my-apps/home/frigate/README.md
@@ -15,10 +15,41 @@ The setup involves three main components:
 
 Git declares Frigate **0.18.0-rc2**, pinned by image digest, with one replica on
 `node.vanillax.dev/class: hp-elite-worker` (the HP Elite i5-13500T). Detection
-uses the bundled SSD MobileNet model through **OpenVINO on CPU**. Video decode
+uses the bundled **USB Coral EdgeTPU** model. Video decode
 and the existing Nest H.264 re-encode streams also use CPU. The six Nest
 streams retain their keyframe workaround; camera stability on this release
 must be checked after deployment.
+
+### USB Coral detector
+
+The HP Talos VM receives the USB Coral through Proxmox passthrough. Frigate
+mounts `/dev/bus/usb` and uses `detectors.coral` with `type: edgetpu` and
+`device: usb`. Its pinned image supplies `/edgetpu_model.tflite`: a 320×320
+RGB, NHWC, uint8-input SSD-family model with `/labelmap.txt`. The previous
+OpenVINO XML model and BGR preprocessing are incompatible with this detector.
+
+The pod requires the existing `custom-usb.coral-tpu` node label as well as
+the HP node class. The NodeFeatureRule recognizes both the bootloader vendor
+`1a6e` and initialized vendor `18d1`. The full USB IDs are `1a6e:089a` before
+initialization and `18d1:9302` afterward. Mounting the entire USB bus accommodates
+device-number changes during firmware loading. Proxmox passthrough must also
+survive that re-enumeration; a physical-port mapping can avoid tying it to just
+one vendor/product identity.
+
+Use USB 3 and verify the device remains visible after the first inference.
+See Frigate's [Coral setup](https://docs.frigate.video/configuration/object_detectors/#edge-tpu-detector)
+and [USB troubleshooting](https://docs.frigate.video/troubleshooting/edgetpu/).
+
+After merge and sync, check the pod becomes Ready, logs report `TPU found`,
+and `/api/stats` reports a running `coral` detector with nonzero inference
+speed. A USB label alone proves enumeration, not successful inference. Video
+FPS and playable recordings must still be verified separately; Coral performs
+object detection and does not repair Nest video transport or decoding.
+
+If the device disappears, check Proxmox passthrough and the node label first.
+To roll back, revert this detector/model, USB mount, and Coral selector change
+through a PR to restore the prior CPU OpenVINO configuration. Do not pair the
+OpenVINO XML model with an EdgeTPU detector.
 
 ### Nest go2rtc override
 
@@ -88,7 +119,7 @@ kubectl -n frigate logs deployment/frigate --since=5m
 ```
 
 Expect a ready Frigate pod on the HP Elite, ArgoCD Synced/Healthy, a running
-OpenVINO detector, and no repeated MQTT authentication or FFmpeg restart
+Coral detector, and no repeated MQTT authentication or FFmpeg restart
 errors. Use the stream check below to verify all six cameras receive frames;
 pod readiness alone does not establish that cameras or recordings work.
 

--- a/my-apps/home/frigate/config.yml
+++ b/my-apps/home/frigate/config.yml
@@ -35,23 +35,21 @@ record:
 detect:
   enabled: true
 detectors:
-  ov:
-    type: openvino
-    device: CPU
-# Frigate 0.17 reads model config ONLY from this top-level block — the old
-# nested detectors.<name>.model form silently resolves to path=None and the
-# detector process crashes with "stat: path should be string ... NoneType",
-# which takes the whole container down (CrashLoopBackOff, 2026-07-19).
+  coral:
+    type: edgetpu
+    device: usb
 model:
-  path: /openvino-model/ssdlite_mobilenet_v2.xml
-  width: 300
-  height: 300
+  path: /edgetpu_model.tflite
+  width: 320
+  height: 320
   input_tensor: nhwc
-  input_pixel_format: bgr
-  labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+  input_pixel_format: rgb
+  input_dtype: int
+  model_type: ssd
+  labelmap_path: /labelmap.txt
 ffmpeg:
   input_args: preset-rtsp-generic
-  # Intel GPU passthrough is not configured; decode and OpenVINO use the HP CPU.
+  # Intel GPU passthrough is not configured; video decoding uses the HP CPU.
   # Nest streams carry Opus audio; MP4 recordings need AAC. This preset
   # transcodes audio to AAC for the record role (without it, recordings are
   # silent or fail to mux the Opus track).

--- a/my-apps/home/frigate/deployment.yaml
+++ b/my-apps/home/frigate/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       # The HP Elite exposes its i5-13500T CPU, but no Intel GPU in the Talos VM.
       nodeSelector:
         node.vanillax.dev/class: hp-elite-worker
+        feature.node.kubernetes.io/custom-usb.coral-tpu: "true"
       initContainers:
       - name: install-go2rtc
         image: ghcr.io/mitchross/frigate-go2rtc:b101-222d37f-v1
@@ -118,8 +119,8 @@ spec:
           mountPath: /media
         - name: cache
           mountPath: /dev/shm
-        # - name: usb
-        #   mountPath: /dev/bus/usb
+        - name: coral-usb
+          mountPath: /dev/bus/usb
       volumes:
       - name: go2rtc-binary
         emptyDir: {}
@@ -137,7 +138,8 @@ spec:
         emptyDir:
           medium: Memory
           sizeLimit: 4Gi
-      # - name: usb
-      #   hostPath:
-      #     path: /dev/bus/usb
-      #     type: Directory
+      # Coral re-enumerates after firmware loading; mount the bus, not one device number.
+      - name: coral-usb
+        hostPath:
+          path: /dev/bus/usb
+          type: Directory


### PR DESCRIPTION
DO NOT MERGE until USB passthrough survives Coral initialization. The operator has been asked to map the physical USB port with USB3 enabled and request a retest.

The operator attached a USB Coral to the HP Elite Talos VM. Frigate still uses CPU OpenVINO; its privileged container exposes startup USB nodes, but it does not bind the USB bus to follow re-enumeration. Switch object detection to the attached EdgeTPU while preserving the camera and Nest bridge configuration.

- Use `type: edgetpu`, `device: usb`, and the pinned Frigate image's bundled `/edgetpu_model.tflite` with 320×320 RGB/NHWC uint8 preprocessing and `/labelmap.txt`.
- Mount `/dev/bus/usb` so firmware initialization can change the device number, and require the existing Coral discovery label alongside the HP node class.
- Document verification, both USB identities, USB 3 guidance, and rollback to the prior detector/model.

Evidence: the HP node advertises `custom-usb.coral-tpu=true`; sysfs reports `1a6e:089a` at USB path `9-2`, which Frigate documents as the normal uninitialized identity. A direct delegate initialization was attempted in the existing Frigate container and failed; the Coral disappeared from host sysfs during initialization. Hardware inference has not succeeded. Proxmox passthrough must survive the transition to `18d1:9302`; check the negotiated connection after initialization.

Validation: Kustomize render and whitespace checks pass. The exact Frigate RC2 image parses the proposed configuration; its TFLite interpreter confirms bundled input shape `[1,320,320,3]` and `uint8`. This is not a fix for corrupted Nest video or stream dropouts.

After merge/sync: verify `TPU found`, a healthy `coral` detector and nonzero inference speed, continued USB visibility, and pod readiness. Revert detector/model, bus mount, and Coral selector together through a PR if initialization cannot succeed.

Docs: https://docs.frigate.video/configuration/object_detectors/#edge-tpu-detector and https://docs.frigate.video/troubleshooting/edgetpu/
