### PR TITLE
fix(langfuse): restore trace ingestion after the ClickHouse 26.8 bump

### DIFF
--- a/docs/domains/power/metering.md
+++ b/docs/domains/power/metering.md
@@ -281,3 +281,31 @@ feeds are integrated only while it is on:
 Grafana **Gaming PC** (`gaming-pc.json`) and the **Gaming** view of the Homelab
 Power dashboard read these. The threshold is a slider so it can be tuned without
 a deploy; a permanent change goes in `configuration.yaml`.
+
+## AC cooling (modeled)
+
+The central AC has no plug meter, so its cost is **modeled**, not measured:
+`binary_sensor.ac_cooling` is on while the Google Nest (`climate.hallway_hallway`)
+reports `hvac_action: cooling` (fan-only runs read `fan` and are not counted),
+and the runtime is priced at `input_number.ac_cooling_wattage` (placeholder 3500 W)
+× the live TOU rate — the same integration pipeline as the gaming sessions.
+
+| Sensor | What it holds |
+|---|---|
+| `sensor.ac_cooling_energy` / `_cost` / `_hours` (+ daily/weekly/monthly/yearly meters) | Modeled AC kWh, USD, and cooling hours |
+| `sensor.ac_cooling_cost_yesterday` / `_cost_last_month`, `_hours_*`, `_energy_last_month` | Finished periods, from `last_period` |
+| `sensor.ac_cost_per_cooling_hour` | Month-to-date USD per cooling hour |
+| `sensor.ac_share_of_house_yesterday` | AC cost as a % of the CE-billed house cost yesterday |
+| `sensor.ac_implied_watts_yesterday` | **Calibration gauge**: (CE house kWh − metered plugs − `input_number.ac_house_baseline_kwh`) ÷ cooling hours |
+
+**Calibration loop:** on 2–3 hot days with no dryer/oven/EV, compare
+`ac_implied_watts_yesterday` to `ac_cooling_wattage`; nudge the slider toward the
+median implied value, then commit it as `initial:` in `configuration.yaml`
+(Git is source of truth; the UI slider resets on HA restart). Month-end check:
+`ac_cooling_cost_last_month` + `combined_*` + baseline should land within ~10–15%
+of the CE bill; the wattage is an estimate (±20 % on a variable-speed unit).
+CE data is one day late, so every house comparison is yesterday-vs-yesterday.
+
+Dashboards: the **Cooling** view of the Homelab Power dashboard and the AC tile
+on its House view; `sensor.ac_*` / `binary_sensor.ac_cooling` are in the
+Prometheus filter globs, so Grafana can read them.

--- a/my-apps/ai/langfuse/clickhouse-settings.xml
+++ b/my-apps/ai/langfuse/clickhouse-settings.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+  <profiles>
+    <default>
+      <!-- ClickHouse 26.8 reads a bare JSON number for DateTime64 as seconds; Langfuse sends microseconds, so every insert overflows and the worker drops the batch. -->
+      <input_format_read_datetime_number_as_raw_value>1</input_format_read_datetime_number_as_raw_value>
+    </default>
+  </profiles>
+</clickhouse>

--- a/my-apps/ai/langfuse/clickhouse.yaml
+++ b/my-apps/ai/langfuse/clickhouse.yaml
@@ -61,6 +61,11 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /var/lib/clickhouse
+        # subPath, not a directory mount: the image's entrypoint writes default-user.xml into this dir at start.
+        - name: settings
+          mountPath: /etc/clickhouse-server/users.d/langfuse-settings.xml
+          subPath: clickhouse-settings.xml
+          readOnly: true
         startupProbe:
           httpGet:
             path: /ping
@@ -86,6 +91,9 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: langfuse-clickhouse-data
+      - name: settings
+        configMap:
+          name: langfuse-clickhouse-settings
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/my-apps/ai/langfuse/kustomization.yaml
+++ b/my-apps/ai/langfuse/kustomization.yaml
@@ -27,6 +27,9 @@ configMapGenerator:
   files:
   - scripts/init-bucket.sh
   - scripts/bucket-cors.json
