### PR TITLE
Model AC cooling cost from the Nest thermostat (Cooling dashboard view)

### DIFF
--- a/docs/domains/power/metering.md
+++ b/docs/domains/power/metering.md
@@ -281,3 +281,31 @@ feeds are integrated only while it is on:
 Grafana **Gaming PC** (`gaming-pc.json`) and the **Gaming** view of the Homelab
 Power dashboard read these. The threshold is a slider so it can be tuned without
 a deploy; a permanent change goes in `configuration.yaml`.
+
+## AC cooling (modeled)
+
+The central AC has no plug meter, so its cost is **modeled**, not measured:
+`binary_sensor.ac_cooling` is on while the Google Nest (`climate.hallway_hallway`)
+reports `hvac_action: cooling` (fan-only runs read `fan` and are not counted),
+and the runtime is priced at `input_number.ac_cooling_wattage` (placeholder 3500 W)
+× the live TOU rate — the same integration pipeline as the gaming sessions.
+
+| Sensor | What it holds |
+|---|---|
+| `sensor.ac_cooling_energy` / `_cost` / `_hours` (+ daily/weekly/monthly/yearly meters) | Modeled AC kWh, USD, and cooling hours |
+| `sensor.ac_cooling_cost_yesterday` / `_cost_last_month`, `_hours_*`, `_energy_last_month` | Finished periods, from `last_period` |
+| `sensor.ac_cost_per_cooling_hour` | Month-to-date USD per cooling hour |
+| `sensor.ac_share_of_house_yesterday` | AC cost as a % of the CE-billed house cost yesterday |
+| `sensor.ac_implied_watts_yesterday` | **Calibration gauge**: (CE house kWh − metered plugs − `input_number.ac_house_baseline_kwh`) ÷ cooling hours |
+
+**Calibration loop:** on 2–3 hot days with no dryer/oven/EV, compare
+`ac_implied_watts_yesterday` to `ac_cooling_wattage`; nudge the slider toward the
+median implied value, then commit it as `initial:` in `configuration.yaml`
+(Git is source of truth; the UI slider resets on HA restart). Month-end check:
+`ac_cooling_cost_last_month` + `combined_*` + baseline should land within ~10–15%
+of the CE bill; the wattage is an estimate (±20 % on a variable-speed unit).
+CE data is one day late, so every house comparison is yesterday-vs-yesterday.
+
+Dashboards: the **Cooling** view of the Homelab Power dashboard and the AC tile
+on its House view; `sensor.ac_*` / `binary_sensor.ac_cooling` are in the
+Prometheus filter globs, so Grafana can read them.

--- a/my-apps/home/home-assistant/configuration.yaml
+++ b/my-apps/home/home-assistant/configuration.yaml
@@ -64,6 +64,9 @@ prometheus:
       - sensor.electricity_tariff_period
       # House-level data pushed by the consumers-energy-sync CronJob.
       - sensor.consumers_energy_*
+      # AC cooling (modeled from the Nest hvac_action, not plug-metered).
+      - sensor.ac_*
+      - binary_sensor.ac_cooling
       # StuckAtPrototype AirCube Zigbee air-quality monitor (temp/humidity/eCO2/
       # tVOC + rssi/lqi). Feeds the aircube-dashboard.json Grafana dashboard.
       - sensor.stuckatprototype_aircube_*
@@ -300,6 +303,28 @@ input_number:
     unit_of_measurement: "W"
     icon: mdi:controller
     initial: 350
