### PR TITLE
fix(surfsense): discard old app data and start fresh

### DIFF
--- a/my-apps/ai/surfsense/CLAUDE.md
+++ b/my-apps/ai/surfsense/CLAUDE.md
@@ -36,11 +36,16 @@ Do not split these child folders into independent Argo Applications unless there
 Argo health gates each wave before advancing:
 
 1. `ExternalSecret` wave **-1** — materialize `surfsense-secrets` before consumers start.
-2. Postgres + Redis wave **0** — PVC/Restore resources reconcile in the same application sync; restore-before-bind keeps backed-up PVCs Pending until Kopiur hydrates them.
-3. `app/migrations-job.yaml` wave **1** — schema/publication migration hook runs only after the data layer is healthy.
-4. `app/credit-policy-job.yaml` wave **2** — reconcile restored or pre-policy wallets after the user table exists.
-5. API+worker, Celery beat, and Zero wave **3**.
-6. Frontend wave **4**.
+2. PVCs and their passive Kopiur Restores wave **0** — remain together for restore-before-bind.
+3. Postgres (`surfsense-postgres-v2`) + Redis (`surfsense-redis-v2`) wave **1** — initialize or recover the data layer.
+4. `app/migrations-job.yaml` wave **2** — schema/publication migration hook.
+5. `app/credit-policy-job.yaml` wave **3** — reconcile wallets after the user table exists.
+6. API+worker (`surfsense-v2`), beat (`surfsense-beat-v2`), and Zero (`surfsense-zero-v2`) wave **4**.
+7. Frontend wave **5**; Mink import CronJob wave **6**.
+
+The v2 claim and backup identities intentionally start a new data lineage. The existing importer is suspended until its credentials and workspace match the fresh account. Future restores use the latest v2 backup normally.
+
+During the one-time identity transition, every old claim-consuming Deployment is pruned, including Postgres and Redis. Old application writers begin pruning before the data layer; PVC protection waits for their consumers to terminate. Argo recomputes reverse prune waves between passes, so the transition does not assume old PVCs retain a fixed prune wave. All old claim holders remain eligible for deletion before the new data-layer Deployments apply in wave 1. Service selectors stay stable; VPAs target the new Deployment names.
 
 Do not put the Kopiur `Restore` CR in an earlier isolated wave than its PVC. The repo's restore-before-bind model intentionally lets the Restore/populator/PVC reconcile together while Argo waits for the workload to become healthy.
 
@@ -62,8 +67,8 @@ Do not put the Kopiur `Restore` CR in an earlier isolated wave than its PVC. The
 
 ## Storage choices
 
-- Postgres: `longhorn` RWO — current repo standard for app/database block storage; Kopiur restore-before-bind.
-- Object/knowledge store: `longhorn` RWO — API+worker co-location removes the need for RWX.
+- Postgres: `longhorn-wired-ha` RWO — two replicas on distinct wired storage nodes; Kopiur restore-before-bind.
+- Object/knowledge store: `longhorn-wired-ha` RWO — two wired replicas; API+worker co-location removes the need for RWX.
 - Redis: `longhorn` RWO — ordinary restart continuity only; backup-exempt.
 - Zero/shared temp: `emptyDir`.
 

--- a/my-apps/ai/surfsense/app/beat.yaml
+++ b/my-apps/ai/surfsense/app/beat.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: surfsense-beat
+  name: surfsense-beat-v2
   namespace: surfsense
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "4"
 spec:
   replicas: 1
   selector:

--- a/my-apps/ai/surfsense/app/credit-policy-job.yaml
+++ b/my-apps/ai/surfsense/app/credit-policy-job.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   activeDeadlineSeconds: 300
   backoffLimit: 4

--- a/my-apps/ai/surfsense/app/deployment.yaml
+++ b/my-apps/ai/surfsense/app/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: surfsense
+  name: surfsense-v2
   namespace: surfsense
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "4"
 spec:
   replicas: 1
   strategy:
@@ -110,7 +110,7 @@ spec:
       volumes:
         - name: object-store
           persistentVolumeClaim:
-            claimName: surfsense-object-store
+            claimName: surfsense-object-store-v2
         - name: shared-temp
           emptyDir: {}
         - name: global-llm-config

--- a/my-apps/ai/surfsense/app/frontend.yaml
+++ b/my-apps/ai/surfsense/app/frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: surfsense-frontend
   namespace: surfsense
   annotations:
-    argocd.argoproj.io/sync-wave: "4"
+    argocd.argoproj.io/sync-wave: "5"
 spec:
   replicas: 1
   selector:

--- a/my-apps/ai/surfsense/app/migrations-job.yaml
+++ b/my-apps/ai/surfsense/app/migrations-job.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   backoffLimit: 4
   template:

--- a/my-apps/ai/surfsense/app/pvc.yaml
+++ b/my-apps/ai/surfsense/app/pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: surfsense-object-store
+  name: surfsense-object-store-v2
   namespace: surfsense
   annotations:
     argocd.argoproj.io/compare-options: ServerSideDiff=false
@@ -9,11 +9,11 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn
+  storageClassName: longhorn-wired-ha
   resources:
     requests:
       storage: 20Gi
   dataSourceRef:
     apiGroup: kopiur.home-operations.com
     kind: Restore
-    name: surfsense-object-store-restore
+    name: surfsense-object-store-v2-restore

--- a/my-apps/ai/surfsense/app/zero.yaml
+++ b/my-apps/ai/surfsense/app/zero.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: surfsense-zero
+  name: surfsense-zero-v2
   namespace: surfsense
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "4"
 spec:
   replicas: 1
   selector:

--- a/my-apps/ai/surfsense/kopiur/object-store.yaml
+++ b/my-apps/ai/surfsense/kopiur/object-store.yaml
@@ -1,14 +1,14 @@
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
-  name: surfsense-object-store
+  name: surfsense-object-store-v2
   namespace: surfsense
 spec:
   sources:
     - pvc:
-        name: surfsense-object-store
+        name: surfsense-object-store-v2
   identity:
-    username: surfsense-object-store
+    username: surfsense-object-store-v2
     hostname: surfsense
   retention:
     keepDaily: 14
@@ -22,23 +22,23 @@ spec:
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotSchedule
 metadata:
-  name: surfsense-object-store-daily
+  name: surfsense-object-store-v2-daily
   namespace: surfsense
 spec:
   policyRef:
-    name: surfsense-object-store
+    name: surfsense-object-store-v2
   schedule:
     cron: "59 3 * * *"
 ---
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: Restore
 metadata:
-  name: surfsense-object-store-restore
+  name: surfsense-object-store-v2-restore
   namespace: surfsense
 spec:
   source:
     fromPolicy:
-      name: surfsense-object-store
+      name: surfsense-object-store-v2
       offset: 0
   mover:
     securityContext:

--- a/my-apps/ai/surfsense/kopiur/postgres-data.yaml
+++ b/my-apps/ai/surfsense/kopiur/postgres-data.yaml
@@ -1,14 +1,14 @@
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
-  name: surfsense-postgres-data
+  name: surfsense-postgres-data-v2
   namespace: surfsense
 spec:
   sources:
     - pvc:
-        name: surfsense-postgres-data
+        name: surfsense-postgres-data-v2
   identity:
-    username: surfsense-postgres-data
+    username: surfsense-postgres-data-v2
     hostname: surfsense
   hooks:
     beforeSnapshot:
@@ -35,23 +35,23 @@ spec:
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotSchedule
 metadata:
-  name: surfsense-postgres-data-hourly
+  name: surfsense-postgres-data-v2-hourly
   namespace: surfsense
 spec:
   policyRef:
-    name: surfsense-postgres-data
+    name: surfsense-postgres-data-v2
   schedule:
     cron: "47 * * * *"
 ---
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: Restore
 metadata:
-  name: surfsense-postgres-data-restore
+  name: surfsense-postgres-data-v2-restore
   namespace: surfsense
 spec:
   source:
     fromPolicy:
-      name: surfsense-postgres-data
+      name: surfsense-postgres-data-v2
       offset: 0
   mover:
     securityContext:

--- a/my-apps/ai/surfsense/kustomization.yaml
+++ b/my-apps/ai/surfsense/kustomization.yaml
@@ -30,6 +30,37 @@ resources:
 components:
   - ../../common/kopiur-backup
 