+- name: langfuse-clickhouse-settings
+  files:
+  - clickhouse-settings.xml
 patches:
 - target:
     kind: Deployment

--- a/my-apps/home/home-assistant/configuration.yaml
+++ b/my-apps/home/home-assistant/configuration.yaml
@@ -64,6 +64,9 @@ prometheus:
       - sensor.electricity_tariff_period
       # House-level data pushed by the consumers-energy-sync CronJob.
       - sensor.consumers_energy_*
+      # AC cooling (modeled from the Nest hvac_action, not plug-metered).
+      - sensor.ac_*
+      - binary_sensor.ac_cooling
       # StuckAtPrototype AirCube Zigbee air-quality monitor (temp/humidity/eCO2/
       # tVOC + rssi/lqi). Feeds the aircube-dashboard.json Grafana dashboard.
       - sensor.stuckatprototype_aircube_*
@@ -300,6 +303,28 @@ input_number:
     unit_of_measurement: "W"
     icon: mdi:controller
     initial: 350
+  # Central AC has no dedicated meter: cost = Nest cooling runtime x this estimate
+  # x the live TOU rate. Calibrate against sensor.ac_implied_watts_yesterday.
+  ac_cooling_wattage:
+    name: "AC — Cooling Wattage (assumed)"
+    min: 500
+    max: 6000
+    step: 50
+    mode: box
+    unit_of_measurement: "W"
+    icon: mdi:air-conditioner
+    initial: 3500
+  # Unmetered non-AC household draw (fridge, water heater, lights), estimated from a
+  # mild no-cooling CE day; subtracted before attributing the residual to the AC.
+  ac_house_baseline_kwh:
+    name: "AC — House Baseline (non-AC kWh/day)"
+    min: 0
+    max: 80
+    step: 0.5
+    mode: box
+    unit_of_measurement: "kWh"
+    icon: mdi:home-minus
+    initial: 15
 
 # Cost integrates a live USD/h cost-rate (power * current TOU rate), not a fixed tariff.
 # Every integral starts at 0 when first created; totals only fill in as data accumulates.
@@ -455,6 +480,29 @@ sensor:
     source: sensor.gaming_pc_gaming_flag
     name: "Gaming PC Gaming Hours"
     unique_id: gaming_pc_gaming_hours
+    unit_time: h
+    round: 3
+    method: left
+  # --- AC cooling: modeled draw while the Nest reports hvac_action == 'cooling' ---
+  - platform: integration
+    source: sensor.ac_cooling_power
+    name: "AC Cooling Energy"
+    unique_id: ac_cooling_energy
+    unit_prefix: k
+    round: 3
+    method: left
+  - platform: integration
+    source: sensor.ac_cooling_cost_rate
+    name: "AC Cooling Cost"
+    unique_id: ac_cooling_cost
+    unit_time: h
+    round: 4
+    method: left
+  # 1 while cooling, else 0, integrated over hours = cooling hours. Survives the recorder purge.
+  - platform: integration
+    source: sensor.ac_cooling_flag
+    name: "AC Cooling Hours"
+    unique_id: ac_cooling_hours
     unit_time: h
     round: 3
     method: left
@@ -830,6 +878,55 @@ utility_meter:
     name: "Gaming PC Gaming Hours Yearly"
     source: sensor.gaming_pc_gaming_hours
     cycle: yearly