+  # Central AC has no dedicated meter: cost = Nest cooling runtime x this estimate
+  # x the live TOU rate. Calibrate against sensor.ac_implied_watts_yesterday.
+  ac_cooling_wattage:
+    name: "AC — Cooling Wattage (assumed)"
+    min: 500
+    max: 6000
+    step: 50
+    mode: box
+    unit_of_measurement: "W"
+    icon: mdi:air-conditioner
+    initial: 3500
+  # Unmetered non-AC household draw (fridge, water heater, lights), estimated from a
+  # mild no-cooling CE day; subtracted before attributing the residual to the AC.
+  ac_house_baseline_kwh:
+    name: "AC — House Baseline (non-AC kWh/day)"
+    min: 0
+    max: 80
+    step: 0.5
+    mode: box
+    unit_of_measurement: "kWh"
+    icon: mdi:home-minus
+    initial: 15
 
 # Cost integrates a live USD/h cost-rate (power * current TOU rate), not a fixed tariff.
 # Every integral starts at 0 when first created; totals only fill in as data accumulates.
@@ -455,6 +480,29 @@ sensor:
     source: sensor.gaming_pc_gaming_flag
     name: "Gaming PC Gaming Hours"
     unique_id: gaming_pc_gaming_hours
+    unit_time: h
+    round: 3
+    method: left
+  # --- AC cooling: modeled draw while the Nest reports hvac_action == 'cooling' ---
+  - platform: integration
+    source: sensor.ac_cooling_power
+    name: "AC Cooling Energy"
+    unique_id: ac_cooling_energy
+    unit_prefix: k
+    round: 3
+    method: left
+  - platform: integration
+    source: sensor.ac_cooling_cost_rate
+    name: "AC Cooling Cost"
+    unique_id: ac_cooling_cost
+    unit_time: h
+    round: 4
+    method: left
+  # 1 while cooling, else 0, integrated over hours = cooling hours. Survives the recorder purge.
+  - platform: integration
+    source: sensor.ac_cooling_flag
+    name: "AC Cooling Hours"
+    unique_id: ac_cooling_hours
     unit_time: h
     round: 3
     method: left
@@ -830,6 +878,55 @@ utility_meter:
     name: "Gaming PC Gaming Hours Yearly"
     source: sensor.gaming_pc_gaming_hours
     cycle: yearly
+  # AC cooling (energy / cost / hours while the Nest cools)
+  ac_cooling_energy_daily:
+    name: "AC Cooling Energy Daily"
+    source: sensor.ac_cooling_energy
+    cycle: daily
+  ac_cooling_energy_weekly:
+    name: "AC Cooling Energy Weekly"
+    source: sensor.ac_cooling_energy
+    cycle: weekly
+  ac_cooling_energy_monthly:
+    name: "AC Cooling Energy Monthly"
+    source: sensor.ac_cooling_energy
+    cycle: monthly
+  ac_cooling_energy_yearly:
+    name: "AC Cooling Energy Yearly"
+    source: sensor.ac_cooling_energy
+    cycle: yearly
+  ac_cooling_cost_daily:
+    name: "AC Cooling Cost Daily"
+    source: sensor.ac_cooling_cost
+    cycle: daily
+  ac_cooling_cost_weekly:
+    name: "AC Cooling Cost Weekly"
+    source: sensor.ac_cooling_cost
+    cycle: weekly
+  ac_cooling_cost_monthly:
+    name: "AC Cooling Cost Monthly"
+    source: sensor.ac_cooling_cost
+    cycle: monthly
+  ac_cooling_cost_yearly:
+    name: "AC Cooling Cost Yearly"
+    source: sensor.ac_cooling_cost
+    cycle: yearly
+  ac_cooling_hours_daily:
+    name: "AC Cooling Hours Daily"
+    source: sensor.ac_cooling_hours
+    cycle: daily
+  ac_cooling_hours_weekly:
+    name: "AC Cooling Hours Weekly"
+    source: sensor.ac_cooling_hours
+    cycle: weekly
+  ac_cooling_hours_monthly:
+    name: "AC Cooling Hours Monthly"
+    source: sensor.ac_cooling_hours
+    cycle: monthly
+  ac_cooling_hours_yearly:
+    name: "AC Cooling Hours Yearly"
+    source: sensor.ac_cooling_hours
+    cycle: yearly
   # MacBook + Monitor
   macbook_cost_daily:
     name: "MacBook Cost Daily"
