### PR TITLE
feat(immich): grow library PVC 50Gi -> 150Gi for the external photo library

### DIFF
--- a/my-apps/media/immich/library-pvc.yaml
+++ b/my-apps/media/immich/library-pvc.yaml
@@ -16,8 +16,9 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      # Working set only (thumbnails/transcodes/new uploads, ~6Gi actual); originals live on the read-only nfs-photos external library.
-      storage: 50Gi
+      # Working set only (thumbnails/transcodes/new uploads); originals live on the read-only nfs-photos external library.
+      # Sized for the ~1.3 TB external library: thumbnails + previews alone approach 40Gi before encoded-video.
+      storage: 150Gi
   storageClassName: longhorn
   # kopiur restore-before-bind: on recreate binds Pending until the Restore populator hydrates it; no-op while Bound. CRs in kopiur/library.yaml.
   # Restores the library working set only — originals stay on the exempt nfs-photos NFS.


### PR DESCRIPTION
Immich's external library was just pointed at the ~1.3 TB TrueNAS photo archive (`/mnt/photos`, read-only NFS). Thumbnails and previews for that many assets land near 40Gi before `encoded-video` is counted, so the existing 50Gi would have filled part-way through the initial scan.

## Changes
- `library` PVC: `50Gi` -> `150Gi`
- Refreshed the sizing comment (the old "~6Gi actual" predated the external library)

## Notes
- `allowVolumeExpansion=true` on the `longhorn` StorageClass, so this expands online — no detach, no pod restart
- The immutable `dataSourceRef` (kopiur restore-before-bind) is untouched
- Originals are unaffected; they stay on the backup-exempt `nfs-photos` mount

## Verification
```
kubectl -n immich get pvc library
kubectl -n immich exec deploy/immich-server -c immich-server -- df -h /library
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w1ghmjbxx8LtCNaUvuboe