+  # AC cooling (energy / cost / hours while the Nest cools)
+  ac_cooling_energy_daily:
+    name: "AC Cooling Energy Daily"
+    source: sensor.ac_cooling_energy
+    cycle: daily
+  ac_cooling_energy_weekly:
+    name: "AC Cooling Energy Weekly"
+    source: sensor.ac_cooling_energy
+    cycle: weekly
+  ac_cooling_energy_monthly:
+    name: "AC Cooling Energy Monthly"
+    source: sensor.ac_cooling_energy
+    cycle: monthly
+  ac_cooling_energy_yearly:
+    name: "AC Cooling Energy Yearly"
+    source: sensor.ac_cooling_energy
+    cycle: yearly
+  ac_cooling_cost_daily:
+    name: "AC Cooling Cost Daily"
+    source: sensor.ac_cooling_cost
+    cycle: daily
+  ac_cooling_cost_weekly:
+    name: "AC Cooling Cost Weekly"
+    source: sensor.ac_cooling_cost
+    cycle: weekly
+  ac_cooling_cost_monthly:
+    name: "AC Cooling Cost Monthly"
+    source: sensor.ac_cooling_cost
+    cycle: monthly
+  ac_cooling_cost_yearly:
+    name: "AC Cooling Cost Yearly"
+    source: sensor.ac_cooling_cost
+    cycle: yearly
+  ac_cooling_hours_daily:
+    name: "AC Cooling Hours Daily"
+    source: sensor.ac_cooling_hours
+    cycle: daily
+  ac_cooling_hours_weekly:
+    name: "AC Cooling Hours Weekly"
+    source: sensor.ac_cooling_hours
+    cycle: weekly
+  ac_cooling_hours_monthly:
+    name: "AC Cooling Hours Monthly"
+    source: sensor.ac_cooling_hours
+    cycle: monthly
+  ac_cooling_hours_yearly:
+    name: "AC Cooling Hours Yearly"
+    source: sensor.ac_cooling_hours
+    cycle: yearly
   # MacBook + Monitor
   macbook_cost_daily:
     name: "MacBook Cost Daily"
@@ -910,6 +1007,16 @@ template:
         state: >
           {{ states('sensor.gaming_pc_current_consumption') | float(0)
              > states('input_number.gaming_pc_active_threshold_w') | float(350) }}
+      # Nest compressor running. Fan-only reads 'fan' and is not counted; delay_off
+      # absorbs the 1-3 min hvac_action lag. Sole thermostat id reference: if the
+      # climate entity is renamed in the UI, change it only here.
+      - name: "AC Cooling"
+        unique_id: ac_cooling
+        device_class: cold
+        icon: mdi:snowflake
+        delay_off: "00:03:00"
+        state: >
+          {{ state_attr('climate.hallway_hallway', 'hvac_action') == 'cooling' }}
   - sensor:
       - name: "Gaming PC Gaming Flag"
         unique_id: gaming_pc_gaming_flag
@@ -979,6 +1086,109 @@ template:
         state: >
           {{ (states('sensor.gaming_pc_gaming_cost_monthly') | float(0)
             / states('sensor.gaming_pc_gaming_hours_monthly') | float(1)) | round(3) }}
