### PR TITLE
feat(langfuse): alert on trace loss instead of finding it days later

### DIFF
--- a/.github/workflows/telemetry-rule-tests.yml
+++ b/.github/workflows/telemetry-rule-tests.yml
@@ -5,6 +5,8 @@ on:
       - 'infrastructure/controllers/opentelemetry-operator-observability/**'
       - 'monitoring/prometheus-stack/kopiur-alerts.yaml'
       - 'monitoring/prometheus-stack/tests/kopiur-alerts.test.yaml'
+      - 'monitoring/prometheus-stack/langfuse-alerts.yaml'
+      - 'monitoring/prometheus-stack/tests/langfuse-alerts.test.yaml'
       - 'scripts/prepare-telemetry-rule-tests.py'
       - 'scripts/tests/test_prepare_telemetry_rule_tests.py'
       - '.github/workflows/telemetry-rule-tests.yml'
@@ -14,6 +16,8 @@ on:
       - 'infrastructure/controllers/opentelemetry-operator-observability/**'
       - 'monitoring/prometheus-stack/kopiur-alerts.yaml'
       - 'monitoring/prometheus-stack/tests/kopiur-alerts.test.yaml'
+      - 'monitoring/prometheus-stack/langfuse-alerts.yaml'
+      - 'monitoring/prometheus-stack/tests/langfuse-alerts.test.yaml'
       - 'scripts/prepare-telemetry-rule-tests.py'
       - 'scripts/tests/test_prepare_telemetry_rule_tests.py'
       - '.github/workflows/telemetry-rule-tests.yml'
@@ -34,6 +38,8 @@ jobs:
         run: python scripts/prepare-telemetry-rule-tests.py /tmp/otel-rule-tests
       - name: Prepare backup-rule tests
         run: python scripts/prepare-telemetry-rule-tests.py /tmp/otel-rule-tests --suite kopiur
+      - name: Prepare Langfuse-rule tests
+        run: python scripts/prepare-telemetry-rule-tests.py /tmp/otel-rule-tests --suite langfuse
       - name: Check rules and evaluate synthetic time series
         run: |
           set -euo pipefail
@@ -41,3 +47,5 @@ jobs:
           docker run --rm --entrypoint promtool -v /tmp/otel-rule-tests:/work:ro -w /work prom/prometheus:v3.5.0 test rules collector-alerts.test.yaml
           docker run --rm --entrypoint promtool -v /tmp/otel-rule-tests:/work:ro -w /work prom/prometheus:v3.5.0 check rules kopiur.rules.yaml
           docker run --rm --entrypoint promtool -v /tmp/otel-rule-tests:/work:ro -w /work prom/prometheus:v3.5.0 test rules kopiur-alerts.test.yaml
+          docker run --rm --entrypoint promtool -v /tmp/otel-rule-tests:/work:ro -w /work prom/prometheus:v3.5.0 check rules langfuse.rules.yaml
+          docker run --rm --entrypoint promtool -v /tmp/otel-rule-tests:/work:ro -w /work prom/prometheus:v3.5.0 test rules langfuse-alerts.test.yaml

--- a/monitoring/prometheus-stack/kustomization.yaml
+++ b/monitoring/prometheus-stack/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - custom-servicemonitors.yaml
   - longhorn-alerts.yaml # volume/node health (was longhorn-backup-alerts.yaml; dead backup-target alerts dropped 2026-07-06)
   - kopiur-alerts.yaml # kopiur backup staleness/failure alerts (the follow-up promised when volsync-alerts were retired 2026-06-27)
+  - langfuse-alerts.yaml # LLM trace loss: ClickHouse insert failures + busy-gateway/no-ingest cross-check
   - argocd-sync-alerts.yaml # ArgoCD control-plane + app-state alerts (stale-sync incident 2026-05-29)
   - admission-webhook-alerts.yaml # API-server-side webhook reachability; pod health cannot prove it
   - dcgm-exporter.yaml # DCGM GPU monitoring

