### PR TITLE
fix(monitoring): allow Prometheus to reach physical exporters

### DIFF
--- a/monitoring/prometheus-stack/network-policy.yaml
+++ b/monitoring/prometheus-stack/network-policy.yaml
@@ -19,3 +19,30 @@ spec:
         - ports:
             - port: "9090"
               protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-prometheus-to-physical-exporters
+  namespace: prometheus-stack
+spec:
+  description: Allow Prometheus to scrape the physical host and disk collectors.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+      operator.prometheus.io/name: kube-prometheus-stack-prometheus
+  egress:
+    - toCIDR:
+        - 192.168.10.14/32
+        - 192.168.10.16/32
+        - 192.168.10.20/32
+        - 192.168.10.21/32
+        - 192.168.10.22/32
+        - 192.168.10.15/32
+        - 192.168.10.133/32
+      toPorts:
+        - ports:
+            - port: "9100"
+              protocol: TCP
+            - port: "9633"
+              protocol: TCP


### PR DESCRIPTION
The permanent hardware exporters respond on all seven hosts, but every production Prometheus scrape times out. Hubble confirms `Policy denied` for Prometheus → Threadripper TCP 9633: the shared LAN policy has no allowance for these exporter ports.

Add one namespace-scoped Cilium policy selecting the actual Prometheus pod labels. It allows only TCP 9100/9633 to the seven configured host IPs; other pods receive no new access. This completes the network path for the live hardware dashboard introduced in #2333.

Validation: selector matches the live Prometheus pod, destinations exactly match both scrape jobs, server dry run accepted, and the complete monitoring application renders. All 14 exporter endpoints respond directly and report 24 drives. Production ingestion will be verified after merge and Argo sync.