+
+      # --- AC cooling (modeled from the Nest, not plug-metered) ---
+      - name: "AC Cooling Flag"
+        unique_id: ac_cooling_flag
+        state_class: measurement
+        state: "{{ 1 if is_state('binary_sensor.ac_cooling', 'on') else 0 }}"
+
+      - name: "AC Cooling Power"
+        unique_id: ac_cooling_power
+        unit_of_measurement: "W"
+        device_class: power
+        state_class: measurement
+        state: >
+          {{ states('input_number.ac_cooling_wattage') | float(3500)
+             if is_state('binary_sensor.ac_cooling', 'on') else 0 }}
+
+      - name: "AC Cooling Cost Rate"
+        unique_id: ac_cooling_cost_rate
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        icon: mdi:cash-fast
+        state: >
+          {{ (states('sensor.ac_cooling_power') | float(0) / 1000
+            * states('sensor.current_electricity_rate') | float(0)) | round(4) }}
+
+      - name: "AC Cooling Cost Yesterday"
+        unique_id: ac_cooling_cost_yesterday
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.ac_cooling_cost_daily', 'last_period') | float(0) | round(4) }}
+
+      - name: "AC Cooling Cost Last Month"
+        unique_id: ac_cooling_cost_last_month
+        unit_of_measurement: "USD"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.ac_cooling_cost_monthly', 'last_period') | float(0) | round(4) }}
+
+      - name: "AC Cooling Hours Yesterday"
+        unique_id: ac_cooling_hours_yesterday
+        unit_of_measurement: "h"
+        state_class: total
+        state: >
+          {{ state_attr('sensor.ac_cooling_hours_daily', 'last_period') | float(0) | round(2) }}
+
+      - name: "AC Cooling Hours Last Month"
+        unique_id: ac_cooling_hours_last_month
+        unit_of_measurement: "h"
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.ac_cooling_hours_monthly', 'last_period') | float(0) | round(2) }}
+
+      - name: "AC Cooling Energy Last Month"
+        unique_id: ac_cooling_energy_last_month
+        unit_of_measurement: "kWh"
+        device_class: energy
+        icon: mdi:calendar-check
+        state_class: total
+        state: >
+          {{ state_attr('sensor.ac_cooling_energy_monthly', 'last_period') | float(0) | round(3) }}
+
+      - name: "AC Cost Per Cooling Hour"
+        unique_id: ac_cost_per_cooling_hour
+        unit_of_measurement: "USD/h"
+        state_class: measurement
+        icon: mdi:cash-clock
+        availability: "{{ states('sensor.ac_cooling_hours_monthly') | float(0) > 0.25 }}"
+        state: >
+          {{ (states('sensor.ac_cooling_cost_monthly') | float(0)
+            / states('sensor.ac_cooling_hours_monthly') | float(1)) | round(3) }}
+
+      - name: "AC Share Of House Yesterday"
+        unique_id: ac_share_of_house_yesterday
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:home-percent
+        availability: "{{ states('sensor.consumers_energy_cost_yesterday') | is_number and states('sensor.ac_cooling_cost_yesterday') | is_number }}"
+        state: >
+          {% set house = states('sensor.consumers_energy_cost_yesterday') | float(0) %}
+          {% if house > 0 %}
+            {{ (states('sensor.ac_cooling_cost_yesterday') | float(0) / house * 100) | round(1) }}
+          {% else %}0{% endif %}
+
+      # Calibration gauge: watts implied by the CE bill (house minus metered plugs
+      # minus baseline, over cooling hours). Tune ac_cooling_wattage toward its median.
+      - name: "AC Implied Watts Yesterday"
+        unique_id: ac_implied_watts_yesterday
+        unit_of_measurement: "W"
+        state_class: measurement
+        icon: mdi:air-conditioner
+        availability: >
+          {{ states('sensor.consumers_energy_kwh_yesterday') | is_number
+             and states('sensor.ac_cooling_hours_yesterday') | float(0) > 0.25 }}
+        state: >
+          {% set h = states('sensor.ac_cooling_hours_yesterday') | float(0) %}
+          {% set resid = (states('sensor.consumers_energy_kwh_yesterday') | float(0)
+            - states('sensor.combined_total_energy_yesterday') | float(0)
+            - states('input_number.ac_house_baseline_kwh') | float(15)) %}
+          {{ (resid / h * 1000) | round(0) if resid > 0 else 0 }}
 
       # now()-based templates re-render every minute; float(<bill default>) keeps this right
       # before the input_number sliders are first touched.

--- a/my-apps/home/home-assistant/customize.yaml
+++ b/my-apps/home/home-assistant/customize.yaml
@@ -232,6 +232,58 @@ sensor.gaming_pc_cost_monthly:
 sensor.gaming_pc_cost_yearly:
   friendly_name: Gaming PC Cost Yearly
 