--- a/monitoring/prometheus-stack/langfuse-alerts.yaml
+++ b/monitoring/prometheus-stack/langfuse-alerts.yaml
@@ -1,0 +1,72 @@
+# Trace-loss detection from langfuse-clickhouse:9363 (endpoint enabled in my-apps/ai/langfuse/clickhouse-prometheus.xml).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: langfuse-alerts
+  namespace: prometheus-stack
+  labels:
+    app.kubernetes.io/name: kube-prometheus-stack
+    app.kubernetes.io/instance: kube-prometheus-stack
+    app.kubernetes.io/managed-by: Helm
+    prometheus: kube-prometheus-stack-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: langfuse.ingestion
+      rules:
+        - alert: LangfuseClickHouseInsertsFailing
+          # The worker drops the batch on insert failure — every failure here is telemetry destroyed, not retried.
+          expr: increase(ClickHouseProfileEvents_FailedInsertQuery{job="langfuse-clickhouse"}[15m]) > 0
+          for: 15m
+          labels:
+            severity: critical
+            component: langfuse
+            category: observability
+          annotations:
+            summary: "Langfuse ClickHouse is rejecting inserts"
+            description: |
+              {{ $value }} failed INSERT(s) in 15m. langfuse-worker drops the
+              whole batch on failure, so traces are being destroyed, not queued.
+
+              Actions:
+              1. kubectl -n langfuse logs deploy/langfuse-worker --tail=50 | grep -i error
+              2. A ClickHouse version bump is the usual cause — a changed parsing
+                 default rejects what Langfuse has always sent. Check the release:
+                 SELECT version, c.1, c.4 FROM system.settings_changes
+                   ARRAY JOIN changes AS c WHERE version = '<new version>'
+              3. Restore the old behaviour in my-apps/ai/langfuse/clickhouse-settings.xml
+        - alert: LangfuseIngestionStalled
+          # Cross-check: the gateway is busy, so traces should be landing whatever the cause of the gap.
+          expr: >-
+            sum(increase(litellm_proxy_total_requests_metric_total[1h])) > 10
+            and on()
+            sum(increase(ClickHouseProfileEvents_InsertedRows{job="langfuse-clickhouse"}[1h])) == 0
+          for: 15m
+          labels:
+            severity: warning
+            component: langfuse
+            category: observability
+          annotations:
+            summary: "LiteLLM is serving requests but Langfuse ingested nothing for an hour"
+            description: |
+              The gateway handled {{ $value }} requests in the last hour while
+              ClickHouse inserted no rows. Traces for that window are lost.
+
+              Actions:
+              1. kubectl -n langfuse get pods
+              2. kubectl -n langfuse logs deploy/langfuse-worker --tail=50
+              3. Confirm the blob store is reachable — event upload precedes the insert:
+                 kubectl -n langfuse logs job/langfuse-init-bucket
+        - alert: LangfuseClickHouseMetricsDown
+          expr: up{job="langfuse-clickhouse"} == 0 or absent(up{job="langfuse-clickhouse"})
+          for: 15m
+          labels:
+            severity: warning
+            component: langfuse
+            category: observability
+          annotations:
+            summary: "Langfuse ClickHouse metrics endpoint is down"
+            description: |
+              Prometheus cannot scrape langfuse-clickhouse. Either ClickHouse is
+              down or the prometheus config/Service/ServiceMonitor changed. Both
+              trace-loss alerts above are blind while this fires.

