### PR TITLE
feat: deploy God's Eye View on the private cluster gateway

### DIFF
--- a/my-apps/home/gods-eye-view/README.md
+++ b/my-apps/home/gods-eye-view/README.md
@@ -1,0 +1,80 @@
+# God's Eye View
+
+Private LAN URL: <https://gods-eye-view.vanillax.me>.
+ArgoCD discovers `my-apps-gods-eye-view` from this directory after merge.
+The HTTPS route uses `gateway-internal-technitium`, which also supplies private
+DNS through ExternalDNS. There is no application login or public tunnel route.
+
+## Runtime
+
+The image contains upstream commit
+[`759652207fd1279ece97f0f19af566feb9a82146`](https://github.com/bilawalsidhu/gods-eye-view/commit/759652207fd1279ece97f0f19af566feb9a82146)
+and its locked npm dependencies. `image/Dockerfile` pins the source archive
+checksum and Node 24 base digest. `scripts/start.mjs` is mounted through a
+hash-suffixed ConfigMap, so startup changes trigger a rollout.
+
+The application needs the Vite development server: many upstream data proxies
+only implement `configureServer`, so a static build or `vite preview` loses
+live feeds. The launcher preserves those plugins, restricts accepted hostnames,
+disables HMR and filesystem watching, and adds a local `/healthz` endpoint that
+does not depend on public feed availability. Source files are read-only; Vite
+dependency optimization, data caches, and debug logs use bounded `emptyDir`
+volumes. No durable application data or PVC needs backups. Globe rendering uses
+the browser's GPU, so no cluster GPU is requested.
+
+## Optional credentials
+
+The initial deployment is keyless, with anonymous OpenSky access. Available
+feeds depend on upstream availability and anonymous rate limits. Google/Cesium
+photorealistic tiles, voice control, AISStream ships, FIRMS fires, and TomTom
+traffic require their respective optional provider credentials.
+
+Provider Settings is disabled in this deployment: its upstream local `.env`
+writer would bypass the repository's secret-management rules. To enable a
+provider, store its credentials in the `homelab-prod` 1Password vault, then add
+an app-owned ExternalSecret and Deployment environment references in a PR.
+Only switch `OPENSKY_AUTH_MODE` to `oauth` when its client credentials exist.
+Google and Cesium tokens are intentionally sent to the browser and must be
+restricted to this hostname. Consult upstream
+[`.env.example`](https://github.com/bilawalsidhu/gods-eye-view/blob/759652207fd1279ece97f0f19af566feb9a82146/.env.example)
+for field names. Restart the Deployment through a Git pod-template change when
+environment credentials rotate; Kubernetes does not refresh process env vars.
+
+The upstream [security model](https://github.com/bilawalsidhu/gods-eye-view/blob/759652207fd1279ece97f0f19af566feb9a82146/SECURITY.md)
+requires an authentication proxy before broader exposure. Provider budget
+counters in the disposable cache reset on pod replacement; use provider-side
+quotas for spend controls when enabling paid services.
+
+## Build and upgrade
+
+Run from the repository root. The existing internal registry accepts image
+pushes; publishing an image does not deploy it until the manifest PR merges.
+
+```sh
+docker build --platform linux/amd64 \
+  -t registry.vanillax.me/gods-eye-view:7596522-r1 \
+  my-apps/home/gods-eye-view/image
+docker push registry.vanillax.me/gods-eye-view:7596522-r1
+docker buildx imagetools inspect registry.vanillax.me/gods-eye-view:7596522-r1
+kustomize build my-apps/home/gods-eye-view
+```
+
+For an upgrade, change the upstream commit, archive checksum and revision label
+together, build with a new tag, test the container and live-data endpoints, push,
+and pin the resulting tag plus registry digest in `deployment.yaml`. Never
+overwrite a deployed tag. Commit and open a PR; merge is a separate operator
+action. The internal registry is the image source, so rebuild/push from this
+Dockerfile if its stored image is lost.
+
+After merge, verify:
+
+```sh
+kubectl -n argocd get application my-apps-gods-eye-view
+kubectl -n gods-eye-view rollout status deployment/gods-eye-view
+kubectl -n gods-eye-view get pods,service,httproute,vpa
+curl -fsS https://gods-eye-view.vanillax.me/healthz
+```
+
+Confirm HTTPRoute `Accepted` and `ResolvedRefs`, open the globe in a WebGL2
+browser on the LAN, and choose a first-run preset. Revert the manifest PR to
+remove the app through ArgoCD or revert an image change to restore that version.

--- a/my-apps/home/gods-eye-view/deployment.yaml
+++ b/my-apps/home/gods-eye-view/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gods-eye-view
+  labels:
+    app.kubernetes.io/name: gods-eye-view
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gods-eye-view
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gods-eye-view
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gods-eye-view
+          image: registry.vanillax.me/gods-eye-view:7596522-r1@sha256:8ed8ab155c10b43a3cd93adf9ac589f2fc102c5c0329cdb69194f208b93bf1e0
+          command: [node, /opt/repo-scripts/start.mjs]
+          env:
+            - name: OPENSKY_AUTH_MODE
+              value: anon
+          ports:
+            - name: http
+              containerPort: 4173
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          volumeMounts:
+            - name: scripts
+              mountPath: /opt/repo-scripts
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            - name: cache
+              mountPath: /app/.gev-cache
+            - name: logs
+              mountPath: /app/.gev-logs
+      volumes:
+        - name: scripts
+          configMap:
+            name: gods-eye-view-scripts
+        - name: tmp
+          emptyDir:
+            sizeLimit: 1Gi
+        - name: cache
+          emptyDir:
+            sizeLimit: 1Gi
+        - name: logs
+          emptyDir:
+            sizeLimit: 128Mi

--- a/my-apps/home/gods-eye-view/httproute.yaml
+++ b/my-apps/home/gods-eye-view/httproute.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gods-eye-view
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-internal-technitium
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - gods-eye-view.vanillax.me
+  rules:
+    - backendRefs:
+        - name: gods-eye-view
+          port: 4173

--- a/my-apps/home/gods-eye-view/image/Dockerfile
+++ b/my-apps/home/gods-eye-view/image/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+FROM node:24-bookworm-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c9af091d5281095a71e
+
+LABEL org.opencontainers.image.source="https://github.com/bilawalsidhu/gods-eye-view" \
+      org.opencontainers.image.revision="759652207fd1279ece97f0f19af566feb9a82146" \
+      org.opencontainers.image.licenses="MIT"
+
+WORKDIR /app
+ADD --checksum=sha256:fcdd9c4d11a388eb3716e4b74730829ec0e039ccd93a1465e820a2937b17ff01 \
+    https://codeload.github.com/bilawalsidhu/gods-eye-view/tar.gz/759652207fd1279ece97f0f19af566feb9a82146 /tmp/source.tar.gz
+RUN tar -xzf /tmp/source.tar.gz --strip-components=1 -C /app \
+    && rm /tmp/source.tar.gz
+
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+# Vite, ws, and the Cesium plugin are required by the live data server.
+RUN npm ci --include=dev --no-audit --no-fund \
+    && npm cache clean --force \
+    && mkdir -p /app/.gev-cache /app/.gev-logs
+
+USER 1000:1000
+EXPOSE 4173
+CMD ["node", "/opt/repo-scripts/start.mjs"]

--- a/my-apps/home/gods-eye-view/kustomization.yaml
+++ b/my-apps/home/gods-eye-view/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gods-eye-view
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+  - vpa.yaml
+
+configMapGenerator:
+  - name: gods-eye-view-scripts
+    files:
+      - scripts/start.mjs

--- a/my-apps/home/gods-eye-view/namespace.yaml
+++ b/my-apps/home/gods-eye-view/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gods-eye-view

--- a/my-apps/home/gods-eye-view/scripts/start.mjs
+++ b/my-apps/home/gods-eye-view/scripts/start.mjs
@@ -1,0 +1,49 @@
+import { createServer } from '/app/node_modules/vite/dist/node/index.js';
+
+// Most upstream data proxies only register with configureServer, not preview.
+const server = await createServer({
+  root: '/app',
+  configFile: '/app/vite.config.js',
+  configLoader: 'runner',
+  cacheDir: '/tmp/vite',
+  server: {
+    host: '0.0.0.0',
+    port: 4173,
+    strictPort: true,
+    allowedHosts: ['gods-eye-view.vanillax.me'],
+    cors: false,
+    hmr: false,
+    watch: null,
+    fs: {
+      deny: ['**/.gev-cache/**', '**/.gev-logs/**'],
+    },
+  },
+  plugins: [{
+    name: 'cluster-runtime',
+    enforce: 'pre',
+    configureServer(vite) {
+      vite.middlewares.use((req, res, next) => {
+        const pathname = new URL(req.url, 'http://localhost').pathname;
+        if (pathname === '/healthz') {
+          res.setHeader('Content-Type', 'text/plain');
+          res.end('ok\n');
+        } else if (pathname.startsWith('/api/setup/')) {
+          res.statusCode = 403;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ error: 'Provider credentials are managed through 1Password and GitOps.' }));
+        } else {
+          next();
+        }
+      });
+    },
+  }],
+});
+
+await server.listen();
+server.printUrls();
+for (const signal of ['SIGTERM', 'SIGINT']) {
+  process.once(signal, async () => {
+    await server.close();
+    process.exit(0);
+  });
+}

