### PR TITLE
feat(jellyfin): Intel QSV transcoding + refresh the Immich README

### DIFF
--- a/my-apps/media/immich/README.md
+++ b/my-apps/media/immich/README.md
@@ -1,195 +1,108 @@
 # Immich — Self-Hosted Photos
 
-Immich photo/video library running on K8s with CloudNativePG, Valkey, and
-a read-only NFS mount pointing at the TrueNAS photo archive. The original
-photos stay on the NAS as the source of truth — Immich only writes
-thumbnails, ML embeddings, and DB rows.
+Photo and video library. The originals live on the TrueNAS archive and are
+mounted read-only as an Immich **external library** — Immich never writes to
+them. It owns only thumbnails, transcodes, ML embeddings and database rows.
 
 ## Architecture
 
 ```
- User → https://photos.vanillax.me (gateway-internal, HTTPS)
+ User → https://photos.vanillax.me (gateway-internal, LAN only)
        │
        ▼
- immich-server (Deployment)  ──── reads /mnt/photos (RO, NFS)
+ immich-server ──────── reads /mnt/photos (read-only NFS, the originals)
+       │                writes /library   (thumbnails, previews, transcodes)
        │
-       ├── Postgres (CNPG) ──── Longhorn PVC (20Gi) + Barman → RustFS S3
-       ├── Valkey (Redis-ish) ─ ephemeral
-       ├── immich-machine-learning (Deployment, co-located via podAffinity)
-       │      └── ML cache PVC (10Gi, Longhorn) — CLIP + face detection models
-       └── library PVC (50Gi, Longhorn) — thumbnails, previews, transcoded video
+       ├── immich-postgres ── plain Postgres Deployment, Longhorn PVC
+       ├── immich-valkey ──── cache, ephemeral
+       └── immich-machine-learning ── CLIP + face recognition
+                                      runs on the Intel iGPU via OpenVINO
 ```
 
-Co-location: `immich-machine-learning` has a `podAffinity` on the server
-pod's hostname. They run on the same node so the server can hit the ML
-service on localhost / pod-network with no extra hops. No
-`runtimeClassName: nvidia` — ML runs on CPU here (set the nodeSelector +
-runtimeClass if you move it to a GPU worker).
+The server and ML pods run on **different nodes**. ML is pinned to the node
+holding the passed-through Intel iGPU; the server stays where the CPU is. They
+talk over the ClusterIP Service — ML receives image bytes in the HTTP request
+and never touches the media filesystem.
 
-## Storage breakdown
+> **Do not mount `library` or `nfs-photos` into the ML pod.** Upstream gives
+> machine-learning only `model-cache:/cache`. Adding the RWO `library` PVC back
+> would Multi-Attach the moment the two pods land on different nodes.
 
-| Data                        | Location                          | Size / Reclaim |
-|-----------------------------|-----------------------------------|----------------|
-| Original photos/videos      | TrueNAS NFS (read-only, static PV)| ~1.27 TiB (source of truth) |
-| Thumbnails + previews       | `library` PVC (Longhorn RWO)      | 50Gi           |
-| ML models (CLIP + face)     | `immich-ml-cache` PVC (Longhorn)  | 10Gi           |
-| DB (metadata, embeddings)   | Immich CNPG cluster (Longhorn PVC) | 20Gi           |
-| DB WAL + base backups       | RustFS S3 (`cnpg` bucket, Barman) | rolling, ~daily |
+## Storage
 
-> ⚠️ **Do NOT wire VolSync `ReplicationSource`/`ReplicationDestination`
-> against the CNPG PVC.** CNPG uses Barman to S3 for DR, not VolSync.
-> Mixing both layers is a known footgun — see
-> `infrastructure/database/CLAUDE.md`.
+| Data | Where | Backup |
+|---|---|---|
+| Originals (~1.3 TB) | TrueNAS NFS, read-only static PV | NAS-side ZFS + replication; `backup-exempt` |
+| Thumbnails, previews, transcodes | `library` PVC, 150Gi Longhorn | kopiur **daily** 03:37 |
+| Database | `immich-postgres-data` PVC, 20Gi Longhorn | kopiur **hourly** :23, CHECKPOINT before-hook |
+| ML models | `immich-ml-cache` PVC, 20Gi Longhorn | `backup-exempt` — re-downloads on demand |
 