--- a/monitoring/prometheus-stack/tests/langfuse-alerts.test.yaml
+++ b/monitoring/prometheus-stack/tests/langfuse-alerts.test.yaml
@@ -1,0 +1,108 @@
+rule_files:
+  - langfuse.rules.yaml
+evaluation_interval: 1m
+tests:
+  - name: a failed-insert storm fires once it has persisted, not on a single rejection
+    interval: 1m
+    input_series:
+      - series: ClickHouseProfileEvents_FailedInsertQuery{job="langfuse-clickhouse",instance="10.244.0.5:9363"}
+        values: '0+0x10 10+12x40'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: LangfuseClickHouseInsertsFailing
+        exp_alerts: []
+      - eval_time: 45m
+        alertname: LangfuseClickHouseInsertsFailing
+        exp_alerts:
+          - exp_labels:
+              job: langfuse-clickhouse
+              instance: 10.244.0.5:9363
+              severity: critical
+              component: langfuse
+              category: observability
+            exp_annotations:
+              summary: 'Langfuse ClickHouse is rejecting inserts'
+              description: |
+                180 failed INSERT(s) in 15m. langfuse-worker drops the
+                whole batch on failure, so traces are being destroyed, not queued.
+
+                Actions:
+                1. kubectl -n langfuse logs deploy/langfuse-worker --tail=50 | grep -i error
+                2. A ClickHouse version bump is the usual cause — a changed parsing
+                   default rejects what Langfuse has always sent. Check the release:
+                   SELECT version, c.1, c.4 FROM system.settings_changes
+                     ARRAY JOIN changes AS c WHERE version = '<new version>'
+                3. Restore the old behaviour in my-apps/ai/langfuse/clickhouse-settings.xml
+  - name: a busy gateway with no inserts is the silent-loss case
+    interval: 1m
+    input_series:
+      - series: litellm_proxy_total_requests_metric_total{requested_model="qwen3.8-27b",job="litellm"}
+        values: '0+2x120'
+      - series: ClickHouseProfileEvents_InsertedRows{job="langfuse-clickhouse",instance="10.244.0.5:9363"}
+        values: '5000+0x120'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: LangfuseIngestionStalled
+        exp_alerts: []
+      - eval_time: 100m
+        alertname: LangfuseIngestionStalled
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              component: langfuse
+              category: observability
+            exp_annotations:
+              summary: 'LiteLLM is serving requests but Langfuse ingested nothing for an hour'
+              description: |
+                The gateway handled 120 requests in the last hour while
+                ClickHouse inserted no rows. Traces for that window are lost.
+
+                Actions:
+                1. kubectl -n langfuse get pods
+                2. kubectl -n langfuse logs deploy/langfuse-worker --tail=50
+                3. Confirm the blob store is reachable — event upload precedes the insert:
+                   kubectl -n langfuse logs job/langfuse-init-bucket
+  - name: healthy ingestion alongside a busy gateway stays quiet
+    interval: 1m
+    input_series:
+      - series: litellm_proxy_total_requests_metric_total{requested_model="qwen3.8-27b",job="litellm"}
+        values: '0+2x120'
+      - series: ClickHouseProfileEvents_InsertedRows{job="langfuse-clickhouse",instance="10.244.0.5:9363"}
+        values: '5000+40x120'
+      - series: ClickHouseProfileEvents_FailedInsertQuery{job="langfuse-clickhouse",instance="10.244.0.5:9363"}
+        values: '0+0x120'
+      - series: up{job="langfuse-clickhouse",instance="10.244.0.5:9363"}
+        values: '1+0x120'
+    alert_rule_test:
+      - eval_time: 100m
+        alertname: LangfuseIngestionStalled
+        exp_alerts: []
+      - eval_time: 100m
+        alertname: LangfuseClickHouseInsertsFailing
+        exp_alerts: []
+      - eval_time: 100m
+        alertname: LangfuseClickHouseMetricsDown
+        exp_alerts: []
+  - name: a missing scrape target fires so the loss alerts are not silently blind
+    interval: 1m
+    input_series:
+      - series: up{job="litellm",instance="10.244.0.9:4000"}
+        values: '1+0x40'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: LangfuseClickHouseMetricsDown
+        exp_alerts: []
+      - eval_time: 30m
+        alertname: LangfuseClickHouseMetricsDown
+        exp_alerts:
+          - exp_labels:
+              job: langfuse-clickhouse
+              severity: warning
+              component: langfuse
+              category: observability
+            exp_annotations:
+              summary: 'Langfuse ClickHouse metrics endpoint is down'
+              description: |
+                Prometheus cannot scrape langfuse-clickhouse. Either ClickHouse is
+                down or the prometheus config/Service/ServiceMonitor changed. Both
+                trace-loss alerts above are blind while this fires.

--- a/my-apps/ai/langfuse/clickhouse-prometheus.xml
+++ b/my-apps/ai/langfuse/clickhouse-prometheus.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+  <!-- Off by default in the image; without it a failed-insert storm (dropped traces) is invisible to Prometheus. -->
+  <prometheus>
+    <endpoint>/metrics</endpoint>
+    <port>9363</port>
+    <metrics>true</metrics>
+    <events>true</events>
+    <asynchronous_metrics>true</asynchronous_metrics>
+  </prometheus>
+</clickhouse>

--- a/my-apps/ai/langfuse/clickhouse.yaml
+++ b/my-apps/ai/langfuse/clickhouse.yaml
@@ -40,6 +40,8 @@ spec:
           containerPort: 8123
         - name: native
           containerPort: 9000
+        - name: metrics
+          containerPort: 9363
         env:
         - name: CLICKHOUSE_DB
           value: langfuse
@@ -65,6 +67,10 @@ spec:
         - name: settings
           mountPath: /etc/clickhouse-server/users.d/langfuse-settings.xml
           subPath: clickhouse-settings.xml
+          readOnly: true
+        - name: settings
+          mountPath: /etc/clickhouse-server/config.d/langfuse-prometheus.xml
+          subPath: clickhouse-prometheus.xml
           readOnly: true
         startupProbe:
           httpGet:
@@ -121,6 +127,8 @@ kind: Service
 metadata:
   name: langfuse-clickhouse
   namespace: langfuse
+  labels:
+    app: langfuse-clickhouse
   annotations:
     argocd.argoproj.io/sync-wave: '0'
 spec:
@@ -133,3 +141,6 @@ spec:
   - name: native
     port: 9000
     targetPort: native
