### PR TITLE
fix(frigate): buffer Nest input and shorten re-encode keyframes

### DIFF
--- a/my-apps/home/frigate/README.md
+++ b/my-apps/home/frigate/README.md
@@ -51,6 +51,31 @@ To roll back, revert this detector/model, USB mount, and Coral selector change
 through a PR to restore the prior CPU OpenVINO configuration. Do not pair the
 OpenVINO XML model with an EdgeTPU detector.
 
+### Buffered Nest video input
+
+The six Nest re-encoders use `#input=nest-buffered`, defined under
+`go2rtc.ffmpeg`. The template keeps FFmpeg's input buffering, allows a
+20-second/20-MB codec probe, uses RTSP over TCP with a 60-second socket timeout,
+and limits decoder threads to two. The H264 encoder also uses two threads and
+emits a keyframe every five frames (one second at the configured 5 FPS).
+
+The previous go2rtc RTSP defaults combined `nobuffer`, `low_delay`, a five-second
+socket timeout, and a 50-frame output GOP. During the offline-feed incident,
+raw video sometimes decoded quickly while a derived stream took 28 seconds to
+attach, longer than Frigate's 20-second no-frame watchdog. An isolated buffered
+restream decoded 1,001 frames over 200 seconds without FFmpeg warnings; two
+additional direct Nest sessions each decoded 150 frames without warnings.
+Another test ended with an RTSP disconnect, and two streams failed to start.
+These tests validate the combined settings on the successful feeds, not which
+individual option caused the failures; they do not establish long-term
+reliability across all cameras.
+
+After deployment, verify sustained camera FPS and newly recorded playable
+segments through multiple Nest renewals. Coral detector health alone is not a
+camera-health check. If this configuration regresses capture, revert the
+`go2rtc.ffmpeg` templates and all six `#input=nest-buffered` selectors together
+through a PR; keep the Coral detector and USB mount in place.
+
 ### Nest go2rtc override
 
 Frigate's stock go2rtc 1.9.14 connected to Google but repeatedly lost usable

--- a/my-apps/home/frigate/config.yml
+++ b/my-apps/home/frigate/config.yml
@@ -57,42 +57,37 @@ ffmpeg:
     record: preset-record-generic-audio-aac
 # go2rtc with Nest cameras via direct SDM API
 go2rtc:
+  ffmpeg:
+    # Preserve startup reference frames while Nest codec parameters arrive.
+    nest-buffered: "-threads 2 -analyzeduration 20000000 -probesize 20000000 -timeout 60000000 -rtsp_transport tcp -i {input}"
+    # At 5 FPS, the default GOP of 50 makes new consumers wait up to ten seconds.
+    h264: "-c:v libx264 -threads 2 -g 5 -keyint_min 5 -sc_threshold 0 -preset:v superfast -tune:v zerolatency -pix_fmt:v yuv420p"
   streams:
-    # Nest cameras via Google SDM API (direct WebRTC). Each *-nest raw stream
-    # feeds an *-sub ffmpeg re-encode; cameras consume the CLEAN *-sub.
-    # WHY: Nest's H264 is AUD-less with irregular keyframes, so Frigate's own
-    # ffmpeg fails INSTANTLY with "Invalid data found" on a cold producer —
-    # probe/timeout tuning does NOT help (it fails before the probe window;
-    # verified @kancelott's 50M/50M/60s still errors). go2rtc's ffmpeg: module
-    # stays connected (internal retries, no exec starttimeout), keeps the Nest
-    # producer warm, and the forced scale = full decode+encode = clean
-    # keyframes Frigate consumes fine. Pattern from frigate #17527 (@edse).
-    # (preload was tried and dropped — bundled go2rtc 1.9.10 didn't hold the
-    # WebRTC producers warm.)
+    # Each raw Nest WebRTC stream feeds a buffered H264 re-encode for live/detect/record.
     backyard-nest:
     - "nest:?client_id={FRIGATE_NEST_CLIENT_ID}&client_secret={FRIGATE_NEST_CLIENT_SECRET}&refresh_token={FRIGATE_NEST_REFRESH_TOKEN}&project_id={FRIGATE_NEST_PROJECT_ID}&device_id=AVPHwEu-b9WJaOye6XlAOJsVuG4cdrmJC3WIVTtENALQQfkYJSpLEQj4va9k1c1YHqDcgAWUdfaIgvBMIy3--kQBCmq_dDI&protocols=WEB_RTC&video=h264&audio=opus"
     backyard-sub:
-    - "ffmpeg:backyard-nest#video=h264#width=1280#height=720#raw=-fpsmax 5"
+    - "ffmpeg:backyard-nest#video=h264#width=1280#height=720#raw=-fpsmax 5#input=nest-buffered"
     garage-inside-nest:
     - "nest:?client_id={FRIGATE_NEST_CLIENT_ID}&client_secret={FRIGATE_NEST_CLIENT_SECRET}&refresh_token={FRIGATE_NEST_REFRESH_TOKEN}&project_id={FRIGATE_NEST_PROJECT_ID}&device_id=AVPHwEuwG9L_DWqqKXGMkSsZWGLHxyieW9NJBmZCARSyBqtpOt2BxS8Un3SYTfuClz3pCd1BS32T-sTRnsRwR3M_ddddZ6s&protocols=WEB_RTC&video=h264&audio=opus"
     garage-inside-sub:
