### PR TITLE
Label the House-view AC tile as bill share

### DIFF
--- a/docs/domains/power/metering.md
+++ b/docs/domains/power/metering.md
@@ -305,6 +305,8 @@ median implied value, then commit it as `initial:` in `configuration.yaml`
 `ac_cooling_cost_last_month` + `combined_*` + baseline should land within ~10–15%
 of the CE bill; the wattage is an estimate (±20 % on a variable-speed unit).
 CE data is one day late, so every house comparison is yesterday-vs-yesterday.
+Because the 3 min `delay_off` over-counts runtime on short cycles, implied watts
+reads low on those days — calibrate from long, sustained cooling days.
 
 Dashboards: the **Cooling** view of the Homelab Power dashboard and the AC tile
 on its House view; `sensor.ac_*` / `binary_sensor.ac_cooling` are in the

--- a/my-apps/home/home-assistant/lovelace-homelab-power.yaml
+++ b/my-apps/home/home-assistant/lovelace-homelab-power.yaml
@@ -612,7 +612,7 @@ views:
             color: amber
           - type: tile
             entity: sensor.ac_share_of_house_yesterday
-            name: AC share
+            name: AC bill share
             grid_options:
               columns: 6
               rows: 1


### PR DESCRIPTION
Follow-up to the AC cooling work (already on main via #2358's branch ride-along + 17cea95):

- House view tile \`AC share\` → \`AC bill share\`: it displays **cost** share (AC USD ÷ CE USD) while the two adjacent tiles show **kWh** share — the label now matches the Cooling view's wording and the quantity shown.
- \`docs/domains/power/metering.md\`: one line in the calibration paragraph noting the 3 min \`delay_off\` over-counts runtime on short cooling cycles, so implied watts reads low on those days — calibrate from long, sustained cooling days.

Two-line label + one doc line. No config or manifest changes.