+  - name: metrics
+    port: 9363
+    targetPort: metrics

--- a/my-apps/ai/langfuse/kustomization.yaml
+++ b/my-apps/ai/langfuse/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - redis.yaml
 - httproute.yaml
 - s3-route.yaml
+- servicemonitor.yaml
 - bucket-init-job.yaml
 - vpa.yaml
 - kopiur/langfuse-postgres-data.yaml
@@ -30,6 +31,7 @@ configMapGenerator:
 - name: langfuse-clickhouse-settings
   files:
   - clickhouse-settings.xml
+  - clickhouse-prometheus.xml
 patches:
 - target:
     kind: Deployment

--- a/my-apps/ai/langfuse/servicemonitor.yaml
+++ b/my-apps/ai/langfuse/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: langfuse-clickhouse
+  namespace: langfuse
+spec:
+  selector:
+    matchLabels:
+      app: langfuse-clickhouse
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/scripts/prepare-telemetry-rule-tests.py
+++ b/scripts/prepare-telemetry-rule-tests.py
@@ -26,7 +26,7 @@ def prepare_tests(source_dir: Path, output_dir: Path, suite: str = "collector") 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("output_dir", type=Path, help="Directory for promtool input files")
-    parser.add_argument("--suite", choices=("collector", "kopiur"), default="collector")
+    parser.add_argument("--suite", choices=("collector", "kopiur", "langfuse"), default="collector")
     args = parser.parse_args()
     try:
         source_dir = SOURCE_DIR if args.suite == "collector" else REPO_ROOT / "monitoring/prometheus-stack"


### PR DESCRIPTION
Follow-up to #2358. That PR fixed the ClickHouse 26.8 parsing break; this one makes sure the next one gets noticed in minutes rather than days.

## The gap

The outage ran 36 hours with zero alerts. Nothing watched the Langfuse data layer at all — ClickHouse ships its Prometheus endpoint **disabled**, so a continuous failed-insert storm was invisible to monitoring even while it filled the worker log.

## What this adds

**Metrics** — enable the ClickHouse Prometheus endpoint on 9363 (`config.d`), expose it on the Service, scrape it with an app-owned ServiceMonitor.

**Three alerts** (`monitoring/prometheus-stack/langfuse-alerts.yaml`):

| Alert | Expression | Catches |
|---|---|---|
| `LangfuseClickHouseInsertsFailing` | failed INSERTs > 0 over 15m, `for: 15m` | This outage, ~30 min in. The worker drops the batch rather than retrying, so each failure is telemetry destroyed. |
| `LangfuseIngestionStalled` | LiteLLM served > 10 requests in 1h **and** ClickHouse inserted 0 rows | Any cause — wedged worker, unreachable blob store, expired credentials. Doesn't depend on knowing the failure mode. |
| `LangfuseClickHouseMetricsDown` | `up == 0 or absent(up)` | The scrape target vanishing, so the two above can't go blind. |

**Tests** — 4 promtool cases following the kopiur suite, including a negative case that keeps healthy ingestion quiet. `--suite langfuse` added to the prep script and the CI workflow alongside collector and kopiur.

## Verification

Booted `clickhouse-server:26.8.2.7` in a throwaway container with both config files mounted:

- server starts clean (a malformed `config.d` file stops ClickHouse booting entirely, unlike `users.d` which only fails the reload — worth proving before this reaches the cluster)
- `input_format_read_datetime_number_as_raw_value = 1` applies to the langfuse user's profile
- a microsecond-integer insert lands with the correct timestamp
- `/metrics` serves `ClickHouseProfileEvents_FailedInsertQuery` and `ClickHouseProfileEvents_InsertedRows` — the exact names the rules query

Also confirmed `FailedInsertQuery` is a real event in this build by forcing a bad insert (`system.events` hides zero-valued events, so its absence proved nothing).

```
promtool check rules langfuse.rules.yaml   SUCCESS: 3 rules found
promtool test rules langfuse-alerts.test.yaml   SUCCESS
```

Existing prep-script unittests still pass; both kustomizations render.

## Separately verified from #2358

Pushed a tagged kimi-k3 request through LiteLLM: it landed in Langfuse with `session_id`, `trace_name: pi-agent` and `tags: ['pi']`. **The K3 handoff fix works end to end**, not just in unit tests.

That also corrects something I got wrong earlier — K3's cost is **not** under-reported. Usage came back `input 0, input_cached 92, output 3, reasoning 5` at `$0.0001476`, which is exactly 8 output tokens at \$15/M plus 92 cached at \$0.30/M. Reasoning tokens are billed as output; only the display column splits them out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rf6evmAgBFZ2Wifyp22LDh