-    - "ffmpeg:garage-inside-nest#video=h264#width=1280#height=720#raw=-fpsmax 5"
+    - "ffmpeg:garage-inside-nest#video=h264#width=1280#height=720#raw=-fpsmax 5#input=nest-buffered"
     garage-outside-nest:
     - "nest:?client_id={FRIGATE_NEST_CLIENT_ID}&client_secret={FRIGATE_NEST_CLIENT_SECRET}&refresh_token={FRIGATE_NEST_REFRESH_TOKEN}&project_id={FRIGATE_NEST_PROJECT_ID}&device_id=AVPHwEv2h0W3viecoGaYuzNnJYw5JpuFl22mo6_2OxWG7xIs8fTPCL0uwgrIOU8WEm7IiTIOQ_cgyzkh18OaR6nBzlTUWQ0&protocols=WEB_RTC&video=h264&audio=opus"
     garage-outside-sub:
-    - "ffmpeg:garage-outside-nest#video=h264#width=1280#height=720#raw=-fpsmax 5"
+    - "ffmpeg:garage-outside-nest#video=h264#width=1280#height=720#raw=-fpsmax 5#input=nest-buffered"
     front-porch-nest:
     - "nest:?client_id={FRIGATE_NEST_CLIENT_ID}&client_secret={FRIGATE_NEST_CLIENT_SECRET}&refresh_token={FRIGATE_NEST_REFRESH_TOKEN}&project_id={FRIGATE_NEST_PROJECT_ID}&device_id=AVPHwEtOw3n2_DdhAm0wdt_NFRX7r04GI3RgzvQ2l2jt7KrpS7kCuvSvUtlDAmDCxg9nqMYUMEQz2IaXjtYJmT3A7gH1vPQ&protocols=WEB_RTC&video=h264&audio=opus"
     front-porch-sub:
-    - "ffmpeg:front-porch-nest#video=h264#width=480#height=640#raw=-fpsmax 5"
+    - "ffmpeg:front-porch-nest#video=h264#width=480#height=640#raw=-fpsmax 5#input=nest-buffered"
     living-room-nest:
     - "nest:?client_id={FRIGATE_NEST_CLIENT_ID}&client_secret={FRIGATE_NEST_CLIENT_SECRET}&refresh_token={FRIGATE_NEST_REFRESH_TOKEN}&project_id={FRIGATE_NEST_PROJECT_ID}&device_id=AVPHwEvWU1Xm4--F8EQvLgj32449ix_pnGNv82a1xR6gJoWCsdxUyyWk1b3C9Aox-hLzJtQ2rp85L1F_BAw1HYaMgaLIa5U&protocols=WEB_RTC&video=h264&audio=opus"
     living-room-sub:
-    - "ffmpeg:living-room-nest#video=h264#width=1280#height=720#raw=-fpsmax 5"
+    - "ffmpeg:living-room-nest#video=h264#width=1280#height=720#raw=-fpsmax 5#input=nest-buffered"
     kitchen-nest:
     - "nest:?client_id={FRIGATE_NEST_CLIENT_ID}&client_secret={FRIGATE_NEST_CLIENT_SECRET}&refresh_token={FRIGATE_NEST_REFRESH_TOKEN}&project_id={FRIGATE_NEST_PROJECT_ID}&device_id=AVPHwEtnbEGv0Bh9GblHDv66SK0jKGBAbQ1Mnnkuki_YW4_XQJGgV_dZ-nlouy_oRShGc1_7PwBFabTHa8ovpRYEyb8CZVk&protocols=WEB_RTC&video=h264&audio=opus"
     kitchen-sub:
-    - "ffmpeg:kitchen-nest#video=h264#width=1280#height=720#raw=-fpsmax 5"
+    - "ffmpeg:kitchen-nest#video=h264#width=1280#height=720#raw=-fpsmax 5#input=nest-buffered"
 cameras:
   # Wyze camera via wyze-bridge (disabled - Wyze API auth broken)
   # shed:


### PR DESCRIPTION
Nest feeds repeatedly reach Frigate's no-frame watchdog while the intermediate re-encoder starts or recovers. Preserve FFmpeg input buffering and emit one-second H264 keyframes so new consumers can receive usable video sooner.

Add a named buffered RTSP input template with bounded probe/socket settings and two decoder threads; use it for the six existing Nest re-encoders. Set a five-frame GOP and two encoder threads. Document validation limits and rollback.

Validation: Kustomize render and whitespace checks pass; the exact running Frigate image parses the complete proposed config. Isolated testing produced 1,001 decoded frames over 200 seconds without FFmpeg warnings, plus two successful 150-frame tests. These are combined-setting tests, not proof of which individual option caused the failures. Another stream disconnected and two failed to start, so this is a tested improvement, not a claim that all camera outages are resolved. Sustained production FPS and fresh playable recordings through repeated session renewals still require verification after merge.