+# Pause writers before preserving the damaged PostgreSQL filesystem; keep PostgreSQL running for the final dump.
+patches:
+  - target:
+      kind: Deployment
+      name: surfsense|surfsense-beat|surfsense-zero
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 0
+  - target:
+      kind: CronJob
+      name: surfsense-mink-sync
+    patch: |-
+      - op: add
+        path: /spec/suspend
+        value: true
+  - target:
+      kind: SnapshotPolicy
+      name: surfsense-postgres-data
+    patch: |-
+      - op: add
+        path: /spec/suspend
+        value: true
+  - target:
+      kind: Job
+      name: surfsense-migrations|surfsense-credit-policy-v1
+    patch: |-
+      - op: replace
+        path: /metadata/annotations/argocd.argoproj.io~1hook
+        value: Skip
+
 configMapGenerator:
   - name: surfsense-mink-sync-script
     files:

--- a/my-apps/ai/surfsense/kustomization.yaml
+++ b/my-apps/ai/surfsense/kustomization.yaml
@@ -30,37 +30,6 @@ resources:
 components:
   - ../../common/kopiur-backup
 
-# Pause writers before preserving the damaged PostgreSQL filesystem; keep PostgreSQL running for the final dump.
-patches:
-  - target:
-      kind: Deployment
-      name: surfsense|surfsense-beat|surfsense-zero
-    patch: |-
-      - op: replace
-        path: /spec/replicas
-        value: 0
-  - target:
-      kind: CronJob
-      name: surfsense-mink-sync
-    patch: |-
-      - op: add
-        path: /spec/suspend
-        value: true
-  - target:
-      kind: SnapshotPolicy
-      name: surfsense-postgres-data
-    patch: |-
-      - op: add
-        path: /spec/suspend
-        value: true
-  - target:
-      kind: Job
-      name: surfsense-migrations|surfsense-credit-policy-v1
-    patch: |-
-      - op: replace
-        path: /metadata/annotations/argocd.argoproj.io~1hook
-        value: Skip
-
 configMapGenerator:
   - name: surfsense-mink-sync-script
     files:
@@ -88,7 +57,7 @@ replacements:
     targets:
       - select:
           kind: Deployment
-          name: surfsense|surfsense-beat
+          name: surfsense-v2|surfsense-beat-v2
         fieldPaths:
           - spec.template.metadata.annotations.llm-config-revision
         options:

--- a/my-apps/ai/surfsense/mink-sync-cronjob.yaml
+++ b/my-apps/ai/surfsense/mink-sync-cronjob.yaml
@@ -4,11 +4,12 @@ metadata:
   name: surfsense-mink-sync
   namespace: surfsense
   annotations:
-    argocd.argoproj.io/sync-wave: "5"
+    argocd.argoproj.io/sync-wave: "6"
 spec:
   schedule: "17 */6 * * *"
   timeZone: Etc/UTC
-  suspend: false
+  # Reconnect the importer to a fresh account/workspace before enabling it.
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 600
   successfulJobsHistoryLimit: 2

--- a/my-apps/ai/surfsense/postgres/deployment.yaml
+++ b/my-apps/ai/surfsense/postgres/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: surfsense-postgres
+  name: surfsense-postgres-v2
   namespace: surfsense
   labels:
     app: surfsense-postgres
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 1
   strategy:
@@ -87,4 +87,4 @@ spec:
       volumes:
         - name: postgres-data
           persistentVolumeClaim:
-            claimName: surfsense-postgres-data
+            claimName: surfsense-postgres-data-v2

--- a/my-apps/ai/surfsense/postgres/pvc.yaml
+++ b/my-apps/ai/surfsense/postgres/pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: surfsense-postgres-data
+  name: surfsense-postgres-data-v2
   namespace: surfsense
   annotations:
     argocd.argoproj.io/compare-options: ServerSideDiff=false
@@ -11,11 +11,11 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn
+  storageClassName: longhorn-wired-ha
   resources:
     requests:
       storage: 20Gi
   dataSourceRef:
     apiGroup: kopiur.home-operations.com
     kind: Restore
-    name: surfsense-postgres-data-restore
+    name: surfsense-postgres-data-v2-restore

--- a/my-apps/ai/surfsense/redis/deployment.yaml
+++ b/my-apps/ai/surfsense/redis/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: surfsense-redis
+  name: surfsense-redis-v2
   namespace: surfsense
   labels:
     app: surfsense-redis
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   replicas: 1
   strategy:
@@ -47,4 +47,4 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: surfsense-redis-data
+            claimName: surfsense-redis-data-v2

--- a/my-apps/ai/surfsense/redis/pvc.yaml
+++ b/my-apps/ai/surfsense/redis/pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: surfsense-redis-data
+  name: surfsense-redis-data-v2
   namespace: surfsense
   labels:
     app: surfsense-redis

