### PR TITLE
fix(grafana): give the main container room to avoid disk reclaim

### DIFF
--- a/monitoring/prometheus-stack/values.yaml
+++ b/monitoring/prometheus-stack/values.yaml
@@ -223,9 +223,9 @@ grafana:
   resources:
     requests:
       cpu: 100m
-      memory: 512Mi
-    limits:
       memory: 1Gi
+    limits:
+      memory: 2Gi
   # Security context
   securityContext:
     runAsNonRoot: true


### PR DESCRIPTION
Grafana intermittently hits its 1Gi main-container memory limit and rereads executable pages from the GPU boot disk. The live inspection measured about 2,492 file-page refaults/sec during one interval; VPA currently recommends about 1.09Gi but controls requests only.

Raise the Grafana memory request from 512Mi to 1Gi and its limit from 1Gi to 2Gi, matching the existing VPA ceiling. This is one YAML file with two value changes.

Validation: full monitoring Kustomize/Helm render succeeded (140 resources); verified the rendered Grafana budget, existing RequestsOnly VPA policy and Recreate strategy; `git diff --check` and all six existing CI checks passed. After merge, recheck container memory pressure, refaults and boot-disk reads under normal dashboard activity. Grafana will briefly restart under its existing Recreate strategy.
