### PR TITLE
fix: stop Temporal and DCGM memory thrashing

### DIFF
--- a/infrastructure/controllers/temporal-worker-controller/manager-identity-recovery.yaml
+++ b/infrastructure/controllers/temporal-worker-controller/manager-identity-recovery.yaml
@@ -10,6 +10,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 240
       backoffLimit: 1
       ttlSecondsAfterFinished: 3600
       template:
@@ -42,9 +43,10 @@ spec:
               resources:
                 requests:
                   cpu: 10m
-                  memory: 32Mi
+                  memory: 768Mi
                 limits:
-                  memory: 128Mi
+                  # The 550 MiB CLI thrashed its executable cache under a 128 MiB cap.
+                  memory: 1Gi
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/monitoring/prometheus-stack/dcgm-exporter.yaml
+++ b/monitoring/prometheus-stack/dcgm-exporter.yaml
@@ -67,9 +67,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 1Gi
+            # 512Mi forced repeated executable-page reads and liveness restarts without OOM kills.
             limits:
-              memory: 512Mi
+              memory: 2Gi
           # /health stalls under GPU load and podMapper's API calls can DeadlineExceed;
           # 5s still killed it 509x, so allow a slow answer and require 3 misses.
           livenessProbe:


### PR DESCRIPTION
Temporal's recovery CLI is trapped under a 128 MiB memory limit, repeatedly rereading executable pages and driving severe physical disk queueing. DCGM shows the same reclaim pattern under its 512 MiB cap.

Two configuration files only:

- **Temporal:** request 768 MiB, limit 1 GiB; stop Jobs after 240 seconds.
- **DCGM:** request 1 GiB, limit 2 GiB.

These are initial budgets to verify under normal load. No scripts, added tests, CI changes, application recovery or PostgreSQL changes.

Validation: render both applications and run existing Cluster CI. Prior cgroup measurements identified the restrictive limits; the latest passive host sample still shows about 732 MiB/s reads and average queue 527. This is not a claim that the SSD is defective.

After merge and Argo sync, verify the new CronJob template, then retire the old stuck Job `temporal-worker-controller-identity-recovery-29814005` only after checking owner and UID against incident evidence. Existing Jobs do not inherit template updates. Observe successive successful runs, stable DCGM scrapes, reduced refault/pressure rates and reduced host queue/latency. No live repair has been performed while preparing this PR.