-The `library` PVC is not currently VolSync-backed. It's large and the
-contents are regenerable from originals + DB (see `docs/domains/cnpg/disaster-recovery.md`
-for the full recovery flow). Enable later if re-generating thumbnails for
-1.27 TiB of photos on every rebuild starts to feel slow.
+Postgres has **two independent backups**. kopiur snapshots the PVC hourly, and
+Immich writes its own SQL dump to `/library/backups` at 02:00 — which the daily
+`library` backup then ships at 03:37. Keep that ordering: the dump must be
+written before the volume that carries it is snapshotted. The snapshot restores
+fast but reproduces any corruption it captured; the dump is the escape hatch.
 
-## NFS static PV — why not dynamic
+Both PVCs use kopiur restore-before-bind: on recreate they sit `Pending` until
+the populator hydrates them, then bind with data. If the repo is unreachable
+they stay `Pending` rather than binding empty.
 
-The `nfs-immich-photos` PV is defined in
-`infrastructure/storage/csi-driver-nfs/storage-class.yaml`. It's a
-**static** PV, not a dynamic one, because:
+### The NFS mount
 
-- Dynamic NFS CSI creates a *new subdirectory per PVC*. That's fine for
-  volumes that start empty, but we're mounting **existing data**.
-- A static PV points directly at the existing share
-  (`192.168.10.133:/mnt/BigTank/photos/All`) with no subdirectory.
-- Mount options (`ro`, `nfsvers`, `nconnect`, …) only get honored when
-  using the CSI driver. Don't use the legacy `nfs:` block — mountOptions
-  silently fail there.
+Static PV `nfs-immich-photos`, defined in
+`infrastructure/storage/csi-driver-nfs/storage-class.yaml`:
 
-Mount spec:
-- **Server:** `192.168.10.133`
-- **Share:** `/mnt/BigTank/photos/All`
-- **Mode:** read-only (`ro` mount option)
-- **In-pod path:** `/mnt/photos` on both `immich-server` and `immich-machine-learning`
+- **Server / share:** `192.168.10.133:/mnt/BigTank/photos/All`
+- **In-pod path:** `/mnt/photos`, read-only, `nfsvers=4.1 nconnect=16`
 
-## Database — Postgres via CNPG
+It is static rather than dynamic because dynamic NFS CSI provisions a *new*
+subdirectory per PVC, and this mounts data that already exists. Use the CSI
+driver, never the legacy `nfs:` block — that silently ignores `mountOptions`.
 
-Manifests: `infrastructure/database/cloudnative-pg/immich/`
+The export maps all clients to `k8-smb-user:nas-private` and is read-only on the
+NAS side. Without that mapping the pod's root is squashed to `nobody`, and the
+dataset's `2770` mode denies it — which surfaces in the Immich UI as
+*"Invalid import path: Lacking read permission for folder"*.
 
-- **Image:** `ghcr.io/tensorchord/cloudnative-vectorchord:17.5-0.4.3` (Postgres 17.5 + VectorChord 0.4.3)
-- **Extensions:** `vchord` (CASCADE-installs pgvector), `vector`, `earthdistance` (CASCADE-installs cube)
-- **Service:** `immich-database-rw.cloudnative-pg.svc.cluster.local:5432`
-- **Creds:** ExternalSecret pulls `immich-db-credentials` (immich ns) + `immich-app-secret` (cnpg ns) from 1Password
-- **Backups:** Barman → RustFS S3 (`192.168.10.133:30293`). Daily base backup at **02:00**, continuous WAL archival.
+## Database
 
-### Why CNPG and not CrunchyData PGO
+Plain Postgres Deployment in `postgres/`, pinned image, database declared via
+env. No operator, no recovery script, no manual sync gate — recovery is the same
+kopiur restore every other PVC gets.
 
-PGO uses Patroni for HA. Patroni's DCS (leader election) corrupts when
-pods are hard-killed — exactly what happens during a Talos
-upgrade/reboot on a single-replica homelab cluster. The corruption
-manifests as a standby loop that doesn't self-heal. CNPG has no Patroni,
-no leader election, just a primary + optional standbys + Barman. Simpler
-recovery, no Patroni DCS to unstick.
+## Adding the external library
 
-## Deploying
+Immich does not create one for you.
 
-ArgoCD picks this up automatically via the my-apps AppSet. Files:
+1. **Administration → External Libraries → Create Library**, import path
+   `/mnt/photos`
+2. Set exclusion patterns for NAS and sync artifacts: `**/@eaDir/**`,
+   `**/*recycle/**`, `**/*snapshot/**`, `**/.stversions/**`, `**/.stfolder/**`
+3. **Settings → External Library:** library watching **off**, periodic scan
+   **on**. inotify does not work over NFS — polling is the only option.
+4. Scan.
 