+# ---------- AC Cooling (ac_*) — modeled from the Nest, not plug-metered ----------
+sensor.ac_cooling_power:
+  friendly_name: AC Cooling Power
+sensor.ac_cooling_energy:
+  friendly_name: AC Cooling Energy
+sensor.ac_cooling_cost:
+  friendly_name: AC Cooling Cost
+sensor.ac_cooling_cost_rate:
+  friendly_name: AC Cooling Cost Rate
+sensor.ac_cooling_hours:
+  friendly_name: AC Cooling Hours
+sensor.ac_cooling_energy_daily:
+  friendly_name: AC Cooling Energy Daily
+sensor.ac_cooling_energy_weekly:
+  friendly_name: AC Cooling Energy Weekly
+sensor.ac_cooling_energy_monthly:
+  friendly_name: AC Cooling Energy Monthly
+sensor.ac_cooling_energy_yearly:
+  friendly_name: AC Cooling Energy Yearly
+sensor.ac_cooling_cost_daily:
+  friendly_name: AC Cooling Cost Daily
+sensor.ac_cooling_cost_weekly:
+  friendly_name: AC Cooling Cost Weekly
+sensor.ac_cooling_cost_monthly:
+  friendly_name: AC Cooling Cost Monthly
+sensor.ac_cooling_cost_yearly:
+  friendly_name: AC Cooling Cost Yearly
+sensor.ac_cooling_hours_daily:
+  friendly_name: AC Cooling Hours Daily
+sensor.ac_cooling_hours_weekly:
+  friendly_name: AC Cooling Hours Weekly
+sensor.ac_cooling_hours_monthly:
+  friendly_name: AC Cooling Hours Monthly
+sensor.ac_cooling_hours_yearly:
+  friendly_name: AC Cooling Hours Yearly
+sensor.ac_cooling_cost_yesterday:
+  friendly_name: AC Cooling Cost Yesterday
+sensor.ac_cooling_cost_last_month:
+  friendly_name: AC Cooling Cost Last Month
+sensor.ac_cooling_energy_last_month:
+  friendly_name: AC Cooling Energy Last Month
+sensor.ac_cooling_hours_yesterday:
+  friendly_name: AC Cooling Hours Yesterday
+sensor.ac_cooling_hours_last_month:
+  friendly_name: AC Cooling Hours Last Month
+sensor.ac_cost_per_cooling_hour:
+  friendly_name: AC Cooling Cost Per Cooling Hour
+sensor.ac_share_of_house_yesterday:
+  friendly_name: AC Cooling Share Of House
+sensor.ac_implied_watts_yesterday:
+  friendly_name: AC Cooling Implied Watts
+
 # ---------- MacBook + Monitor (macbook_*) ----------
 sensor.macbook_current_consumption:
   friendly_name: MacBook + Monitor Power

--- a/my-apps/home/home-assistant/lovelace-homelab-power.yaml
+++ b/my-apps/home/home-assistant/lovelace-homelab-power.yaml
@@ -610,6 +610,13 @@ views:
               columns: 6
               rows: 1
             color: amber
+          - type: tile
+            entity: sensor.ac_share_of_house_yesterday
+            name: AC share
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
       - type: grid
         column_span: 2
         cards:
@@ -1043,6 +1050,212 @@ views:
               A **session** is the plug drawing more than the threshold (350 W; idle is ~200 W, gaming
               450–600 W) until five quiet minutes pass. **Idle tax** is everything the PC costs outside
               sessions: sitting on at 200 W is about 1.4 kWh a day. Tune the threshold under Settings.
