### PR TITLE
fix(monitoring): give Loki write buffering room and expose backend health

### DIFF
--- a/monitoring/loki-stack/kustomization.yaml
+++ b/monitoring/loki-stack/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ns.yaml
   - loki-http-route.yaml
   - externalsecret.yaml
+  - write-pvc.yaml
 # OSS Loki chart lives at grafana-community/helm-charts; grafana/helm-charts went GEL-only at v7.0.0.
 helmCharts:
   - name: loki

--- a/monitoring/loki-stack/values.yaml
+++ b/monitoring/loki-stack/values.yaml
@@ -50,6 +50,10 @@ loki:
     compaction_interval: 10m
     delete_request_store: s3
 deploymentMode: SimpleScalable
+monitoring:
+  serviceMonitor:
+    enabled: true
+    interval: 30s
 backend:
   replicas: 1
   # Write-path WAL/cache only; log data lives on S3. Backup-exempt, rebuilds from S3.

--- a/monitoring/loki-stack/write-pvc.yaml
+++ b/monitoring/loki-stack/write-pvc.yaml
@@ -1,0 +1,21 @@
+# Expand the stable writer claim directly; the StatefulSet's 10Gi template is immutable.
+# On bootstrap this claim is created before the StatefulSet and reused by loki-write-0.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-loki-write-0
+  namespace: loki-stack
+  labels:
+    app.kubernetes.io/component: write
+    app.kubernetes.io/instance: loki
+    app.kubernetes.io/name: loki
+    backup-exempt: "true"
+  annotations:
+    storage.vanillax.dev/backup-exempt-reason: "Loki write-ahead log; persisted log history is stored in S3"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-flash
+  resources:
+    requests:
+      storage: 20Gi

--- a/monitoring/tempo/values.yaml
+++ b/monitoring/tempo/values.yaml
@@ -1,3 +1,6 @@
+serviceMonitor:
+  enabled: true
+  interval: 30s
 tempo:
   receivers:
     otlp:


### PR DESCRIPTION
Loki recorded 45 write-ahead-log disk-full failures after its September 10 22:13 UTC start. Its 10Gi writer claim reached 9.14Gi used during the last week; current filesystem use was 8.86Gi, with a later direct check finding 7.32Gi in the WAL. Loki received about 220GB of raw logs in roughly 5.4 hours, and repeated Longhorn-manager messages were hitting the per-stream rate limit.

Expand the stable `data-loki-write-0` PVC to 20Gi and enable the charts’ native Loki and Tempo ServiceMonitors at 30-second intervals. The StatefulSet's immutable 10Gi claim template stays unchanged: Kubernetes creates missing ordinal claims but does not resize an existing one. On bootstrap Argo creates the explicitly declared claim before the StatefulSet. The existing expandable `longhorn-flash` class and same bound PV preserve the data; no replacement claim or workload restart is declared.

This buys headroom and adds visibility. It does not fix the separate Longhorn retry/log storm. Loki’s 24-hour S3 history retention stays unchanged because retention is not the WAL cleanup mechanism. The main Prometheus retention (15 days / 40GiB) and Tempo’s 72-hour trace retention also stay unchanged.

Validation:

- Both pinned Helm charts rendered through Kustomize; the only rendered changes are the PVC and two ServiceMonitors. All workload and ConfigMap manifests are identical.
- Scoped server dry-run passed for all three resources using Argo's existing server-side-apply semantics (`--force-conflicts`); no live apply or manual sync was performed.
- Live Prometheus selects all ServiceMonitors/namespaces; both charts select the existing metrics Services. Existing Loki claim has no conflicting Argo owner.
- Kubernetes v1.37 StatefulSet source verifies it creates missing claims and does not rewrite existing requests. Argo 3.5's documented SSA behavior handles the existing kube-controller-manager storage field ownership.

References: [Argo server-side apply](https://argo-cd.readthedocs.io/en/release-3.5/user-guide/sync-options/#server-side-apply), [StatefulSet claim handling](https://github.com/kubernetes/kubernetes/blob/v1.37.0/pkg/controller/statefulset/stateful_pod_control.go#L381), [PVC expansion](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims).