--- a/my-apps/home/gods-eye-view/service.yaml
+++ b/my-apps/home/gods-eye-view/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gods-eye-view
+spec:
+  selector:
+    app.kubernetes.io/name: gods-eye-view
+  ports:
+    - name: http
+      port: 4173
+      targetPort: http

--- a/my-apps/home/gods-eye-view/vpa.yaml
+++ b/my-apps/home/gods-eye-view/vpa.yaml
@@ -1,0 +1,23 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: gods-eye-view
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gods-eye-view
+  updatePolicy:
+    updateMode: InPlaceOrRecreate
+    minReplicas: 1
+  resourcePolicy:
+    containerPolicies:
+      - containerName: gods-eye-view
+        controlledResources: [cpu, memory]
+        controlledValues: RequestsOnly
+        minAllowed:
+          cpu: 100m
+          memory: 256Mi
+        maxAllowed:
+          cpu: "2"
+          memory: 2Gi


### PR DESCRIPTION
Adds God's Eye View at `https://gods-eye-view.vanillax.me` on the private Technitium gateway. Merging lets the existing My-Apps ApplicationSet discover and deploy it. Starts keyless; optional credentials require a later 1Password ExternalSecret change.

The tested amd64 image is already published to the internal registry and pinned by digest. Its Dockerfile pins upstream commit `759652207fd1279ece97f0f19af566feb9a82146`, archive checksum, and Node 24 base digest. The ConfigMap-mounted launcher retains upstream Vite live-data middleware (static serving and preview omit several proxies), enforces the hostname, disables local credential writes, and adds health probes. Includes non-root/read-only runtime settings, disposable bounded caches, VPA, and build/upgrade documentation.

Validation:
- Built and ran the image with non-root, read-only filesystem, dropped capabilities, and a 2 GiB memory limit.
- Browser rendered the globe and tracked live aircraft without JavaScript errors.
- CelesTrak stations and ADS-B military endpoints returned HTTP 200 with real data (201 aircraft during the check); keyless AIS returned its expected missing-key response.
- Verified health endpoint, accepted/rejected hostnames, blocked Provider Settings, and denial of existing dotenv/cache files.
- Kustomize render, Kubernetes client dry-run/schema validation, app-scoped VPA policy validation, ArgoCD structure validation, inline-script guard, and whitespace checks passed.
- Confirmed the published registry manifest and digest.

Cluster rollout and the final LAN URL remain pending merge, per the repository PR workflow. The service has no application authentication and is intentionally private; paid/provider-specific features are not configured.
