### PR TITLE
fix(cilium): raise endpoint-create cold-start floors to the converged rate

### DIFF
--- a/infrastructure/networking/cilium/values.yaml
+++ b/infrastructure/networking/cilium/values.yaml
@@ -97,10 +97,10 @@ k8sClientRateLimit:
   qps: 20
   burst: 40
 
-# Cilium's default endpoint-create limit (0.5/s, burst 4) 429s the sandbox storm after a node
-# restart; auto-adjust stays on and tunes these back toward observed endpoint-generation time.
+# Cold-start floors set to where auto-adjust actually converges (~5x); the learned factor lives
+# in agent memory, so a restarting agent 429s a mass pod restart before it can relearn it.
 extraConfig:
-  api-rate-limit: "endpoint-create=rate-limit:2/s,rate-burst:16,parallel-requests:8,max-wait-duration:30s"
+  api-rate-limit: "endpoint-create=rate-limit:10/s,rate-burst:48,parallel-requests:24,max-wait-duration:30s"
 
 # Must match the README seed flag, or a fresh bootstrap leaves envoy holding zero listeners.
 envoy:


### PR DESCRIPTION
## What

One line: raise the `endpoint-create` api-rate-limit floors from `2/s, burst 16, parallel 8` to `10/s, burst 48, parallel 24`.

## Why

A full-cluster `delete pods` (deliberate chaos test) left ~54 pods stuck in `ContainerCreating` for ~25 minutes on the node hosting 95 pods:

```
plugin type="cilium-cni" failed (add): unable to create endpoint:
  Cilium API client timeout exceeded
  [PUT /endpoint/{id}][429] putEndpointIdTooManyRequests
```

The configured limits were never the limits that actually run. Live metrics from the agent on that node show auto-adjust had converged ~5x above them:

| metric | live value | configured |
|---|---|---|
| `adjustment_factor` | 5.177411 | — |
| `rate_limit value=limit` | 10.354821 | 2/s |
| `rate_limit value=burst` | 49.0 | 16 |
| `requests_in_flight value=limit` | 24.0 | 8 |
| `processing_duration value=mean` | 0.386293 | est. default 2.0s |

That adjustment factor is in-memory agent state. The chaos test deleted the Cilium agents along with everything else, so each agent came back at the cold configured values at precisely the moment 255 recreated pods needed endpoints — the only condition under which the cold values matter at all.

Endpoint generation actually takes 0.386s on average against a 2.0s built-in estimate, which is why the cold limiter starts ~5x too conservative and has to learn its way up under load.

## What this changes

A restarting agent now starts where a warmed one ends up. `auto-adjust` stays enabled, so it still tunes *down* if endpoint generation is genuinely slower than the estimate — relevant for the wifi-linked `hp-micro` node.

Only knobs already proven to parse in this cluster are used; no new option names are introduced.

## Not included

The VPA `BestEffort` eviction fallback seen during the same window was investigated and is **not** a standing bug — it was a one-shot artifact of the chaos test deleting the VPA admission controller. Pods created while it was down came back without injected requests, VPA evicted them once, and the replacements came back `Burstable`. All 7 occurrences fall in a 10-minute window and stopped on their own. No change needed.

## Test plan

- [ ] ArgoCD syncs `cilium`; agents roll one at a time (`maxUnavailable: 1`)
- [ ] `cilium-dbg metrics list | grep api_limiter` shows the new floors
- [ ] Re-run the chaos test and confirm the `ContainerCreating` backlog drains in seconds, not ~25 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142wV54y6qUkQQE8iN8Tz6Q

---

## Second commit: Renovate rule description

`.github/renovate.json5` — **description text only. No version ceiling; Cilium updates stay unrestricted.**

The same incident re-triggered the known split-xDS wedge (`Cilium 1.20.0 split-xDS stale NetworkPolicy cache wedges a node's CNI`, PR #2012). The agent replays stale NetworkPolicy xDS resources for dead endpoints onto a new Envoy stream, Envoy NACKs `duplicate resource key <IP>`, and endpoint regeneration on that node stops.

It is unfixed in every 1.20.x and still appears unreported upstream. ADS mode livelocks instead (`cilium/cilium#47624`), so neither 1.20 xDS mode is sound — split is kept because its recovery is known.

The `allowedVersions: '<1.21.0'` ceiling that PR #2042 removed is **deliberately not restored**. This just puts the reason and the recovery in front of whoever reads the 1.21 PR months from now.

**Recovery, agent before envoy:** delete that node's `cilium-agent` pod. The NetworkPolicy cache rebuilds from live endpoints only, so the phantom entries cannot return.

Note this PR does **not** fix the wedge — there is no fix to apply. It fixes the cold-start rate limit, which is why the backlog took ~25 minutes to drain instead of seconds.