@@ -910,6 +1007,16 @@ template:
         state: >
           {{ states('sensor.gaming_pc_current_consumption') | float(0)
              > states('input_number.gaming_pc_active_threshold_w') | float(350) }}
+      # Nest compressor running. Fan-only reads 'fan' and is not counted; delay_off
+      # absorbs the 1-3 min hvac_action lag. Sole thermostat id reference: if the
+      # climate entity is renamed in the UI, change it only here.
+      - name: "AC Cooling"
+        unique_id: ac_cooling
+        device_class: cold
+        icon: mdi:snowflake
+        delay_off: "00:03:00"
+        state: >
+          {{ state_attr('climate.hallway_hallway', 'hvac_action') == 'cooling' }}
   - sensor:
       - name: "Gaming PC Gaming Flag"
         unique_id: gaming_pc_gaming_flag
@@ -979,6 +1086,109 @@ template:
         state: >
           {{ (states('sensor.gaming_pc_gaming_cost_monthly') | float(0)
             / states('sensor.gaming_pc_gaming_hours_monthly') | float(1)) | round(3) }}
+
+      # --- AC cooling (modeled from the Nest, not plug-metered) ---
+      - name: "AC Cooling Flag"
+        unique_id: ac_cooling_flag
+        state_class: measurement
+        state: "{{ 1 if is_state('binary_sensor.ac_cooling', 'on') else 0 }}"
+
+      - name: "AC Cooling Power"
+        unique_id: ac_cooling_power
+        unit_of_measurement: "W"
+        device_class: power
+        state_class: measurement
+        state: >
+          {{ states('input_number.ac_cooling_wattage') | float(3500)
+             if is_state('binary_sensor.ac_cooling', 'on') else 0 }}
+
+      - name: "AC Cooling Cost Rate"
+        unique_id: ac_cooling_cost_rate
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        icon: mdi:cash-fast
+        state: >
+          {{ (states('sensor.ac_cooling_power') | float(0) / 1000
+            * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
+
+      - name: "AC Cooling Cost Yesterday"
+        unique_id: ac_cooling_cost_yesterday
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.ac_cooling_cost_daily', 'last_period') | float(0) | round(4) }}
+
+      - name: "AC Cooling Cost Last Month"
+        unique_id: ac_cooling_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.ac_cooling_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "AC Cooling Hours Yesterday"
+        unique_id: ac_cooling_hours_yesterday
+        unit_of_measurement: "h"
+        state_class: total
+        state: >
+          {{ state_attr('sensor.ac_cooling_hours_daily', 'last_period') | float(0) | round(2) }}
+
+      - name: "AC Cooling Hours Last Month"
+        unique_id: ac_cooling_hours_last_month
+        unit_of_measurement: "h"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.ac_cooling_hours_monthly', 'last_period') | float(0) | round(2) }}
+
+      - name: "AC Cooling Energy Last Month"
+        unique_id: ac_cooling_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.ac_cooling_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "AC Cost Per Cooling Hour"
+        unique_id: ac_cost_per_cooling_hour
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        icon: mdi:cash-clock
+        availability: "{{ states('sensor.ac_cooling_hours_monthly') | float(0) > 0.25 }}"
+        state: >
+          {{ (states('sensor.ac_cooling_cost_monthly') | float(0)
+            / states('sensor.ac_cooling_hours_monthly') | float(1)) | round(3) }}
+
+      - name: "AC Share Of House Yesterday"
+        unique_id: ac_share_of_house_yesterday
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:home-percent
+        availability: "{{ states('sensor.consumers_energy_cost_yesterday') | is_number and states('sensor.ac_cooling_cost_yesterday') | is_number }}"
+        state: >
+          {% set house = states('sensor.consumers_energy_cost_yesterday') | float(0) %}
+          {% if house > 0 %}
+            {{ (states('sensor.ac_cooling_cost_yesterday') | float(0) / house * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      # Calibration gauge: watts implied by the CE bill (house minus metered plugs
+      # minus baseline, over cooling hours). Tune ac_cooling_wattage toward its median.
+      - name: "AC Implied Watts Yesterday"
+        unique_id: ac_implied_watts_yesterday
+        unit_of_measurement: "W"
+        state_class: measurement
+        icon: mdi:air-conditioner
+        availability: >
+          {{ states('sensor.consumers_energy_kwh_yesterday') | is_number
+             and states('sensor.ac_cooling_hours_yesterday') | float(0) > 0.25 }}
+        state: >
+          {% set h = states('sensor.ac_cooling_hours_yesterday') | float(0) %}
+          {% set resid = (states('sensor.consumers_energy_kwh_yesterday') | float(0)
+            - states('sensor.combined_total_energy_yesterday') | float(0)
+            - states('input_number.ac_house_baseline_kwh') | float(15)) %}
+          {{ (resid / h * 1000) | round(0) if resid > 0 else 0 }}
 
       # now()-based templates re-render every minute; float(<bill default>) keeps this right
       # before the input_number sliders are first touched.

--- a/my-apps/home/home-assistant/customize.yaml
+++ b/my-apps/home/home-assistant/customize.yaml
@@ -232,6 +232,58 @@ sensor.gaming_pc_cost_monthly:
 sensor.gaming_pc_cost_yearly:
   friendly_name: Gaming PC Cost Yearly
 
+# ---------- AC Cooling (ac_*) — modeled from the Nest, not plug-metered ----------
+sensor.ac_cooling_power:
+  friendly_name: AC Cooling Power
+sensor.ac_cooling_energy:
+  friendly_name: AC Cooling Energy
+sensor.ac_cooling_cost:
+  friendly_name: AC Cooling Cost
+sensor.ac_cooling_cost_rate:
+  friendly_name: AC Cooling Cost Rate
+sensor.ac_cooling_hours:
+  friendly_name: AC Cooling Hours
+sensor.ac_cooling_energy_daily:
+  friendly_name: AC Cooling Energy Daily
+sensor.ac_cooling_energy_weekly:
+  friendly_name: AC Cooling Energy Weekly
+sensor.ac_cooling_energy_monthly:
+  friendly_name: AC Cooling Energy Monthly
+sensor.ac_cooling_energy_yearly:
+  friendly_name: AC Cooling Energy Yearly
+sensor.ac_cooling_cost_daily:
+  friendly_name: AC Cooling Cost Daily
+sensor.ac_cooling_cost_weekly:
+  friendly_name: AC Cooling Cost Weekly
+sensor.ac_cooling_cost_monthly:
+  friendly_name: AC Cooling Cost Monthly
+sensor.ac_cooling_cost_yearly:
+  friendly_name: AC Cooling Cost Yearly
+sensor.ac_cooling_hours_daily:
+  friendly_name: AC Cooling Hours Daily
+sensor.ac_cooling_hours_weekly:
+  friendly_name: AC Cooling Hours Weekly
+sensor.ac_cooling_hours_monthly:
+  friendly_name: AC Cooling Hours Monthly
+sensor.ac_cooling_hours_yearly:
+  friendly_name: AC Cooling Hours Yearly
+sensor.ac_cooling_cost_yesterday:
+  friendly_name: AC Cooling Cost Yesterday
+sensor.ac_cooling_cost_last_month:
+  friendly_name: AC Cooling Cost Last Month
+sensor.ac_cooling_energy_last_month:
+  friendly_name: AC Cooling Energy Last Month
+sensor.ac_cooling_hours_yesterday:
+  friendly_name: AC Cooling Hours Yesterday
+sensor.ac_cooling_hours_last_month:
+  friendly_name: AC Cooling Hours Last Month
+sensor.ac_cost_per_cooling_hour:
+  friendly_name: AC Cooling Cost Per Cooling Hour
+sensor.ac_share_of_house_yesterday:
+  friendly_name: AC Cooling Share Of House
+sensor.ac_implied_watts_yesterday:
+  friendly_name: AC Cooling Implied Watts
+
 # ---------- MacBook + Monitor (macbook_*) ----------
 sensor.macbook_current_consumption:
   friendly_name: MacBook + Monitor Power

--- a/my-apps/home/home-assistant/lovelace-homelab-power.yaml
+++ b/my-apps/home/home-assistant/lovelace-homelab-power.yaml
@@ -610,6 +610,13 @@ views:
               columns: 6
               rows: 1
             color: amber
+          - type: tile
+            entity: sensor.ac_share_of_house_yesterday
+            name: AC share
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
       - type: grid
         column_span: 2
         cards:
@@ -1043,6 +1050,212 @@ views:
               A **session** is the plug drawing more than the threshold (350 W; idle is ~200 W, gaming
               450–600 W) until five quiet minutes pass. **Idle tax** is everything the PC costs outside
               sessions: sitting on at 200 W is about 1.4 kWh a day. Tune the threshold under Settings.
+
+  # ───────────────────────── Cooling: central AC (Nest-modeled) ─────────────────────────
+  - title: Cooling
+    icon: mdi:snowflake
+    path: cooling
+    type: sections
+    max_columns: 4
+    dense_section_placement: true
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Right now
+            heading_style: title
+            badges:
+              - type: entity
+                entity: climate.hallway_hallway
+                name: Thermostat
+              - type: entity
+                entity: binary_sensor.ac_cooling
+                name: Compressor
+          - type: tile
+            entity: sensor.ac_cooling_power
+            name: Est. draw
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_cost_rate
+            name: Burn rate
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.ac_cooling_hours_daily
+            name: Cooling hours today
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cost_per_cooling_hour
+            name: Cost per cooling hour
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+      - type: grid
+        cards:
+          - type: heading
+            heading: Today
+            heading_style: title
+          - type: tile
+            entity: sensor.ac_cooling_hours_daily
+            name: Hours cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_energy_daily
+            name: kWh cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_cost_daily
+            name: Cost cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+      - type: grid
+        cards:
+          - type: heading
+            heading: This month
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.ac_cooling_hours_last_month
+                name: Hours last month
+              - type: entity
+                entity: sensor.ac_cooling_cost_last_month
+                name: Cost last month
+          - type: tile
+            entity: sensor.ac_cooling_hours_monthly
+            name: Hours cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_energy_monthly
+            name: kWh cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_cost_monthly
+            name: Cost cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+      - type: grid
+        cards:
+          - type: heading
+            heading: Share of the house
+            heading_style: title
+          - type: tile
+            entity: sensor.ac_share_of_house_yesterday
+            name: AC share of bill
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_cost_yesterday
+            name: AC cost yesterday
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.consumers_energy_cost_yesterday
+            name: House cost yesterday
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: tile
+            entity: sensor.consumers_energy_effective_rate
+            name: CE charged (per kWh)
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Cooling vs house, by day
+            heading_style: title
+          - type: statistics-graph
+            title: 
+            chart_type: bar
+            period: day
+            days_to_show: 60
+            stat_types:
+              - change
+            entities:
+              - consumers_energy:grid_kwh
+              - sensor.ac_cooling_energy
+              - sensor.combined_total_energy
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Cooling hours, by day
+            heading_style: title
+          - type: statistics-graph
+            title: 
+            chart_type: bar
+            period: day
+            days_to_show: 30
+            stat_types:
+              - change
+            entities:
+              - sensor.ac_cooling_hours
+      - type: grid
+        cards:
+          - type: heading
+            heading: Is the model right?
+            heading_style: title
+          - type: tile
+            entity: sensor.ac_implied_watts_yesterday
+            name: Implied watts (yesterday)
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: input_number.ac_cooling_wattage
+            name: Assumed wattage
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: tile
+            entity: input_number.ac_house_baseline_kwh
+            name: House baseline
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: markdown
+            content: |
+              The AC has no meter, so cost = **Nest cooling runtime × assumed wattage × live TOU
+              rate**. While the Nest reports `cooling`, the assumed draw is integrated at the live
+              rate. **Calibrate** on hot days with no dryer/oven/EV: nudge *assumed wattage* toward
+              *implied watts*, then commit the value as `initial:` in configuration.yaml.
+              CE data is one day late, so every house comparison is yesterday-vs-yesterday.
 
   # ───────────────────────── Settings: rates and thresholds ─────────────────────────
   - title: Settings


### PR DESCRIPTION
## What

Estimates what the central AC costs per day/month, since it has no plug meter. While the Google Nest reports \`hvac_action: cooling\`, its runtime is priced at an assumed wattage × the live TOU rate, through the same integration/utility_meter pipeline as the gaming sessions. The Consumers Energy scrape provides the whole-house bill to attribute and calibrate against.

## Changes (4 commits)

1. **Sensors** (\`configuration.yaml\` + \`customize.yaml\`):
   - \`binary_sensor.ac_cooling\` — Nest compressor running (fan-only excluded; 3 min \`delay_off\` against SDM state lag; unavailable while the Nest itself is unavailable). The thermostat entity id (\`climate.hallway_hallway\`, verified live) is referenced in exactly this one template — rename the climate entity in the UI and only this line changes.
   - \`ac_cooling_{power,energy,cost,cost_rate,hours}\` + daily/weekly/monthly/yearly meters (12) + finished-period templates (\`_yesterday\`, \`_last_month\`, via \`last_period\`).
   - Tunables: \`input_number.ac_cooling_wattage\` (placeholder **3500 W**) and \`input_number.ac_house_baseline_kwh\` (placeholder **15 kWh/day**), on the Settings view ("Air conditioning" card).
   - Calibration: \`sensor.ac_implied_watts_yesterday\` derives the AC watts implied by the Consumers Energy bill (house kWh − metered plugs − baseline, over cooling hours); tune the wattage toward it and commit \`initial:\` (Git is source of truth). \`sensor.ac_share_of_house_yesterday\` attributes AC cost against the CE billed house cost.
   - \`sensor.ac_*\` + \`binary_sensor.ac_cooling\` added to the Prometheus filter globs.
2. **Dashboard** (\`lovelace-homelab-power.yaml\`): new **Cooling** view (between Gaming and Settings) with right-now/today/month tiles, share-of-house, cooling-vs-house and cooling-hours-by-day statistics graphs, and an "Is the model right?" calibration panel; AC share tile added to the House view.
3. **Docs** (\`docs/domains/power/metering.md\`): "AC cooling (modeled)" section with the entity table, calibration loop, and caveats.
4. **Review fixes**: comment-cap, Nest-outage availability guard, Settings sliders, customize dedupe (Claude Code review).

## Known placeholders and failure modes (by design)

- \`ac_cooling_wattage\` / \`ac_house_baseline_kwh\` are starting points; the "Is the model right?" panel is the calibration loop. Tune on hot, no-dryer/EV days, then commit the new \`initial:\` values.
- CE data is one day late, so house comparisons are yesterday-vs-yesterday. CE \`_yesterday\` sensors are REST-pushed and absent until the next 13:17 run — AC share cards read unavailable in that window (guarded, expected).
- While the Nest is offline, \`binary_sensor.ac_cooling\` reads unavailable and AC cost accrues at \$0 — an undercount during the outage, flagged rather than silently zero.
- Follow-up (not this PR): a Grafana panel over the now-exported \`ac_*\` Prometheus series; optional 21:30 daily AC summary notification.

## Verification after merge

After ArgoCD sync + HA rollout restart:
- Developer Tools → States: all \`sensor.ac_*\` numeric, \`binary_sensor.ac_cooling\` flips on a real cooling call, \`ac_cooling_cost_rate\` > 0 while cooling.
- Dashboard: Cooling view renders; statistics graphs fill after a day boundary.
- Prometheus: \`sensor.ac_*\` series appear on the scrape.

No new Kubernetes objects; no manifest changes — config-only for the existing home-assistant app.