+
+  # ───────────────────────── Cooling: central AC (Nest-modeled) ─────────────────────────
+  - title: Cooling
+    icon: mdi:snowflake
+    path: cooling
+    type: sections
+    max_columns: 4
+    dense_section_placement: true
+    sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: Right now
+            heading_style: title
+            badges:
+              - type: entity
+                entity: climate.hallway_hallway
+                name: Thermostat
+              - type: entity
+                entity: binary_sensor.ac_cooling
+                name: Compressor
+          - type: tile
+            entity: sensor.ac_cooling_power
+            name: Est. draw
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_cost_rate
+            name: Burn rate
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.ac_cooling_hours_daily
+            name: Cooling hours today
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cost_per_cooling_hour
+            name: Cost per cooling hour
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+      - type: grid
+        cards:
+          - type: heading
+            heading: Today
+            heading_style: title
+          - type: tile
+            entity: sensor.ac_cooling_hours_daily
+            name: Hours cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_energy_daily
+            name: kWh cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_cost_daily
+            name: Cost cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+      - type: grid
+        cards:
+          - type: heading
+            heading: This month
+            heading_style: title
+            badges:
+              - type: entity
+                entity: sensor.ac_cooling_hours_last_month
+                name: Hours last month
+              - type: entity
+                entity: sensor.ac_cooling_cost_last_month
+                name: Cost last month
+          - type: tile
+            entity: sensor.ac_cooling_hours_monthly
+            name: Hours cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_energy_monthly
+            name: kWh cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_cost_monthly
+            name: Cost cooling
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+      - type: grid
+        cards:
+          - type: heading
+            heading: Share of the house
+            heading_style: title
+          - type: tile
+            entity: sensor.ac_share_of_house_yesterday
+            name: AC share of bill
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: sensor.ac_cooling_cost_yesterday
+            name: AC cost yesterday
+            grid_options:
+              columns: 6
+              rows: 1
+            color: amber
+          - type: tile
+            entity: sensor.consumers_energy_cost_yesterday
+            name: House cost yesterday
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: tile
+            entity: sensor.consumers_energy_effective_rate
+            name: CE charged (per kWh)
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Cooling vs house, by day
+            heading_style: title
+          - type: statistics-graph
+            title: 
+            chart_type: bar
+            period: day
+            days_to_show: 60
+            stat_types:
+              - change
+            entities:
+              - consumers_energy:grid_kwh
+              - sensor.ac_cooling_energy
+              - sensor.combined_total_energy
+      - type: grid
+        column_span: 2
+        cards:
+          - type: heading
+            heading: Cooling hours, by day
+            heading_style: title
+          - type: statistics-graph
+            title: 
+            chart_type: bar
+            period: day
+            days_to_show: 30
+            stat_types:
+              - change
+            entities:
+              - sensor.ac_cooling_hours
+      - type: grid
+        cards:
+          - type: heading
+            heading: Is the model right?
+            heading_style: title
+          - type: tile
+            entity: sensor.ac_implied_watts_yesterday
+            name: Implied watts (yesterday)
+            grid_options:
+              columns: 6
+              rows: 1
+            color: blue
+          - type: tile
+            entity: input_number.ac_cooling_wattage
+            name: Assumed wattage
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: tile
+            entity: input_number.ac_house_baseline_kwh
+            name: House baseline
+            grid_options:
+              columns: 6
+              rows: 1
+            color: grey
+          - type: markdown
+            content: |
+              The AC has no meter, so cost = **Nest cooling runtime × assumed wattage × live TOU
+              rate**. While the Nest reports `cooling`, the assumed draw is integrated at the live
+              rate. **Calibrate** on hot days with no dryer/oven/EV: nudge *assumed wattage* toward
+              *implied watts*, then commit the value as `initial:` in configuration.yaml.
+              CE data is one day late, so every house comparison is yesterday-vs-yesterday.
 
   # ───────────────────────── Settings: rates and thresholds ─────────────────────────
   - title: Settings

--- a/scripts/pi/qwen-sampling.test.mjs
+++ b/scripts/pi/qwen-sampling.test.mjs
@@ -36,10 +36,16 @@ for (const level of ["low", "medium", "xhigh", "off"]) {
   });
 }
 
