### PR TITLE
fix(vllm): align runtime tunables with club-3090 2x3090 reference

### DIFF
--- a/docs/domains/ai-gpu/pi-agent-local-dev.md
+++ b/docs/domains/ai-gpu/pi-agent-local-dev.md
@@ -161,8 +161,8 @@ pool, but parallel agent fanout competes for the same capacity. See the
 Pi's template mapping switches reasoning but does not switch sampling.
 The small repo-owned
 [Qwen sampler extension](https://github.com/mitchross/talos-argocd-proxmox/blob/main/scripts/pi/qwen-sampling.ts)
-uses Pi's `before_provider_request` hook to select Qwen's six recommended
-sampling values after serialization. It applies only to
+uses Pi's `before_provider_request` hook to select the deployment's six
+mode-specific sampling values after serialization. It applies only to
 `vanillax-vllm/qwen3.8-27b`, leaves messages/tools/template mapping intact, and
 sets mode-specific values even if a stale client temperature was selected.
 
@@ -174,9 +174,13 @@ cp scripts/pi/qwen-sampling.ts ~/.pi/agent/extensions/qwen-sampling.ts
 ```
 
 Restart Pi or use `/reload`. Thinking requests use temperature 1.0, top-p 0.95,
-top-k 20, min-p 0, presence penalty 0, repetition penalty 1. Off requests use
-0.7, 0.8, 20, 0, 1.5, 1 respectively. The server-wide thinking sampler stays
-unchanged. Without this extension, Pi off still disables reasoning, but needs
+top-k 20, min-p 0, presence penalty 0, repetition penalty **1.05**. Off requests
+use 0.7, 0.8, 20, 0, 1.5, **1.0** respectively. The thinking penalty is a local,
+community-reported mitigation candidate, not Qwen's official default or a
+proven fix. It matches the server and WebUI policy; see the runbook's caveats.
+After pulling a sampler update, repeat the copy above and `/reload`: Git/Argo
+cannot update an already installed workstation copy. Without this extension,
+Pi off still disables reasoning, but needs
 another per-request sampler override to match Qwen's recommendation.
 [Pi request hook](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md#before_provider_request),
 [canonical server policy and API examples](https://github.com/mitchross/talos-argocd-proxmox/blob/main/my-apps/ai/vllm/README.md#explicit-reasoning-and-sampling).

--- a/my-apps/ai/open-webui/qwen-no-think-filter.py
+++ b/my-apps/ai/open-webui/qwen-no-think-filter.py
@@ -35,7 +35,8 @@ class Filter:
 
         sampler = dict(temperature=1.0 if enabled else 0.7,
                        top_p=0.95 if enabled else 0.8, top_k=20, min_p=0.0,
-                       presence_penalty=0.0 if enabled else 1.5, repetition_penalty=1.0)
+                       presence_penalty=0.0 if enabled else 1.5,
+                       repetition_penalty=1.05 if enabled else 1.0)
         for target in (body, extra_body):
             # Block WebUI's later fill-if-absent from restoring a stale effort.
             target["reasoning_effort"] = kwargs.get("reasoning_effort")

--- a/my-apps/ai/vllm/README.md
+++ b/my-apps/ai/vllm/README.md
@@ -1,9 +1,10 @@
 # vLLM — official Qwen3.8-27B FP8 on two RTX 3090s
 
-**Live production backend, verified 2026-09-06.** Official FP8 is loaded on
-both cards. The [capacity and client audit](../../../docs/domains/ai-gpu/3090-llm-optimization.md)
-records measured KV capacity and request checks. The medium fallback in this
-PR takes effect after merge and Argo reconciliation; live probes sent medium explicitly.
+**Git-declared backend and operating policy.** The
+[2026-09-06 capacity and client audit](../../../docs/domains/ai-gpu/3090-llm-optimization.md)
+records measurements of the earlier v0.28.0 deployment, with medium sent
+explicitly. It is not a benchmark of the v0.29.0 tunables below. Confirm the
+running arguments and repeat acceptance after merge and Argo reconciliation.
 
 | Setting | Value |
 |---|---|
@@ -17,7 +18,7 @@ PR takes effect after merge and Argo reconciliation; live probes sent medium exp
 | Attention | FlashInfer explicitly selected for Ampere FP8 KV |
 | KV / recurrent state | `fp8_e4m3` / float16 |
 | GPU utilization budget | 0.92 per GPU |
-| Prefill | chunked, 8,192 tokens per batch |
+| Prefill | 8,192-token aggregate budget; at most 4,096 prefill tokens per request per step |
 | Vision | native encoder; one image per request, video disabled |
 | Reasoning | on, explicit `medium` default; `low` and `xhigh` per request |
 | Speculation | **off**; no MTP or external drafter |
@@ -109,6 +110,33 @@ client/default behavior; it does not claim a universal cure for thinking loops.
 `xhigh` and cautions that lower effort can cause more retries in agent tasks.
 [Official FP8 history](https://huggingface.co/Qwen/Qwen3.8-27B-FP8/commits/main)
 
+## Tuning policy and evidence limits
+
+`--max-num-batched-tokens 8192` is the aggregate scheduling budget;
+`--long-prefill-token-threshold 4096` caps the prefill chunk of each request.
+That cap is active even at two sequence slots. A single long prompt therefore
+does not receive 8,192-token chunks. Alignment, available tokens, vision and
+other scheduler constraints can reduce chunks further. This is an intentional
+8192/4096 profile, not a claim of four times fewer steps or a measured speedup.
+[Versioned scheduler](https://github.com/vllm-project/vllm/blob/v0.29.0/vllm/v1/core/sched/scheduler.py).
+
+`align` and `prefix-match-unit=16` explicitly pin cache behavior; the latter is
+matching granularity, not a recurrent-state checkpoint every 16 tokens.
+Retain `expandable_segments:True` without a split-size override. Allocator
+fragmentation tuning needs measurements, not just a copied reference setting.
+[PyTorch allocator guidance](https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf).
+
+Thinking `repetition_penalty=1.05` is a **local mitigation candidate**, not the
+official Qwen default of 1.0 or an established fix. The author of
+[Qwen3.8 issue 216](https://github.com/QwenLM/Qwen3.8/issues/216) corrected earlier
+claims: low/medium are not universally immune, and the reported narrow penalty
+band and extraction scores do not establish coding/tool/vision quality.
+The suspected EOS-inside-thinking mechanism is not a confirmed root cause.
+Keep medium as the default and validate all supported modes, not just xhigh.
+The server value is a fallback, not an enforced floor: explicit client values
+win. WebUI and the Pi extension therefore use 1.05 for every thinking effort
+and 1.0 for off. Update server, clients, tests and docs together.
+
 ## Reasoning acceptance checks
 
 Before live tests, inspect the **running** Deployment args and request payloads.
@@ -158,13 +186,21 @@ legacy `qwen_non_thinking_default` function ID now updates in place to the
 reasoning policy; Pi must retain its explicit mapping and medium startup level.
 Generic `high` must become medium in WebUI or be unavailable in Pi. Clear stale
 per-chat presets that explicitly request xhigh. Stored user/client settings
-outside Git still require payload inspection after rollout.
+outside Git still require payload inspection after rollout. Verify the WebUI
+PostSync function-loader job succeeds; it loads the updated filter into WebUI.
+Refresh an installed Pi extension using the copy command and `/reload` in the
+Pi guide. In both clients, inspect the outgoing sampler as well as kwargs:
+1.05 for default/low/medium/xhigh, 1.0 for off, including through LiteLLM.
+A successful request alone does not show which penalty reached vLLM.
 
 The offline tests check policy resolution and preservation of tool/image/history
 payloads, not model quality. Actual tool/vision/multi-turn generation must pass
 after merge. Treat output truncation (`finish_reason=length`) as inconclusive,
-not a successful reasoning check. Stop on loops, malformed tool output or lost
-history and inspect payloads before changing runtime flags. Roll back this
+not a successful reasoning check. Repeat representative coding, tool and image
+requests with a sufficient output budget. Flag a completed empty final answer
+with no tool calls; empty content accompanying a valid tool call is normal.
+Stop on loops, malformed tool output or lost history and inspect payloads
+before changing runtime flags. Roll back this
 reasoning-policy commit through Git if needed; it does not alter backend sizing.
 
 ## Reproducible staging
@@ -235,8 +271,13 @@ that near-ceiling vision is verified. Run the existing
 prefill/decode, cache preemptions, GPU peaks, and a sustained multi-turn soak.
 Test a context ladder before claiming 262K usability. Prefix caching makes
 warm prompts cheaper; unique-prefix tests are needed for genuine prefill.
-The 8,192-token prefill batch matches the club-3090 2x3090 reference (their
-A/B found it concurrency-neutral vs 2,048 at max-num-seqs 2).
+Compare the prior 2,048-token budget against the 8,192 aggregate / 4,096
+per-request profile using the same prompts, output budgets and sampler. Test
+one fresh long prompt, two fresh prompts, and a long prefill arriving during
+decode. Record time to first token, inter-token latency, preemptions, available
+KV capacity and peak memory. Do not reuse the September 6 pool measurements
+as proof of capacity after changing prefill workspace. Prefix-hit counters
+alone do not establish correctness or a latency improvement.
 
 Stop on staging/hash failure, insufficient KV pool, OOM/Xid, broken tool or
 vision output, or repeated preemptions. Do not enable MTP to rescue a failing
@@ -245,7 +286,11 @@ routing configuration; they do not establish new runtime performance.
 
 ## Rollback
 
-Revert the FP8 cutover commit through Git, preserving the prior hardware
+For this tuning policy, revert its commits through Git and restore the previous
+Pi extension copy, then reload Pi. That retains vLLM and the current model;
+do not revert the entire FP8 cutover merely to undo sampler/prefill tuning.
+
+For a full backend rollback, revert the FP8 cutover commit through Git, preserving the prior hardware
 expansion. That restores llama.cpp's replica, selector Service, both-hostname
 HTTPRoute and vLLM's old alias/zero replicas. Argo releases vLLM's two cards
 before the retained one-card GGUF profile can run. Verify the model ID and

--- a/my-apps/ai/vllm/README.md
+++ b/my-apps/ai/vllm/README.md
@@ -9,7 +9,7 @@ PR takes effect after merge and Argo reconciliation; live probes sent medium exp
 |---|---|
 | Model | Official `Qwen/Qwen3.8-27B-FP8`, no Unsloth/GGUF conversion |
 | Revision | `017b9c7af6b5689d5dd426a76e0bc077eb5ca20a` |
-| Runtime | stock vLLM `v0.28.0`, existing immutable image digest |
+| Runtime | stock vLLM `v0.29.0`, existing immutable image digest |
 | GPUs | 2 × RTX 3090, tensor parallel 2, multiprocessing executor |
 | Interconnect | no custom all-reduce; NCCL P2P disabled; shared host transport |
 | Context ceiling | 262,144 tokens, native model limit, no RoPE extrapolation |
@@ -17,7 +17,7 @@ PR takes effect after merge and Argo reconciliation; live probes sent medium exp
 | Attention | FlashInfer explicitly selected for Ampere FP8 KV |
 | KV / recurrent state | `fp8_e4m3` / float16 |
 | GPU utilization budget | 0.92 per GPU |
-| Prefill | chunked, 2,048 tokens per batch |
+| Prefill | chunked, 8,192 tokens per batch |
 | Vision | native encoder; one image per request, video disabled |
 | Reasoning | on, explicit `medium` default; `low` and `xhigh` per request |
 | Speculation | **off**; no MTP or external drafter |
@@ -91,7 +91,7 @@ hard reasoning-token budget or a substitute for `enable_thinking=false`.
 | `top_k` | 20 | 20 |
 | `min_p` | 0.0 | 0.0 |
 | `presence_penalty` | 0.0 | 1.5 |
-| `repetition_penalty` | 1.0 | 1.0 |
+| `repetition_penalty` | 1.05 | 1.0 |
 
 Changing the thinking flag alone does not switch vLLM's sampler. Direct
 clients must send all six non-thinking values when opting out. Open WebUI's
@@ -235,7 +235,8 @@ that near-ceiling vision is verified. Run the existing
 prefill/decode, cache preemptions, GPU peaks, and a sustained multi-turn soak.
 Test a context ladder before claiming 262K usability. Prefix caching makes
 warm prompts cheaper; unique-prefix tests are needed for genuine prefill.
-The 2,048-token prefill batch favors interactive latency over peak bulk prefill.
+The 8,192-token prefill batch matches the club-3090 2x3090 reference (their
+A/B found it concurrency-neutral vs 2,048 at max-num-seqs 2).
 
 Stop on staging/hash failure, insufficient KV pool, OOM/Xid, broken tool or
 vision output, or repeated preemptions. Do not enable MTP to rescue a failing

--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -102,12 +102,25 @@ spec:
             - --mamba-ssm-cache-dtype
             - float16
             - --enable-prefix-caching
+            # v0.29.0 already defaults to align with prefix caching on; stated
+            # explicitly to match the club-3090 reference and pin the behavior.
+            - --mamba-cache-mode
+            - align
+            - --prefix-match-unit
+            - "16"
             - --enable-chunked-prefill
+            # 8192 matches the club-3090 2x3090 reference; their A/B found it
+            # concurrency-neutral vs 2048 at max-num-seqs 2, ~4x prefill steps.
             - --max-num-batched-tokens
-            - "2048"
+            - "8192"
+            - --long-prefill-token-threshold
+            - "4096"
             # Speculation stays off until the GDN long-session faults are fixed.
+            # repetition_penalty 1.05: community-measured stable band (1.05-1.10)
+            # for the EOS-mid-think empty-answer failure; 1.0 sits at the U-curve
+            # center where ~17-38% of xhigh calls return empty content (QwenLM/Qwen3.8#216).
             - --override-generation-config
-            - '{"temperature":1.0,"top_p":0.95,"top_k":20,"min_p":0.0,"presence_penalty":0.0,"repetition_penalty":1.0}'
+            - '{"temperature":1.0,"top_p":0.95,"top_k":20,"min_p":0.0,"presence_penalty":0.0,"repetition_penalty":1.05}'
             - --enable-force-include-usage
             - --host
             - 0.0.0.0
@@ -131,7 +144,7 @@ spec:
             - name: OMP_NUM_THREADS
               value: "1"
             - name: PYTORCH_CUDA_ALLOC_CONF
-              value: expandable_segments:True
+              value: expandable_segments:True,max_split_size_mb:512
           ports:
             - name: http
               containerPort: 8000

--- a/my-apps/ai/vllm/deployment.yaml
+++ b/my-apps/ai/vllm/deployment.yaml
@@ -109,16 +109,17 @@ spec:
             - --prefix-match-unit
             - "16"
             - --enable-chunked-prefill
-            # 8192 matches the club-3090 2x3090 reference; their A/B found it
-            # concurrency-neutral vs 2048 at max-num-seqs 2, ~4x prefill steps.
+            # Aggregate scheduling budget: 8192 tokens across up to two requests.
+            # The 4096 threshold below caps each request's prefill chunk; it is
+            # active even with max-num-seqs=2. Benchmark latency and KV headroom.
             - --max-num-batched-tokens
             - "8192"
             - --long-prefill-token-threshold
             - "4096"
             # Speculation stays off until the GDN long-session faults are fixed.
-            # repetition_penalty 1.05: community-measured stable band (1.05-1.10)
-            # for the EOS-mid-think empty-answer failure; 1.0 sits at the U-curve
-            # center where ~17-38% of xhigh calls return empty content (QwenLM/Qwen3.8#216).
+            # Local thinking policy: community-reported mitigation candidate,
+            # not an upstream default or proven fix (QwenLM/Qwen3.8#216).
+            # Keep WebUI/Pi thinking=1.05 and off=1.0 in sync with this default.
             - --override-generation-config
             - '{"temperature":1.0,"top_p":0.95,"top_k":20,"min_p":0.0,"presence_penalty":0.0,"repetition_penalty":1.05}'
             - --enable-force-include-usage
@@ -144,7 +145,7 @@ spec:
             - name: OMP_NUM_THREADS
               value: "1"
             - name: PYTORCH_CUDA_ALLOC_CONF
-              value: expandable_segments:True,max_split_size_mb:512
+              value: expandable_segments:True
           ports:
             - name: http
               containerPort: 8000

--- a/scripts/pi/qwen-sampling.test.mjs
+++ b/scripts/pi/qwen-sampling.test.mjs
@@ -22,19 +22,39 @@ for (const level of ["low", "medium", "xhigh", "off"]) {
       tools: [{ type: "function", function: { name: "lookup" } }],
       max_tokens: 32768,
       temperature: 9,
+      repetition_penalty: 1.2,
     };
     const result = handler({ payload }, context);
     assert.deepEqual(
       [result.temperature, result.top_p, result.top_k, result.min_p,
         result.presence_penalty, result.repetition_penalty],
-      off ? [0.7, 0.8, 20, 0, 1.5, 1] : [1, 0.95, 20, 0, 0, 1],
+      off ? [0.7, 0.8, 20, 0, 1.5, 1] : [1, 0.95, 20, 0, 0, 1.05],
     );
     for (const key of ["messages", "tools", "chat_template_kwargs", "max_tokens"]) {
       assert.equal(result[key], payload[key]);
     }
     assert.equal(payload.temperature, 9);
+    assert.equal(payload.repetition_penalty, 1.2);
   });
 }
+
+test("omitted kwargs use the thinking policy without changing template defaults", () => {
+  const payload = { repetition_penalty: 1.0 };
+  const result = handler({ payload }, context);
+  assert.equal(result.repetition_penalty, 1.05);
+  assert.equal(result.temperature, 1.0);
+  assert.equal("chat_template_kwargs" in result, false);
+  assert.deepEqual(payload, { repetition_penalty: 1.0 });
+});
+
+test("switching off and back on does not retain the previous mode's penalty", () => {
+  let payload = { chat_template_kwargs: { enable_thinking: true, reasoning_effort: "medium" } };
+  for (const enabled of [true, false, true]) {
+    payload = { ...payload, chat_template_kwargs: { enable_thinking: enabled } };
+    payload = handler({ payload }, context);
+    assert.equal(payload.repetition_penalty, enabled ? 1.05 : 1.0);
+  }
+});
 
 test("other providers and models keep their sampler but still get traced", () => {
   for (const model of [undefined, { ...context.model, provider: "vanillax-litellm", id: "kimi-k3" },

--- a/scripts/pi/qwen-sampling.ts
+++ b/scripts/pi/qwen-sampling.ts
@@ -24,7 +24,7 @@ export default function (pi: ExtensionAPI) {
       top_k: 20,
       min_p: 0.0,
       presence_penalty: off ? 1.5 : 0.0,
-      repetition_penalty: 1.0,
+      repetition_penalty: off ? 1.0 : 1.05,
     };
   });
 }

--- a/scripts/tests/test_qwen_reasoning.py
+++ b/scripts/tests/test_qwen_reasoning.py
@@ -27,13 +27,23 @@ class QwenReasoningTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(kwargs, body['extra_body']['chat_template_kwargs'])
         self.assertEqual(body['reasoning_effort'], effort if enabled else None)
         self.assertEqual(body['extra_body']['reasoning_effort'], effort if enabled else None)
+        expected = dict(temperature=1.0 if enabled else 0.7,
+                        top_p=0.95 if enabled else 0.8, top_k=20, min_p=0.0,
+                        presence_penalty=0.0 if enabled else 1.5,
+                        repetition_penalty=1.05 if enabled else 1.0)
+        for target in (body, body['extra_body']):
+            self.assertEqual({key: target[key] for key in expected}, expected)
+        if enabled:
+            deployment = yaml.safe_load((ROOT / 'my-apps/ai/vllm/deployment.yaml').read_text())
+            args = deployment['spec']['template']['spec']['containers'][0]['args']
+            self.assertEqual(json.loads(args[args.index('--override-generation-config') + 1]), expected)
 
     async def test_default_request_has_explicit_medium_and_preserves_history(self):
         body = await self.request()
         self.assert_mode(body)
         self.assertEqual([body[k] for k in ['temperature', 'top_p', 'top_k',
                                           'min_p', 'presence_penalty', 'repetition_penalty']],
-                         [1.0, 0.95, 20, 0.0, 0.0, 1.0])
+                         [1.0, 0.95, 20, 0.0, 0.0, 1.05])
 
     async def test_explicit_efforts_survive_both_forwarding_shapes(self):
         for effort in ['low', 'medium', 'xhigh']:
@@ -42,6 +52,17 @@ class QwenReasoningTests(unittest.IsolatedAsyncioTestCase):
                             dict(extra_body={'chat_template_kwargs': {'reasoning_effort': effort}})]:
                 with self.subTest(effort=effort, options=options):
                     self.assert_mode(await self.request(**options), effort)
+
+    async def test_stale_penalties_cannot_override_either_forwarding_shape(self):
+        for effort in ('low', 'medium', 'xhigh', 'none'):
+            for nested in (False, True):
+                with self.subTest(effort=effort, nested=nested):
+                    options = dict(repetition_penalty=1.2,
+                                   extra_body={'repetition_penalty': 0.5})
+                    (options['extra_body'] if nested else options)['reasoning_effort'] = effort
+                    body = await self.request(**options)
+                    enabled = effort != 'none'
+                    self.assert_mode(body, effort, enabled=enabled, preserve=enabled)
 
     async def test_generic_high_maps_to_medium_and_invalid_effort_fails(self):
         self.assert_mode(await self.request(reasoning_effort='high'))
@@ -105,7 +126,21 @@ class DeclaredPolicyTests(unittest.TestCase):
         self.assertEqual(defaults, dict(enable_thinking=True, reasoning_effort='medium', preserve_thinking=True))
         sampler = json.loads(args[args.index('--override-generation-config') + 1])
         self.assertEqual(sampler, dict(temperature=1.0, top_p=0.95, top_k=20, min_p=0.0,
-                                      presence_penalty=0.0, repetition_penalty=1.0))
+                                      presence_penalty=0.0, repetition_penalty=1.05))
+
+    def test_prefill_budget_cache_policy_and_allocator_are_explicit(self):
+        deployment = yaml.safe_load((ROOT / 'my-apps/ai/vllm/deployment.yaml').read_text())
+        container = deployment['spec']['template']['spec']['containers'][0]
+        args = container['args']
+        expected = {'--max-num-batched-tokens': '8192',
+                    '--long-prefill-token-threshold': '4096',
+                    '--max-num-seqs': '2', '--max-model-len': '262144',
+                    '--mamba-cache-mode': 'align', '--prefix-match-unit': '16'}
+        for flag, value in expected.items():
+            self.assertEqual(args[args.index(flag) + 1], value)
+        self.assertFalse(any(arg.startswith('--speculative-config') for arg in args))
+        env = {entry['name']: entry.get('value') for entry in container['env']}
+        self.assertEqual(env['PYTORCH_CUDA_ALLOC_CONF'], 'expandable_segments:True')
 
     def test_pi_mapping_exposes_only_valid_efforts_and_explicit_off(self):
         doc = (ROOT / 'docs/domains/ai-gpu/pi-agent-local-dev.md').read_text()


### PR DESCRIPTION
## What

Tune the existing official Qwen3.8-27B FP8 / stock vLLM dual-3090 deployment, with consistent client sampling and explicit validation requirements. The club-3090 profile motivated the tunables; this PR does **not** establish a speedup on this machine.

## Changes

| Setting | Before | After / interpretation |
|---|---|---|
| `--max-num-batched-tokens` | 2048 | **8192 aggregate tokens per scheduling step** |
| `--long-prefill-token-threshold` | omitted | **4096 per-request prefill cap**; active even with two sequence slots |
| Mamba cache / prefix matching | implicit | explicit `align` / `16` |
| Thinking repetition penalty | 1.0 | **1.05 in the server default, WebUI filter, and Pi extension** |
| Non-thinking repetition penalty | 1.0 | **1.0, unchanged** |
| PyTorch allocator | `expandable_segments:True` | unchanged; the proposed `max_split_size_mb:512` addition was removed |

A single long prompt does not receive an 8192-token prefill chunk with this configuration. Other scheduling/alignment constraints can reduce chunks further. The earlier description of the 4096 threshold as inert, and the claim of four times fewer prefill steps, were incorrect.

## Sampler evidence and scope

Thinking repetition penalty 1.05 is a **local community-reported mitigation candidate**, not Qwen's official default or a proven fix. QwenLM/Qwen3.8#216 contains corrections to its earlier results: low/medium are not universally immune, and its extraction results do not establish coding/tool/vision quality. EOS within an unfinished thinking block is a suspected mechanism, not a confirmed root cause.

The server value is a fallback, not a floor. Explicit client parameters override it. Both repository-owned clients now send thinking=1.05 / off=1.0, and the tests exercise default/low/medium/xhigh/off, conflicting stale parameters, both WebUI forwarding shapes, and Pi's actual request hook. Messages, tools, reasoning history, output budgets, and telemetry remain intact.

## Validation

- Reproduced the original failing server-sampler assertion locally before the fix.
- Updated Python policy suite: **13 tests passed**.
- Updated Pi request-hook suite: **8 tests passed** (Node 22.16 with `--experimental-strip-types`; the documented Node 24+ command remains valid).
- Negative controls: restoring either old client sampler causes the updated tests to fail.
- `git diff --check`: passed.
- Original Cluster CI job logs identify `test_server_cannot_use_implicit_xhigh_or_non_thinking_sampler` as the failure inside the broadly named monitoring/Argo validation step. The monitoring tests before it passed; no monitoring configuration changes were needed.
- Full Kustomize/schema validation is delegated to the new GitHub Actions run; Kustomize/Helm were unavailable in the editing environment. No live GPU benchmark, cluster mutation, or runtime rollout was performed.

## Deliberately unchanged

Official checkpoint/revision, stock vLLM 0.29.0 image and digest, TP=2, 262144 context ceiling, sequence limit, memory budget, FlashInfer/FP8 KV, native vision limits, medium reasoning with preserved history, GPU topology and power caps. **MTP/speculation stays off.** No custom kernels or speculative backports.

## Rollout and rollback

After user merge, ArgoCD applies the vLLM argument change through the existing Recreate deployment. Verify the WebUI PostSync function-loader succeeds and inspect outgoing parameters through LiteLLM. A copied workstation Pi extension must be refreshed separately:

```bash
# From the updated repository root, after backing up any existing local copy:
cp scripts/pi/qwen-sampling.ts ~/.pi/agent/extensions/qwen-sampling.ts
```

Then use `/reload` in Pi or restart it. Git/Argo cannot update a workstation copy automatically.

Read fresh KV capacity from boot logs. Test one and two cold prompts plus prefill arriving during decode; measure time to first token, inter-token latency, preemptions and peak memory. Repeat tool, image and multi-turn checks for all reasoning modes. A completed empty final answer without tool calls is a failure; empty content accompanying a valid tool call is not. Historical September 6 measurements are not results for this tuning profile.

Rollback this policy through Git and restore/reload the prior Pi extension; do not revert the full FP8 backend cutover merely to undo tuning.

## References

- [vLLM 0.29.0 scheduler](https://github.com/vllm-project/vllm/blob/v0.29.0/vllm/v1/core/sched/scheduler.py)
- [Qwen3.8 issue 216](https://github.com/QwenLM/Qwen3.8/issues/216)
- [PyTorch CUDA allocator guidance](https://docs.pytorch.org/docs/stable/notes/cuda.html)
- [Upstream speculative-decode fault discussion](https://github.com/vllm-project/vllm/pull/50021)
