### PR TITLE
fix(n8n): pin image to 2.36.7 instead of floating :latest

### DIFF
--- a/my-apps/home/n8n/values.yaml
+++ b/my-apps/home/n8n/values.yaml
@@ -1,7 +1,9 @@
 image:
   repository: n8nio/n8n
   pullPolicy: IfNotPresent
-  tag: "latest"
+  # Pinned (was :latest — floating tag defeats Renovate + makes rollback/diff impossible).
+  # Renovate helm-values manager tracks minor/patch bumps from here.
+  tag: "2.36.7"
 
 main:
   replicaCount: 1


### PR DESCRIPTION
## Why

While triaging the Trivy scan reports across the cluster (332 VulnerabilityReports), n8n was flagged running `n8nio/n8n:latest` — and unlike every other image in this repo, it had **no digest pin**, so the tag genuinely floats. A registry `latest` roll would hot-swap the running n8n (workflows, queue mode, migrations) with zero review.

## What

- `my-apps/home/n8n/values.yaml`: `tag: "latest"` → `tag: "2.36.7"`

2.36.7 is the exact version already running in-cluster (resolved from the live pod's `imageID` digest), so **this changes no runtime behavior** — no image re-pull beyond the same content, no migration. It makes the deployed image declarative and lets Renovate's enabled `helm-values` manager propose minor/patch bumps as reviewable PRs.

## Scope check

Audit of every `image:` reference in the repo:
- All kustomize/k8s manifests that use `latest`/branch tags are **digest-pinned** (`:latest@sha256:...`) and rolled via the auto-merged 'all container digests' Renovate group — deterministic already.
- Remaining unpinned images are major/minor-pinned (`mysql:8.4`, `docker:29-dind`, `qdrant:v1.19`, ...) — Renovate tracks those as version bumps.
- n8n was the single exception. (Note: `my-apps/ai/open-webui/mcpo-deployment.yaml` contains an unpinned `mcpo:main`, but the file is commented out of the kustomization — dead, not deployed; left as-is.)

Not included: ArgoCD is already on the latest release (v3.5.2, Aug 27) — its CVE-2025-68121 (Go crypto/tls) needs a future upstream release; Renovate will propose the chart bump when it lands.