-test("other providers and models remain untouched", () => {
-  for (const model of [undefined, { ...context.model, provider: "moonshot" },
+test("other providers and models keep their sampler but still get traced", () => {
+  for (const model of [undefined, { ...context.model, provider: "vanillax-litellm", id: "kimi-k3" },
     { ...context.model, id: "other-model" }]) {
-    assert.equal(handler({ payload: { temperature: 0.2 } }, { model }), undefined);
+    const result = handler({ payload: { temperature: 0.2 } },
+      { ...context, model });
+    assert.equal(result.temperature, 0.2);
+    for (const key of ["top_p", "top_k", "min_p", "presence_penalty", "repetition_penalty"]) {
+      assert.equal(key in result, false);
+    }
+    assert.deepEqual(result.metadata, { session_id: "session-test", trace_name: "pi-agent", tags: ["pi"] });
   }
 });
 

--- a/scripts/pi/qwen-sampling.ts
+++ b/scripts/pi/qwen-sampling.ts
@@ -3,11 +3,9 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 // Pi's thinking toggle changes template kwargs, but does not switch Qwen's sampler.
 export default function (pi: ExtensionAPI) {
   pi.on("before_provider_request", (event, ctx) => {
-    if (ctx.model?.provider !== "vanillax-vllm" || ctx.model.id !== "qwen3.8-27b") return;
     const payload = event.payload as Record<string, unknown>;
-    const kwargs = payload.chat_template_kwargs as Record<string, unknown> | undefined;
-    const off = kwargs?.enable_thinking === false;
-    return {
+    // Tag every provider, not just vLLM: a Ctrl+P swap to K3 must stay in the same Langfuse session.
+    const traced = {
       ...payload,
       metadata: {
         session_id: ctx.sessionManager.getSessionId(),
@@ -15,6 +13,12 @@ export default function (pi: ExtensionAPI) {
         tags: ["pi"],
         ...(payload.metadata as Record<string, unknown> | undefined),
       },
+    };
+    if (ctx.model?.provider !== "vanillax-vllm" || ctx.model.id !== "qwen3.8-27b") return traced;
+    const kwargs = payload.chat_template_kwargs as Record<string, unknown> | undefined;
+    const off = kwargs?.enable_thinking === false;
+    return {
+      ...traced,
       temperature: off ? 0.7 : 1.0,
       top_p: off ? 0.8 : 0.95,
       top_k: 20,


### PR DESCRIPTION
## What broke

Langfuse stopped ingesting traces at **2026-09-10 03:33:26 UTC**. LiteLLM kept exporting and the worker kept receiving — it just dropped every batch:

```
error: Numeric value is out of range for DateTime64: (while reading the value of key start_time)
code: 407
droppedIds: [{project_id: "homelab-ai", trace_id: ...}]
```

Grafana recorded ~134 gateway requests in the following 24h. Langfuse recorded zero of them.

## Root cause

Not Langfuse, not LiteLLM. ClickHouse 26.8 changed a parsing default:

```
input_format_read_datetime_number_as_raw_value: 1 -> 0
```

> From 26.8, an unquoted number for a `DateTime`/`DateTime64` column in the `JSON` and `Values`/`Quoted` paths is a Unix timestamp in seconds, consistent with the `Values` format, `CAST` and `toDateTime64`.

Langfuse sends `start_time` as a microsecond integer. 26.6 read it as raw ticks at the column's scale (correct); 26.8 reads it as seconds, which lands around year 57,000 and overflows `DateTime64(6)`.

Timing confirms it — the ClickHouse `26.6.1.1193 -> 26.8.2.7` bump (#2322) merged at **03:34:41 UTC**, 75 seconds after the last successful trace.

Reproduced against the live server:

| Input | Result |
|---|---|
| `{"t": 1757475206377000}` (µs int, what Langfuse sends) | `Code: 407 DECIMAL_OVERFLOW` |
| same, with `input_format_read_datetime_number_as_raw_value=1` | lands correctly |
| same, with `compatibility='26.6'` | lands correctly |

## The fix

A `users.d` settings profile restoring the one setting. Two deliberate choices:

- **Kept 26.8 instead of reverting to 26.6** — a ClickHouse downgrade over an existing data directory is the riskier move, and this is a single setting to drop once Langfuse quotes the value.
- **One setting, not `compatibility='26.6'`** — `compatibility` reverts every default changed since that release; this reverts only the one that broke.
- **subPath mount** — the image entrypoint writes `default-user.xml` into `users.d/` at startup. A directory mount would take cluster auth with it.

## Also: K3 handoff was invisible in Langfuse

`scripts/pi/qwen-sampling.ts` gated the whole handler on `provider === "vanillax-vllm"`, so only qwen got `session_id`/`trace_name`/`tags`. A `pi-withk3` Ctrl+P swap to kimi-k3 landed as an orphan trace with no session — the two halves of one agent run could not be correlated.

The metadata block now applies to every provider; only the Qwen sampler overrides stay gated. 6/6 tests pass.

## Not fixed here

- The ~36h of dropped traces are gone — Langfuse drops on insert failure rather than queueing.
- kimi-k3 reports `output: 0` with reasoning tokens counted separately, so its output cost is under-reported. That is LiteLLM's usage mapping for Moonshot.

## Verifying after merge

```bash
kubectl -n langfuse logs deploy/langfuse-worker --tail=50 | grep -i "out of range"   # expect nothing
kubectl -n langfuse exec deploy/langfuse-clickhouse -- \
  clickhouse-client -d langfuse --query "SELECT max(start_time) FROM events_full"    # expect now-ish
```

In the UI, set Env to `homelab` — Home defaults to `default`, which is why it reads empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rf6evmAgBFZ2Wifyp22LDh