### PR TITLE
fix(posthog): keep broker headroom and close stale log segments

### DIFF
--- a/my-apps/development/posthog/core/jobs.yaml
+++ b/my-apps/development/posthog/core/jobs.yaml
@@ -19,6 +19,16 @@ spec:
         app.kubernetes.io/component: kafka-init
     spec:
       restartPolicy: OnFailure
+      initContainers:
+      - name: configure-segment-size
+        image: docker.redpanda.com/redpandadata/redpanda:v25.1.9@sha256:8f7e9e4c1422baaa1a5e2a6c6c668cfe05442cb3cb476542c7dff61725e6fe31
+        command: ["rpk", "cluster", "config", "set", "log_segment_size=67108864", "--no-confirm", "-X", "admin.hosts=kafka:9644"]
+      - name: configure-segment-roll
+        image: docker.redpanda.com/redpandadata/redpanda:v25.1.9@sha256:8f7e9e4c1422baaa1a5e2a6c6c668cfe05442cb3cb476542c7dff61725e6fe31
+        command: ["rpk", "cluster", "config", "set", "log_segment_ms=3600000", "--no-confirm", "-X", "admin.hosts=kafka:9644"]
+      - name: configure-disk-headroom
+        image: docker.redpanda.com/redpandadata/redpanda:v25.1.9@sha256:8f7e9e4c1422baaa1a5e2a6c6c668cfe05442cb3cb476542c7dff61725e6fe31
+        command: ["rpk", "cluster", "config", "set", "storage_min_free_bytes=1073741824", "--no-confirm", "-X", "admin.hosts=kafka:9644"]
       containers:
       - name: kafka-init
         image: docker.redpanda.com/redpandadata/redpanda:v25.1.9@sha256:8f7e9e4c1422baaa1a5e2a6c6c668cfe05442cb3cb476542c7dff61725e6fe31


### PR DESCRIPTION
PostHog's broker had only **10 MiB of free-space protection** and a **14-day segment lifetime**, which can keep low-traffic log files around beyond the seven-day retention window. Apply three native Redpanda settings through the existing Argo `kafka-init` Sync Job:

| Setting | Before | After |
| --- | --- | --- |
| Default segment size | 128 MiB | 64 MiB |
| Default segment lifetime | 14 days | 1 hour |
| Stop accepting producers below free space | 10 MiB | 1 GiB |

Seven-day retention remains unchanged. All 30 user topics currently inherit these defaults; no topic overrides are reset. Smaller, more frequently closed segments allow more granular retention cleanup. Existing segment files are not immediately rewritten, and cleanup remains asynchronous. The free-space floor applies backpressure before the filesystem fills; clients still need to handle retries.

Read-only checks on September 11, 2026 at 03:32–03:38 UTC found all 26 consumer groups stable, maximum lag 134 records, and oldest outstanding records in active groups about 3–14 seconds old. The unclaimed `events_plugin_ingestion_ai` queue still contains 21 records, the oldest about 4.23 days old. **Retention is not consumer-aware:** those records can expire after seven days if that queue remains unclaimed. This PR preserves the current retention window; ownership of that queue remains a follow-up.

The expanded 32 GiB claim currently uses about 7.75 GB, with roughly 26 GB free. Its measured one-hour net filesystem growth was about 462 bytes/s following cleanup; that is an observation, not a future growth guarantee. The existing 5% space alert precedes the new 1 GiB producer floor.

One YAML file, 10 added lines: direct `rpk` arguments using the existing pinned image, in the existing hook. No new script, Job, operator, or manual rollout procedure. Argo applies the settings on sync; the broker reports all three properties as dynamic, requiring no restart.

Validation: PostHog Kustomize render; server-side dry-run CREATE of the rendered hook under a validation name; live Redpanda v25.1.9 property schema and pinned CLI syntax; `git diff --check`. Dry-run admission succeeded, with the namespace's existing restricted-profile advisory for the hook's container security context. No live configuration changed.

References: [Redpanda 25.1 cluster properties](https://docs.redpanda.com/streaming/25.1/reference/properties/cluster-properties/), [topic inheritance and retention](https://docs.redpanda.com/streaming/25.1/reference/properties/topic-properties/).
