### PR TITLE
fix(apps): expand PostHog storage and restore Perplexica backups

### DIFF
--- a/my-apps/ai/perplexica/README.md
+++ b/my-apps/ai/perplexica/README.md
@@ -16,47 +16,9 @@ startup. Local Transformers embeddings and SearXNG remain unchanged.
 After rollout, run a search and check its calls in
 [AI observability](../../../docs/domains/ai-gpu/ai-observability.md).
 
-## Backup permissions and restore acceptance
+## Backup permissions
 
-The seed creates `config.json` as `0:568` with mode `0600`; the existing
-`db.sqlite` is `568:568` with mode `0664`. The backup and restore movers use
-UID 0 / GID 568 under the documented
-[root-owned data exception](../../../docs/domains/storage/kopiur-mover-permissions.md).
-No permission-bypass capabilities or ownership rewrite is required: root owns
-the config, and group 568 can read the database. The namespace annotation permits
-root movers; it does not change Pod Security Admission or grant capabilities.
-On September 10, 2026, both files were readable with **all capabilities dropped**
-as `0:568`, and a read-only SQLite `PRAGMA quick_check` returned `ok`.
-
-The application currently runs as root. A restore without privileged ownership
-preservation may leave the database owned by root rather than its old UID 568;
-this is compatible with the current application. Recheck all file owners and
-modes if its runtime identity or file-writing behavior changes: root without
-capabilities cannot read another UID's owner-only files.
-
-After the merged settings have synced, use the native
-[Snapshot invocation](https://kopiur.home-operations.com/reference/crds/snapshot/)
-with `policyRef.name: perplexica-data` and `deletionPolicy: Retain`. Require a
-completed, non-partial backup, zero failed files, and a concrete
-`status.snapshot.kopiaSnapshotID`; a successful no-change run alone is not a new
-restore point.
-
-For an isolated drill, declare a separate
-[Restore](https://kopiur.home-operations.com/reference/crds/restore/) through Git,
-pin `source.snapshotRef.name` to that successful Snapshot, and use a **new**
-`target.pvc` name, `longhorn`, `10Gi`, and `ReadWriteOnce`. Set
-`policy.onMissingSnapshot: Fail`, use the same mover identity, and leave the
-production PVC and its existing populator Restore untouched. The shared backup
-component replaces Restore targets with `populator`, so a drill with
-`target.pvc` must be rendered independently of that component.
-
-Acceptance requires `Completed`, a matching resolved Kopia snapshot ID, and
-read-only checks on the isolated PVC: parse `config.json` without printing its
-contents, confirm expected database tables are present, and require
-`sqlite3 -readonly /restore/db.sqlite 'PRAGMA integrity_check;'` to return `ok`.
-Check file ownership and readability as the application's UID, too. The existing
-application image includes SQLite and Node; no custom recovery image is needed.
-Compare hashes against the immutable backup source if retained, rather than an
-actively changing production database. Remove only the named drill resources
-after recording the result; retain the verified backup. This proves the data
-round trip, while an isolated application launch is a separate functional check.
+`config.json` is root-owned with mode `0600`; the database is group-readable by GID 568.
+Backup and restore movers use UID 0 / GID 568 under the [root-owned data exception](../../../docs/domains/storage/kopiur-mover-permissions.md).
+This grants no extra capabilities and requires no ownership rewrite.
+Rollout verification includes a completed backup and an isolated restore with configuration parsing, SQLite integrity, and file-readability checks.

--- a/my-apps/ai/perplexica/README.md
+++ b/my-apps/ai/perplexica/README.md
@@ -15,3 +15,48 @@ startup. Local Transformers embeddings and SearXNG remain unchanged.
 
 After rollout, run a search and check its calls in
 [AI observability](../../../docs/domains/ai-gpu/ai-observability.md).
+
+## Backup permissions and restore acceptance
+
+The seed creates `config.json` as `0:568` with mode `0600`; the existing
+`db.sqlite` is `568:568` with mode `0664`. The backup and restore movers use
+UID 0 / GID 568 under the documented
+[root-owned data exception](../../../docs/domains/storage/kopiur-mover-permissions.md).
+No permission-bypass capabilities or ownership rewrite is required: root owns
+the config, and group 568 can read the database. The namespace annotation permits
+root movers; it does not change Pod Security Admission or grant capabilities.
+On September 10, 2026, both files were readable with **all capabilities dropped**
+as `0:568`, and a read-only SQLite `PRAGMA quick_check` returned `ok`.
+
+The application currently runs as root. A restore without privileged ownership
+preservation may leave the database owned by root rather than its old UID 568;
+this is compatible with the current application. Recheck all file owners and
+modes if its runtime identity or file-writing behavior changes: root without
+capabilities cannot read another UID's owner-only files.
+
+After the merged settings have synced, use the native
+[Snapshot invocation](https://kopiur.home-operations.com/reference/crds/snapshot/)
+with `policyRef.name: perplexica-data` and `deletionPolicy: Retain`. Require a
+completed, non-partial backup, zero failed files, and a concrete
+`status.snapshot.kopiaSnapshotID`; a successful no-change run alone is not a new
+restore point.
+
+For an isolated drill, declare a separate
+[Restore](https://kopiur.home-operations.com/reference/crds/restore/) through Git,
+pin `source.snapshotRef.name` to that successful Snapshot, and use a **new**
+`target.pvc` name, `longhorn`, `10Gi`, and `ReadWriteOnce`. Set
+`policy.onMissingSnapshot: Fail`, use the same mover identity, and leave the
+production PVC and its existing populator Restore untouched. The shared backup
+component replaces Restore targets with `populator`, so a drill with
+`target.pvc` must be rendered independently of that component.
+
+Acceptance requires `Completed`, a matching resolved Kopia snapshot ID, and
+read-only checks on the isolated PVC: parse `config.json` without printing its
+contents, confirm expected database tables are present, and require
+`sqlite3 -readonly /restore/db.sqlite 'PRAGMA integrity_check;'` to return `ok`.
+Check file ownership and readability as the application's UID, too. The existing
+application image includes SQLite and Node; no custom recovery image is needed.
+Compare hashes against the immutable backup source if retained, rather than an
+actively changing production database. Remove only the named drill resources
+after recording the result; retain the verified backup. This proves the data
+round trip, while an isolated application launch is a separate functional check.

--- a/my-apps/ai/perplexica/README.md
+++ b/my-apps/ai/perplexica/README.md
@@ -21,4 +21,4 @@ After rollout, run a search and check its calls in
 `config.json` is root-owned with mode `0600`; the database is group-readable by GID 568.
 Backup and restore movers use UID 0 / GID 568 under the [root-owned data exception](../../../docs/domains/storage/kopiur-mover-permissions.md).
 This grants no extra capabilities and requires no ownership rewrite.
-Rollout verification includes a completed backup and an isolated restore with configuration parsing, SQLite integrity, and file-readability checks.
+Existing Kopiur schedules run backups; rollout verification checks the native controller results.

--- a/my-apps/ai/perplexica/kopiur/perplexica-data.yaml
+++ b/my-apps/ai/perplexica/kopiur/perplexica-data.yaml
@@ -18,10 +18,12 @@ spec:
     keepWeekly: 6
     keepMonthly: 3
   mover:
+    # config.json is 0:568/0600; db.sqlite is 568:568/0664.
+    # UID 0 reads the config; GID 568 reads the database without DAC capabilities.
     securityContext:
-      runAsUser: 568
+      runAsUser: 0
       runAsGroup: 568
-      runAsNonRoot: true
+      runAsNonRoot: false
     podSecurityContext:
       fsGroup: 568
       supplementalGroups:
@@ -51,10 +53,11 @@ spec:
       name: perplexica-data
       offset: 0
   mover:
+    # Restore as the root-running application, retaining the shared data group.
     securityContext:
-      runAsUser: 568
+      runAsUser: 0
       runAsGroup: 568
-      runAsNonRoot: true
+      runAsNonRoot: false
     podSecurityContext:
       fsGroup: 568
       supplementalGroups:

--- a/my-apps/ai/perplexica/namespace.yaml
+++ b/my-apps/ai/perplexica/namespace.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: perplexica
+  annotations:
+    # The seed writes root-owned config.json with mode 0600.
+    kopiur.home-operations.com/privileged-movers: "true"
   labels:
     # kopiur-managed: ClusterExternalSecret cred fanout + ClusterRepository
     # tenancy (allowedNamespaces selector). Replaces pvc-plumber labels.

--- a/my-apps/development/posthog/data-layer/kafka.yaml
+++ b/my-apps/development/posthog/data-layer/kafka.yaml
@@ -11,14 +11,14 @@ metadata:
     backup-exempt: "true"
   annotations:
     argocd.argoproj.io/compare-options: ServerSideDiff=false
-    storage.vanillax.dev/backup-exempt-reason: "PostHog data is disposable/rebuildable in this homelab; do not back up. Redpanda runs --unsafe-bypass-fsync with ~1h retention + auto_create_topics — log is ephemeral/rebuildable."
+    storage.vanillax.dev/backup-exempt-reason: "PostHog event queues are disposable/rebuildable in this homelab; no kopiur backup. Retention is configured separately on the broker and topics."
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: longhorn-flash
   resources:
     requests:
-      # Redpanda runs --unsafe-bypass-fsync with ~1h retention; the log is ephemeral, 8Gi is plenty.
-      storage: 8Gi
+      # Expansion preserves the queued data; retention changes must wait for consumers to catch up.
+      storage: 32Gi
   # Backup-exempt by design: no dataSourceRef and no backup CRs. Do not re-add.
 ---
 ---
@@ -34,7 +34,6 @@ metadata:
     # Consumer fetch long-polls read as slow requests to Coroot's L7 eBPF
     # latency SLI at the 500ms default; 10s keeps a real stall visible.
     coroot.com/slo-latency-threshold: "10s"
-  annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: 1
@@ -74,6 +73,17 @@ spec:
           name: proxy
         - containerPort: 9644
           name: admin
+        startupProbe:
+          exec:
+            command: ["rpk", "cluster", "health", "-X", "admin.hosts=127.0.0.1:9644"]
+          timeoutSeconds: 5
+          periodSeconds: 10
+          failureThreshold: 60
+        readinessProbe:
+          exec:
+            command: ["rpk", "cluster", "health", "-X", "admin.hosts=127.0.0.1:9644"]
+          timeoutSeconds: 5
+          periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /v1/status/ready


### PR DESCRIPTION
PostHog's message broker is blocked by a full 8 GiB volume. Expand it to 32 GiB and add startup/readiness checks for log replay. Perplexica backups fail on root-owned `config.json`; use UID 0 / GID 568 movers under the existing exception, with no extra capabilities or ownership rewrite.

Validation: both apps render; PostHog passes server dry-run and Perplexica matches installed schemas. The proposed mover identity read both files with all capabilities dropped; SQLite quick_check passed. The README now contains six concise lines about the fix and rollout verification.

After merge, Argo applies the changes and existing Kopiur schedules run backups. Read-only verification checks PostHog capacity and broker recovery, plus Kopiur's scheduled backup results. This PR does not provide an automatic isolated restore test; no CLI-triggered backups, restore drills, or new test resources are part of this change.

PVC expansion cannot be reversed by shrinking the claim. Retention tuning follows backlog recovery to avoid expiring unprocessed events.