-| File | Purpose |
-|------|---------|
-| `namespace.yaml` | `immich` namespace |
-| `kustomization.yaml` | Ties everything together (also generates config ConfigMap) |
-| `deployment-server.yaml` | Immich API/web server. OTEL Node.js auto-instrumentation annotated. Uses `RollingUpdate` because it's the only RWO PVC it touches is the `library` volume in RWX-ish mode (ReadWriteOncePod on Longhorn still allows same-node re-mount) — watch for Multi-Attach if you scale replicas. |
-| `deployment-machine-learning.yaml` | Immich ML. Co-located via `podAffinity` on server hostname. |
-| `deployment-valkey.yaml` | Redis-compatible cache. Ephemeral. |
-| `services.yaml` | Three ClusterIPs — named ports matter for HTTPRoute + Prometheus scrape. |
-| `httproute.yaml` | **Internal** HTTPRoute → `photos.vanillax.me` via `gateway-internal`. No Cloudflare tunnel — LAN only. |
-| `library-pvc.yaml` | 50Gi Longhorn PVC. |
-| `ml-cache-pvc.yaml` | 10Gi Longhorn PVC. |
-| `nfs-photos-pvc.yaml` | Claims the static NFS PV. |
-| `externalsecret.yaml` | Pulls DB creds, JWT secret, etc. from 1Password. |
-
-## Initial setup (first deploy)
-
-Immich doesn't auto-create an admin. First run:
-
-1. Port-forward the UI (or use the HTTPRoute once DNS is live):
-   ```bash
-   kubectl port-forward -n immich svc/immich-server 2283:2283
-   # open http://localhost:2283
-   ```
-2. The first page is **"Getting Started" → admin account creation**.
-   Pick your admin email + password. **This account cannot be recovered
-   without DB access** — store the password in 1Password before you forget.
-3. Log in. You'll be prompted to invite other users if you want.
-4. **Add the external library:**
-   - `Administration → External Libraries → Create Library`
-   - Import path: `/mnt/photos`
-   - Owner: the admin (or any user)
-   - **Scan schedule: every 6 hours** (or whatever cadence matches your
-     upload pattern). inotify does NOT work over NFS — you must poll.
-5. Click **Scan**. The library enters "scanning" state immediately but
-   doesn't start generating thumbnails until it finishes the initial
-   file walk.
-
-## What to expect on first ML scan
-
-On a 1.27 TiB library with ~100k photos/videos, expect:
-
-| Phase                      | Duration (rough, CPU-only ML) |
-|----------------------------|-------------------------------|
-| File discovery walk        | 30 min – 2 hr                 |
-| Thumbnail + preview gen    | **1–3 days**                   |
-| CLIP embeddings (search)   | 2–5 days                      |
-| Face detection + clustering| 3–7 days                      |
-
-The ML service runs per-photo, not per-batch-blast, so throughput is
-bounded by CPU. If it feels stuck, check
-`kubectl logs -n immich deploy/immich-machine-learning` — it logs each
-processed file.
-
-Accelerate:
-- Move `immich-machine-learning` to the GPU worker (add nodeSelector +
-  `runtimeClassName: nvidia` + GPU resource request). Will need to
-  coordinate with llama-cpp/ComfyUI priority — pick `gpu-workload-preemptible`.
-- Bump the ML `concurrency` in Immich's server settings (Admin →
-  Settings → Jobs).
-
-## Networking
-
-- **HTTPRoute:** `photos.vanillax.me` via `gateway-internal` (HTTPS).
-  **Not public** — LAN-only, no Cloudflare tunnel.
-- **Cilium policy:** NFS traffic to TrueNAS (port 2049 TCP/UDP) is
-  allowed in `block-lan-access.yaml`. Without that exemption the
-  default-deny egress would kill the photo mount.
-- **Database:** server + ML pods connect to
-  `immich-database-rw.cloudnative-pg` on 5432 (Cilium allows intra-cluster
-  traffic by default; no explicit rule needed for in-cluster services).
+Leave the **storage template disabled**. It only reorganises files Immich owns;
+it never touches external-library files, and the mount is read-only regardless.
 
 ## Gotchas
 
