### PR TITLE
fix(cloudflared): spread three tunnel replicas across physical hosts

### DIFF
--- a/infrastructure/networking/cloudflared/deployment.yaml
+++ b/infrastructure/networking/cloudflared/deployment.yaml
@@ -15,11 +15,11 @@ spec:
       labels:
         app: cloudflared
     spec:
-      # Spread across physical hosts; permit co-location when a host is unavailable.
+      # Require balanced physical-host spread among currently eligible nodes.
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
           # Compare only pods from the same rollout. Old/new ReplicaSets
           # otherwise distort skew while a Deployment is replacing pods.
           matchLabelKeys:


### PR DESCRIPTION
Cloudflared's three Ready replicas currently occupy only two physical hosts (two on SFF, one on Dell), because its zone-spread rule is optional. Make the existing rule mandatory so a completed rollout uses three distinct eligible physical hosts, retaining three replicas and the existing PDB.

The current eligible hosts are SFF, Elite, Dell and GPU; each has room for the existing 300m CPU / 600Mi request. The existing rolling strategy allows one surge pod and zero unavailable pods at three replicas. Its `pod-template-hash` match keeps old replicas out of the new revision's spread calculation, so the surge can start without waiting for an old pod to disappear. No fixed `minDomains` is added; reduced eligible topology remains supported.

Validation: complete app rendered with Kustomize 5.8.1, live node labels/taints/resource headroom and Deployment rollout settings checked read-only, and `git diff --check`. This PR is not deployed; the three-host distribution still needs rollout verification after merge.