--- a/my-apps/ai/surfsense/vpa.yaml
+++ b/my-apps/ai/surfsense/vpa.yaml
@@ -4,7 +4,7 @@ metadata:
   name: surfsense-postgres
   namespace: surfsense
 spec:
-  targetRef: {apiVersion: apps/v1, kind: Deployment, name: surfsense-postgres}
+  targetRef: {apiVersion: apps/v1, kind: Deployment, name: surfsense-postgres-v2}
   updatePolicy:
     updateMode: InPlaceOrRecreate
     minReplicas: 1
@@ -18,7 +18,7 @@ metadata:
   name: surfsense-redis
   namespace: surfsense
 spec:
-  targetRef: {apiVersion: apps/v1, kind: Deployment, name: surfsense-redis}
+  targetRef: {apiVersion: apps/v1, kind: Deployment, name: surfsense-redis-v2}
   updatePolicy:
     updateMode: InPlaceOrRecreate
     minReplicas: 1
@@ -32,7 +32,7 @@ metadata:
   name: surfsense
   namespace: surfsense
 spec:
-  targetRef: {apiVersion: apps/v1, kind: Deployment, name: surfsense}
+  targetRef: {apiVersion: apps/v1, kind: Deployment, name: surfsense-v2}
   updatePolicy:
     updateMode: InPlaceOrRecreate
     minReplicas: 1
@@ -47,7 +47,7 @@ metadata:
   name: surfsense-beat
   namespace: surfsense
 spec:
-  targetRef: {apiVersion: apps/v1, kind: Deployment, name: surfsense-beat}
+  targetRef: {apiVersion: apps/v1, kind: Deployment, name: surfsense-beat-v2}
   updatePolicy:
     updateMode: InPlaceOrRecreate
     minReplicas: 1
@@ -61,7 +61,7 @@ metadata:
   name: surfsense-zero
   namespace: surfsense
 spec:
-  targetRef: {apiVersion: apps/v1, kind: Deployment, name: surfsense-zero}
+  targetRef: {apiVersion: apps/v1, kind: Deployment, name: surfsense-zero-v2}
   updatePolicy:
     updateMode: InPlaceOrRecreate
     minReplicas: 1


### PR DESCRIPTION
Merging this PR discards the existing SurfSense database, uploaded files and Redis queue, then starts SurfSense fresh through Argo and the existing storage controllers. Expect downtime and fresh-account onboarding. This replaces the earlier filesystem-maintenance proposal entirely.

The three replacement PVCs keep their existing sizes: PostgreSQL 20Gi, object store 20Gi and Redis 2Gi. PostgreSQL and object storage use the existing two-copy wired storage class. Redis remains disposable single-copy storage.

PostgreSQL and object storage receive new `-v2` backup identities and matching Restore resources. They start empty because the old backup lineage cannot match; future scheduled backups and ordinary restore-before-bind remain enabled, with unchanged retention. This does not erase historical repository backups.

Argo performs the reset in one normal sync:

1. Remove the old API/worker, beat and Zero Deployments; provision the fresh claims.
2. Remove the old PostgreSQL/Redis Deployments and old claims, waiting for their consumers to terminate. Start the new data-layer Deployments and let their normal entrypoints initialize clean volumes.
3. Run the existing migrations and credit-policy hook against the fresh database.
4. Start the replacement API/worker, beat and Zero Pods with normal replica counts. The new Zero Pod also clears its disposable local cache.

The old Mink importer is disabled until connected to the new account and workspace. All normal services and future backups remain enabled. No filesystem repair, manual data command, new recovery Job or custom program is involved.

The ordering is deliberate: deployed Argo v3.5.2 waits for foreground pruning to finish. Its prune waves are recalculated between passes. All five old writer/data-layer Deployments are removed, so PVC protection can finish before the replacement data-layer Deployments start in wave 1. This does not rely on old PVCs retaining a fixed prune wave. Service selectors remain stable; VPA targets and the existing config replacement match the new Deployment names.

Validation: all 38 resources render; all three claim bindings, both new backup lineages, normal replica counts and VPA targets were checked. Scoped server-side dry-run passed with existing Pod Security warnings. Current wired storage capacity accommodates the two 20Gi protected volumes and their second copies. The five old Deployments are currently Argo-tracked with no prune exclusions. No live deployment or data deletion has been performed by this PR preparation.

This reset intentionally deletes the old claims. Reverting Git afterward is not a guaranteed data rollback.