-- **No file watching over NFS.** Periodic scan only (set in Immich UI).
-  Any kernel that tells you it supports `inotify` over NFS is lying.
-- **Read-only NFS mount.** Edits in the Immich UI (rotate, delete, move)
-  won't touch originals on TrueNAS. Deletes happen inside Immich's DB
-  only; the file on NAS stays. If you want true deletion, delete on
-  the NAS, then re-scan.
-- **Moving files on NAS breaks associations.** Immich tracks by path,
-  not content hash. Rename a folder on TrueNAS and Immich sees the old
-  photos as deleted + new photos as new — losing albums, likes, face
-  assignments. Use the Immich UI move, or accept the re-scan cost.
-- **RWO on Longhorn means Deployment strategy matters.** If you scale
-  `immich-server` beyond 1 replica, switch to `strategy: Recreate`
-  (or use `ReadWriteMany`). The default `RollingUpdate` will deadlock
-  on Multi-Attach.
-- **Deleting the namespace ≠ deleting your photos.** The NFS mount is
-  read-only and points at the NAS. But it **does** delete the `library`
-  PVC (thumbnails) and the CNPG cluster (DB, including face tags and
-  albums). Don't delete the namespace casually.
+- **Immich tracks assets by path, not content hash.** Renaming a folder on the
+  NAS reads as "all deleted, all new" and loses albums, favourites and face
+  assignments. Move within the Immich UI, or accept a full re-scan.
+- **Deletes in the UI never reach the NAS.** The mount is read-only. To really
+  delete, delete on the NAS and re-scan.
+- **An empty `library` volume fails Immich's integrity check** once the database
+  holds asset rows — it checks for `.immich` marker files rather than
+  re-initialising. The init container seeds them idempotently, which is what
+  makes a cold DR restore work. Do not remove it.
+- **`immich-server` uses `Recreate`.** It holds the RWO `library` PVC;
+  `RollingUpdate` would Multi-Attach deadlock.
+- **Deleting the namespace does not delete your photos**, but it does delete the
+  thumbnails and the database — albums, tags and faces included.
 
-## Recovery / DR
+## Recovery
 
-See [`docs/domains/cnpg/disaster-recovery.md`](../../../docs/domains/cnpg/disaster-recovery.md)
-for the authoritative DR procedure (rewritten against the April 2026
-CNPG clean-slate baseline). Summary:
-
-1. NFS share survives — originals are safe as long as TrueNAS survives.
-2. CNPG cluster restores from Barman S3 — brings back metadata, album
-   structure, face tags.
-3. `library` PVC is empty on rebuild — Immich will regenerate thumbnails
-   on next scan (slow, see timing table above). No data loss, just
-   compute to rebuild.
+Originals survive anything short of losing the NAS. `immich-postgres-data` and
+`library` restore from kopiur automatically on a rebuild, bringing back albums,
+faces and the thumbnail working set. See `docs/disaster-recovery.md`.

--- a/my-apps/media/jellyfin/deployment.yaml
+++ b/my-apps/media/jellyfin/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: jellyfin
     spec:
+      # Intel QSV transcoding: only nodes with a passed-through iGPU carry this NFD label.
+      nodeSelector:
+        feature.node.kubernetes.io/pci-0300_8086.present: "true"
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -37,8 +40,10 @@ spec:
             requests:
               cpu: 500m
               memory: 2Gi
+              gpu.intel.com/i915: 1
             limits:
               memory: 6Gi
+              gpu.intel.com/i915: 1
           envFrom:
             - configMapRef:
                 name: jellyfin-env


### PR DESCRIPTION
Two things, both downstream of the iGPU landing in #2383.

## Jellyfin QSV
Jellyfin already ran with `supplementalGroups: [44, 104, 1000]` (video + render), so it only needed the device: request `gpu.intel.com/i915` and select on `feature.node.kubernetes.io/pci-0300_8086.present`. It was already on hp-elite by chance — now it's pinned there on purpose.

**Not done by this PR:** hardware acceleration still has to be enabled in Jellyfin itself — Dashboard → Playback → Transcoding → *Intel QuickSync (QSV)*. The manifest only grants access to the device.

**To verify once the node has i915**, check the device node's group actually matches one of the supplementalGroups:
```
kubectl -n jellyfin exec deploy/jellyfin -- ls -l /dev/dri
```
If `renderD128` is owned by a gid outside `[44, 104, 1000]`, that list needs the real one — Talos may not use Debian's numbering.

## Immich README
It still described CloudNativePG, Barman and VolSync. All three are retired; the app is plain Postgres + kopiur. Rewritten to match reality:

- ML now runs on a different node from the server, and **must not** mount the RWO `library` PVC — that's the Multi-Attach trap, called out explicitly
- Both backup layers and why the 02:00 dump / 03:37 sweep ordering matters
- The NFS export's `mapall` identity, and the exact Immich error you get without it
- External-library setup, including why the storage template stays off and why watching can't work over NFS
- Path-based asset tracking, so nobody renames a NAS folder and loses their albums

Net −181/+99 lines.

## Unrelated, not fixed here
`ghcr.io/jellyfin/jellyfin:10.11.11` has no digest pin. Pinned tag rather than a floating `:latest`, so it's not urgent, but it's the odd one out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w1ghmjbxx8LtCNaUvuboe